### PR TITLE
Rename CLI from databricks-code to coding-tool-gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
 # Coding Tool Gateway
 
-`databricks-code` is a lightweight launcher for running Codex, Claude Code, and Gemini CLI through Databricks.
+`coding-tool-gateway` is a lightweight launcher for running Codex, Claude Code, and Gemini CLI through Databricks.
 
 It is designed for a simple setup flow:
 
 ```bash
-git clone https://github.com/databricks/databricks-code.git
-cd databricks-code
+git clone https://github.com/databricks/coding-tool-gateway.git
+cd coding-tool-gateway
 pipx install .
-databricks-code
+coding-tool-gateway
 ```
 
-On first run, `databricks-code` handles local bootstrap, prompts for your Databricks workspace, configures the selected coding tool, and launches it.
+On first run, `coding-tool-gateway` handles local bootstrap, prompts for your Databricks workspace, configures the selected coding tool, and launches it.
 
 ## Why Coding Tool Gateway
 
 - Minimal setup for Databricks-backed coding tools
 - One workspace configuration shared across Codex, Claude Code, and Gemini CLI
 - Oauth Databricks authentication support
-- Managed local config files with restore support through `databricks-code logout`
-- Built-in AI Gateway usage reporting with `databricks-code usage`
+- Managed local config files with restore support through `coding-tool-gateway logout`
+- Built-in AI Gateway usage reporting with `coding-tool-gateway usage`
 
 ## Supported Tools
 
@@ -32,13 +32,13 @@ On first run, `databricks-code` handles local bootstrap, prompts for your Databr
 Install and launch:
 
 ```bash
-git clone https://github.com/databricks/databricks-code.git
-cd databricks-code
+git clone https://github.com/databricks/coding-tool-gateway.git
+cd coding-tool-gateway
 pipx install .
-databricks-code
+coding-tool-gateway
 ```
 
-On first launch, `databricks-code` will:
+On first launch, `coding-tool-gateway` will:
 
 1. Install missing local dependencies it manages:
    `databricks`, `codex`, `claude`, `gemini`
@@ -51,10 +51,10 @@ On first launch, `databricks-code` will:
 After setup, normal usage is simple:
 
 ```bash
-databricks-code
-databricks-code --tool codex
-databricks-code --tool claude
-databricks-code --tool gemini
+coding-tool-gateway
+coding-tool-gateway --tool codex
+coding-tool-gateway --tool claude
+coding-tool-gateway --tool gemini
 ```
 
 ## Configuration
@@ -62,7 +62,7 @@ databricks-code --tool gemini
 Use `configure` to update workspace settings or saved models:
 
 ```bash
-databricks-code configure
+coding-tool-gateway configure
 ```
 
 The interactive flow supports:
@@ -75,8 +75,8 @@ The interactive flow supports:
 Examples:
 
 ```bash
-databricks-code --tool claude --model databricks-claude-opus-4-6
-databricks-code --tool gemini --model databricks-gemini-2-5-pro
+coding-tool-gateway --tool claude --model databricks-claude-opus-4-6
+coding-tool-gateway --tool gemini --model databricks-gemini-2-5-pro
 ```
 
 Notes:
@@ -88,10 +88,10 @@ Notes:
 ## Commands
 
 ```bash
-databricks-code configure
-databricks-code status
-databricks-code usage
-databricks-code logout
+coding-tool-gateway configure
+coding-tool-gateway status
+coding-tool-gateway usage
+coding-tool-gateway logout
 ```
 
 - `configure`
@@ -106,7 +106,7 @@ databricks-code logout
 ## Usage Reporting
 
 ```bash
-databricks-code usage
+coding-tool-gateway usage
 ```
 
 `usage` requires Databricks AI Gateway V2. When enabled, it queries `system.ai_gateway.usage` and shows:
@@ -116,25 +116,25 @@ databricks-code usage
 - top models this week
 - a 7-day breakdown for Codex, Claude Code, and Gemini CLI
 
-If the workspace is not configured for AI Gateway V2, `databricks-code usage` will stop early and tell you to re-run `databricks-code configure`.
+If the workspace is not configured for AI Gateway V2, `coding-tool-gateway usage` will stop early and tell you to re-run `coding-tool-gateway configure`.
 
 ## Managed Local Files
 
-`databricks-code` manages these local files:
+`coding-tool-gateway` manages these local files:
 
 - `~/.codex/config.toml`
 - `~/.claude/settings.json`
 - `~/.gemini/.env`
 
-If one of these files already exists, `databricks-code` creates a backup before writing its managed version. `databricks-code logout` restores the backup.
+If one of these files already exists, `coding-tool-gateway` creates a backup before writing its managed version. `coding-tool-gateway logout` restores the backup.
 
 ## Authentication
 
 - Databricks authentication always uses the workspace URL you configured
 - If AI Gateway V2 is enabled, tool base URLs point to the AI Gateway hostname while authentication still uses the original workspace URL
 - Codex and Claude use a Databricks token helper instead of storing a fixed token
-- Gemini refreshes its Databricks bearer token automatically while launched through `databricks-code`
-- `databricks-code usage` fetches a fresh Databricks token on each run
+- Gemini refreshes its Databricks bearer token automatically while launched through `coding-tool-gateway`
+- `coding-tool-gateway usage` fetches a fresh Databricks token on each run
 
 ## Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "databricks-code"
+name = "coding-tool-gateway"
 version = "0.1.0"
 description = "Bootstrap Codex against a Databricks workspace with minimal setup."
 readme = "README.md"
@@ -13,7 +13,7 @@ dependencies = [
 ]
 
 [project.scripts]
-databricks-code = "databricks_code.cli:main"
+coding-tool-gateway = "coding_tool_gateway.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools.command.install import install
 
 def _run_bootstrap():
     try:
-        from databricks_code.bootstrap import main as bootstrap_main
+        from coding_tool_gateway.bootstrap import main as bootstrap_main
 
         bootstrap_main()
     except Exception:

--- a/src/coding_tool_gateway/__init__.py
+++ b/src/coding_tool_gateway/__init__.py
@@ -1,0 +1,1 @@
+"""coding-tool-gateway package."""

--- a/src/coding_tool_gateway/bootstrap.py
+++ b/src/coding_tool_gateway/bootstrap.py
@@ -1,8 +1,8 @@
-"""Best-effort runtime/bootstrap installer for databricks-code dependencies."""
+"""Best-effort runtime/bootstrap installer for coding-tool-gateway dependencies."""
 
 from __future__ import annotations
 
-from databricks_code.cli import TOOL_SPECS, ensure_bootstrap_dependencies, print_err
+from coding_tool_gateway.cli import TOOL_SPECS, ensure_bootstrap_dependencies, print_err
 
 
 def main() -> int:
@@ -10,7 +10,7 @@ def main() -> int:
         for tool in TOOL_SPECS:
             ensure_bootstrap_dependencies(tool)
     except RuntimeError as exc:
-        print_err(f"databricks-code bootstrap failed: {exc}")
+        print_err(f"coding-tool-gateway bootstrap failed: {exc}")
         return 1
     return 0
 

--- a/src/coding_tool_gateway/cli.py
+++ b/src/coding_tool_gateway/cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""CLI entry point for databricks-code."""
+"""CLI entry point for coding-tool-gateway."""
 
 from __future__ import annotations
 
@@ -24,7 +24,7 @@ from urllib import request as urllib_request
 from urllib.parse import urlparse
 
 
-APP_DIR = Path.home() / ".databricks-code"
+APP_DIR = Path.home() / ".coding-tool-gateway"
 STATE_PATH = APP_DIR / "state.json"
 
 CODEX_CONFIG_DIR = Path.home() / ".codex"
@@ -1145,7 +1145,7 @@ def render_codex_config(workspace: str, use_ai_gateway_v2: bool, org_id: str | N
     auth_command = build_auth_shell_command(workspace)
     base_url = build_tool_base_url("codex", workspace, use_ai_gateway_v2, org_id)
     return (
-        "# Managed by databricks-code. Run `databricks-code logout` to restore the prior config.\n"
+        "# Managed by coding-tool-gateway. Run `coding-tool-gateway logout` to restore the prior config.\n"
         'profile = "default"\n'
         "\n"
         "[profiles.default]\n"
@@ -1192,7 +1192,7 @@ def render_gemini_env(
 ) -> str:
     base_url = build_tool_base_url("gemini", workspace, use_ai_gateway_v2, org_id)
     return (
-        "# Managed by databricks-code. Run `databricks-code logout` to restore the prior config.\n"
+        "# Managed by coding-tool-gateway. Run `coding-tool-gateway logout` to restore the prior config.\n"
         f'GEMINI_MODEL="{model}"\n'
         f'GOOGLE_GEMINI_BASE_URL="{base_url}"\n'
         'GEMINI_API_KEY_AUTH_MECHANISM="bearer"\n'
@@ -1261,7 +1261,7 @@ def prompt_for_org_id() -> str:
 
 
 def prompt_for_configuration(tool: str | None = None) -> tuple[str, bool, str | None]:
-    print_section("databricks-code Setup")
+    print_section("coding-tool-gateway Setup")
     if tool is None:
         print_note("This will configure your Databricks workspace for all supported tools.")
     else:
@@ -1461,7 +1461,7 @@ def configure_model_for_tool(tool: str, model: str | None) -> int:
     print_kv("Base URL", state["base_urls"][tool])
     print_kv("Config file", str(TOOL_SPECS[tool]["config_path"]))
     print_success(f"{TOOL_SPECS[tool]['display']} model configuration saved")
-    print_note(f"Launch via `databricks-code --tool {tool}`.")
+    print_note(f"Launch via `coding-tool-gateway --tool {tool}`.")
     return 0
 
 
@@ -1500,11 +1500,11 @@ def usage() -> int:
     state = load_state()
     workspace = state.get("workspace")
     if not workspace:
-        raise RuntimeError("Workspace is not configured. Run `databricks-code configure` first.")
+        raise RuntimeError("Workspace is not configured. Run `coding-tool-gateway configure` first.")
     if not bool(state.get("use_ai_gateway_v2")):
         raise RuntimeError(
             "Usage summary requires Databricks AI Gateway V2. "
-            f"Run `databricks-code configure`, enable AI Gateway V2, then try again. Docs: {AI_GATEWAY_V2_DOCS_URL}"
+            f"Run `coding-tool-gateway configure`, enable AI Gateway V2, then try again. Docs: {AI_GATEWAY_V2_DOCS_URL}"
         )
 
     ensure_databricks_auth(workspace)
@@ -1596,7 +1596,7 @@ def status() -> int:
     managed_configs = state.get("managed_configs") or {}
     selected_models = state.get("selected_models") or {}
 
-    print(heading("databricks-code Status"))
+    print(heading("coding-tool-gateway Status"))
     print()
     print(
         f"  {status_badge('Configured', 'ok') if workspace else status_badge('Not Configured', 'warn')}"
@@ -1633,8 +1633,8 @@ def status() -> int:
 
     print_section("State")
     print_kv("State file", str(STATE_PATH) if STATE_PATH.exists() else "missing")
-    print_note("Use `databricks-code configure` to update workspace settings or tool models.")
-    print_note("Use `databricks-code logout` to clear managed configs and restore prior files.")
+    print_note("Use `coding-tool-gateway configure` to update workspace settings or tool models.")
+    print_note("Use `coding-tool-gateway logout` to clear managed configs and restore prior files.")
     return 0
 
 
@@ -1658,32 +1658,32 @@ def logout() -> int:
     print_kv("Codex config", "restored" if codex_restored else "unchanged")
     print_kv("Claude config", "restored" if claude_restored else "unchanged")
     print_kv("Gemini config", "restored" if gemini_restored else "unchanged")
-    print_success("databricks-code state cleared")
+    print_success("coding-tool-gateway state cleared")
     return 0
 
 
 def print_help() -> None:
-    print(heading("databricks-code"))
+    print(heading("coding-tool-gateway"))
     print(muted("Databricks-backed Codex, Claude Code, and Gemini bootstrap"))
     print()
     print(label("Commands"))
-    print(f"  {value('databricks-code')} {muted('[--tool codex|claude|gemini] [--model MODEL] [tool-args...]')}")
+    print(f"  {value('coding-tool-gateway')} {muted('[--tool codex|claude|gemini] [--model MODEL] [tool-args...]')}")
     print("    Launch the selected tool using the saved workspace configuration.")
-    print(f"  {value('databricks-code configure')}")
+    print(f"  {value('coding-tool-gateway configure')}")
     print("    Interactively configure workspace settings or Claude/Gemini model selection.")
-    print(f"  {value('databricks-code status')}")
+    print(f"  {value('coding-tool-gateway status')}")
     print("    Show the current workspace, tool configs, and saved model selections.")
-    print(f"  {value('databricks-code usage')}")
+    print(f"  {value('coding-tool-gateway usage')}")
     print("    Show a fixed Databricks AI Gateway usage summary for the saved AI Gateway V2 workspace.")
-    print(f"  {value('databricks-code logout')}")
-    print("    Clear databricks-code state and restore any backed-up tool config files.")
+    print(f"  {value('coding-tool-gateway logout')}")
+    print("    Clear coding-tool-gateway state and restore any backed-up tool config files.")
     print()
     print(label("Behavior"))
-    print_note("On first run, databricks-code prompts for your Databricks workspace settings.")
-    print_note("`databricks-code configure` lets you choose whether to configure workspace settings or tool models.")
+    print_note("On first run, coding-tool-gateway prompts for your Databricks workspace settings.")
+    print_note("`coding-tool-gateway configure` lets you choose whether to configure workspace settings or tool models.")
     print_note("Normal launches use the saved or explicit model and do not do interactive model discovery.")
-    print_note("`databricks-code usage` fetches a fresh Databricks token each time, so expired one-hour tokens are handled automatically.")
-    print_note("`databricks-code usage` shows a fixed last-7-days breakdown for Codex, Claude Code, and Gemini CLI.")
+    print_note("`coding-tool-gateway usage` fetches a fresh Databricks token each time, so expired one-hour tokens are handled automatically.")
+    print_note("`coding-tool-gateway usage` shows a fixed last-7-days breakdown for Codex, Claude Code, and Gemini CLI.")
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:

--- a/src/databricks_code/__init__.py
+++ b/src/databricks_code/__init__.py
@@ -1,1 +1,0 @@
-"""databricks-code package."""


### PR DESCRIPTION
Renames the package, console script, Python module, and app data dir (~/.databricks-code → ~/.coding-tool-gateway). README and all user-facing strings updated to match.

Note: existing users on 0.1.0 will lose their saved workspace state on upgrade since the app data dir moves. Acceptable at this version.

Co-authored-by: Isaac