### PR TITLE
Non-destructive config merge for Claude Code and Gemini CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 dist/
 .venv/
 .DS_Store
+CLAUDE.md
+.omc/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+SANDBOX_HOME := /tmp/coding-gateway-sandbox
+
+.PHONY: run configure status logout usage mcp clean test lint
+
+# Development commands — all run in sandbox to protect real configs
+run: ## Launch tool in sandbox (use TOOL=claude, ARGS="--model x")
+	CODING_GATEWAY_CONFIG_HOME=$(SANDBOX_HOME) uv run coding-gateway $(if $(TOOL),--tool $(TOOL)) $(ARGS)
+
+configure: ## Run configure in sandbox
+	CODING_GATEWAY_CONFIG_HOME=$(SANDBOX_HOME) uv run coding-gateway configure $(ARGS)
+
+mcp: ## Configure MCP servers in sandbox
+	CODING_GATEWAY_CONFIG_HOME=$(SANDBOX_HOME) uv run coding-gateway configure mcp $(ARGS)
+
+status: ## Show status from sandbox state
+	CODING_GATEWAY_CONFIG_HOME=$(SANDBOX_HOME) uv run coding-gateway status
+
+logout: ## Clear sandbox state
+	CODING_GATEWAY_CONFIG_HOME=$(SANDBOX_HOME) uv run coding-gateway logout
+
+usage: ## Show usage stats from sandbox
+	CODING_GATEWAY_CONFIG_HOME=$(SANDBOX_HOME) uv run coding-gateway usage $(ARGS)
+
+inspect: ## Show what the sandbox wrote
+	@echo "==> Sandbox configs:"
+	@ls -la $(SANDBOX_HOME)/.claude/ 2>/dev/null || echo "  .claude/ not created"
+	@ls -la $(SANDBOX_HOME)/.codex/ 2>/dev/null || echo "  .codex/ not created"
+	@ls -la $(SANDBOX_HOME)/.gemini/ 2>/dev/null || echo "  .gemini/ not created"
+	@ls -la $(SANDBOX_HOME)/.coding-gateway/ 2>/dev/null || echo "  .coding-gateway/ not created"
+
+clean: ## Nuke sandbox and start fresh
+	rm -rf $(SANDBOX_HOME)
+	@echo "Sandbox cleaned"
+
+test: ## Run tests
+	uv run pytest $(ARGS)
+
+lint: ## Run linter
+	uv run ruff check src/
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
   "typer>=0.12.0",
 ]
 
+[dependency-groups]
+dev = ["pytest>=8.0"]
+
 [project.scripts]
 coding-gateway = "coding_tool_gateway.cli:main"
 

--- a/sandbox.sh
+++ b/sandbox.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Run coding-gateway in a sandboxed HOME so it can't touch your real configs.
+# Usage: ./sandbox.sh [any coding-gateway args...]
+# Example: ./sandbox.sh configure
+# Example: ./sandbox.sh --tool claude
+# Example: ./sandbox.sh status
+
+SANDBOX_HOME="/tmp/coding-gateway-sandbox"
+mkdir -p "$SANDBOX_HOME"
+
+echo "==> Sandboxed HOME: $SANDBOX_HOME"
+echo "==> Your real ~/.claude, ~/.codex, ~/.gemini are untouched"
+echo ""
+
+HOME="$SANDBOX_HOME" uv run coding-gateway "$@"

--- a/src/coding_tool_gateway/cli.py
+++ b/src/coding_tool_gateway/cli.py
@@ -28,14 +28,16 @@ from rich.console import Console
 from rich.panel import Panel
 
 
-APP_DIR = Path.home() / ".coding-gateway"
+_CONFIG_HOME = Path(os.environ.get("CODING_GATEWAY_CONFIG_HOME", Path.home()))
+
+APP_DIR = _CONFIG_HOME / ".coding-gateway"
 STATE_PATH = APP_DIR / "state.json"
 
-CODEX_CONFIG_DIR = Path.home() / ".codex"
+CODEX_CONFIG_DIR = _CONFIG_HOME / ".codex"
 CODEX_CONFIG_PATH = CODEX_CONFIG_DIR / "config.toml"
-CLAUDE_CONFIG_DIR = Path.home() / ".claude"
+CLAUDE_CONFIG_DIR = _CONFIG_HOME / ".claude"
 CLAUDE_SETTINGS_PATH = CLAUDE_CONFIG_DIR / "settings.json"
-GEMINI_CONFIG_DIR = Path.home() / ".gemini"
+GEMINI_CONFIG_DIR = _CONFIG_HOME / ".gemini"
 GEMINI_ENV_PATH = GEMINI_CONFIG_DIR / ".env"
 
 CODEX_BACKUP_PATH = APP_DIR / "codex-config.backup.toml"
@@ -1328,6 +1330,116 @@ def configure_shared_state(workspace: str) -> dict:
     return state
 
 
+# Keys managed by coding-gateway — used for merge and surgical removal on logout.
+_CLAUDE_MANAGED_TOP_KEYS = {"apiKeyHelper"}
+_CLAUDE_MANAGED_ENV_KEYS = {
+    "ANTHROPIC_MODEL",
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_CUSTOM_HEADERS",
+    "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS",
+    "CLAUDE_CODE_API_KEY_HELPER_TTL_MS",
+    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+    "ANTHROPIC_DEFAULT_SONNET_MODEL",
+    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+}
+_GEMINI_MANAGED_ENV_KEYS = {
+    "GEMINI_MODEL",
+    "GOOGLE_GEMINI_BASE_URL",
+    "GEMINI_API_KEY_AUTH_MECHANISM",
+    "GEMINI_API_KEY",
+}
+
+
+def _merge_claude_settings(gateway_settings: dict) -> dict:
+    """Read existing Claude settings.json and merge only gateway-managed keys."""
+    existing: dict = {}
+    if CLAUDE_SETTINGS_PATH.exists():
+        try:
+            existing = json.loads(CLAUDE_SETTINGS_PATH.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            existing = {}
+    merged = dict(existing)
+    merged["apiKeyHelper"] = gateway_settings["apiKeyHelper"]
+    existing_env = dict(merged.get("env", {}))
+    existing_env.update(gateway_settings["env"])
+    merged["env"] = existing_env
+    return merged
+
+
+def _unmerge_claude_settings() -> bool:
+    """Remove only gateway-managed keys from Claude settings.json."""
+    if not CLAUDE_SETTINGS_PATH.exists():
+        return False
+    try:
+        settings = json.loads(CLAUDE_SETTINGS_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return False
+    for key in _CLAUDE_MANAGED_TOP_KEYS:
+        settings.pop(key, None)
+    env = settings.get("env")
+    if isinstance(env, dict):
+        for key in _CLAUDE_MANAGED_ENV_KEYS:
+            env.pop(key, None)
+        if not env:
+            settings.pop("env", None)
+    CLAUDE_SETTINGS_PATH.write_text(json.dumps(settings, indent=2) + "\n", encoding="utf-8")
+    return True
+
+
+def _merge_gemini_env(new_vars: dict[str, str]) -> str:
+    """Read existing .env and update only gateway-managed keys."""
+    existing_lines: list[str] = []
+    if GEMINI_ENV_PATH.exists():
+        try:
+            existing_lines = GEMINI_ENV_PATH.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            existing_lines = []
+    updated_keys: set[str] = set()
+    result_lines: list[str] = []
+    for line in existing_lines:
+        stripped = line.strip()
+        if stripped.startswith("#") and "Managed by coding-gateway" in stripped:
+            continue
+        key = stripped.split("=", 1)[0] if "=" in stripped else None
+        if key and key in new_vars:
+            result_lines.append(f'{key}="{new_vars[key]}"')
+            updated_keys.add(key)
+        else:
+            result_lines.append(line)
+    for key, val in new_vars.items():
+        if key not in updated_keys:
+            result_lines.append(f'{key}="{val}"')
+    header = MANAGED_FILE_HEADER.rstrip("\n")
+    if result_lines and result_lines[0] != header:
+        result_lines.insert(0, header)
+    return "\n".join(result_lines) + "\n"
+
+
+def _unmerge_gemini_env() -> bool:
+    """Remove only gateway-managed keys from Gemini .env."""
+    if not GEMINI_ENV_PATH.exists():
+        return False
+    try:
+        lines = GEMINI_ENV_PATH.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return False
+    result = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("#") and "Managed by coding-gateway" in stripped:
+            continue
+        key = stripped.split("=", 1)[0] if "=" in stripped else None
+        if key and key in _GEMINI_MANAGED_ENV_KEYS:
+            continue
+        result.append(line)
+    content = "\n".join(result).strip()
+    if content:
+        GEMINI_ENV_PATH.write_text(content + "\n", encoding="utf-8")
+    else:
+        GEMINI_ENV_PATH.unlink(missing_ok=True)
+    return True
+
+
 def write_codex_tool_config(state: dict) -> dict:
     backup_existing_file(CODEX_CONFIG_PATH, CODEX_BACKUP_PATH)
     write_text_file(
@@ -1344,15 +1456,14 @@ def write_codex_tool_config(state: dict) -> dict:
 
 def write_claude_tool_config(state: dict, model: str) -> dict:
     backup_existing_file(CLAUDE_SETTINGS_PATH, CLAUDE_BACKUP_PATH)
-    write_json_file(
-        CLAUDE_SETTINGS_PATH,
-        render_claude_settings(
-            state["workspace"],
-            bool(state.get("use_ai_gateway_v2")),
-            model,
-            state.get("claude_models") or {},
-        ),
+    gateway_settings = render_claude_settings(
+        state["workspace"],
+        bool(state.get("use_ai_gateway_v2")),
+        model,
+        state.get("claude_models") or {},
     )
+    merged = _merge_claude_settings(gateway_settings)
+    write_json_file(CLAUDE_SETTINGS_PATH, merged)
     state = mark_tool_managed(state, "claude")
     save_state(state)
     return state
@@ -1361,15 +1472,14 @@ def write_claude_tool_config(state: dict, model: str) -> dict:
 def write_gemini_tool_config(state: dict, model: str) -> dict:
     backup_existing_file(GEMINI_ENV_PATH, GEMINI_BACKUP_PATH)
     token = get_databricks_token(state["workspace"])
-    write_text_file(
-        GEMINI_ENV_PATH,
-        render_gemini_env(
-            state["workspace"],
-            bool(state.get("use_ai_gateway_v2")),
-            model,
-            token,
-        ),
-    )
+    base_url = build_tool_base_url("gemini", state["workspace"], bool(state.get("use_ai_gateway_v2")))
+    new_vars = {
+        "GEMINI_MODEL": model,
+        "GOOGLE_GEMINI_BASE_URL": base_url,
+        "GEMINI_API_KEY_AUTH_MECHANISM": "bearer",
+        "GEMINI_API_KEY": token,
+    }
+    write_text_file(GEMINI_ENV_PATH, _merge_gemini_env(new_vars))
     state = mark_tool_managed(state, "gemini")
     save_state(state)
     return state
@@ -1380,15 +1490,14 @@ def refresh_gemini_token_once(state: dict) -> str:
     model = (state.get("selected_models") or {}).get("gemini")
     if not model:
         raise RuntimeError("No Gemini model is configured.")
-    write_text_file(
-        GEMINI_ENV_PATH,
-        render_gemini_env(
-            state["workspace"],
-            bool(state.get("use_ai_gateway_v2")),
-            model,
-            token,
-        ),
-    )
+    base_url = build_tool_base_url("gemini", state["workspace"], bool(state.get("use_ai_gateway_v2")))
+    new_vars = {
+        "GEMINI_MODEL": model,
+        "GOOGLE_GEMINI_BASE_URL": base_url,
+        "GEMINI_API_KEY_AUTH_MECHANISM": "bearer",
+        "GEMINI_API_KEY": token,
+    }
+    write_text_file(GEMINI_ENV_PATH, _merge_gemini_env(new_vars))
     return token
 
 
@@ -1751,16 +1860,34 @@ def logout() -> int:
     state = load_state()
     managed_configs = state.get("managed_configs") or {}
 
-    results: dict[str, bool] = {
-        tool: restore_file(spec["config_path"], spec["backup_path"], bool(managed_configs.get(tool)))
-        for tool, spec in TOOL_SPECS.items()
-    }
+    results: dict[str, str] = {}
+    # Claude: surgically remove only gateway-managed keys
+    if managed_configs.get("claude"):
+        results["claude"] = "cleaned" if _unmerge_claude_settings() else "unchanged"
+    else:
+        results["claude"] = "unchanged"
+    # Codex: restore from backup (TOML merge not yet implemented)
+    results["codex"] = (
+        "restored"
+        if restore_file(CODEX_CONFIG_PATH, CODEX_BACKUP_PATH, bool(managed_configs.get("codex")))
+        else "unchanged"
+    )
+    # Gemini: surgically remove only gateway-managed keys
+    if managed_configs.get("gemini"):
+        results["gemini"] = "cleaned" if _unmerge_gemini_env() else "unchanged"
+    else:
+        results["gemini"] = "unchanged"
+
+    # Clean up backup files that are no longer needed
+    for path in (CLAUDE_BACKUP_PATH, GEMINI_BACKUP_PATH):
+        path.unlink(missing_ok=True)
+
     clear_state()
 
     print_heading("Logout")
     print_kv("Workspace", state.get("workspace") or "none")
     for tool, spec in TOOL_SPECS.items():
-        print_kv(f"{spec['display']} config", "restored" if results[tool] else "unchanged")
+        print_kv(f"{spec['display']} config", results.get(tool, "unchanged"))
     print_success("coding-gateway state cleared")
     return 0
 

--- a/tests/test_config_merge.py
+++ b/tests/test_config_merge.py
@@ -1,0 +1,325 @@
+"""Tests for non-destructive config merge/unmerge logic.
+
+Verifies that coding-gateway's configure and logout flows preserve
+user settings that the gateway does not manage.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_CLAUDE_SETTINGS = {
+    "$schema": "https://example.com/schema",
+    "model": "claude-sonnet-4-20250514",
+    "env": {
+        "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+        "MY_CUSTOM_VAR": "keep-me",
+    },
+    "mcpServers": {
+        "slack": {"type": "http", "url": "https://slack.example.com"},
+        "jira": {"type": "http", "url": "https://jira.example.com"},
+    },
+    "permissions": {"allow": ["read"], "deny": ["write"]},
+    "hooks": {"PreToolUse": {"command": "echo hi"}},
+    "allow": ["Bash", "Read", "Write"],
+    "enabledPlugins": {"plugin-a": True, "plugin-b": True},
+    "statusLine": {"enabled": True},
+    "alwaysThinkingEnabled": True,
+    "voiceEnabled": False,
+}
+
+GATEWAY_CLAUDE_SETTINGS = {
+    "apiKeyHelper": "sh -c 'databricks auth token --host https://test.cloud.databricks.com'",
+    "env": {
+        "ANTHROPIC_MODEL": "databricks-claude-opus-4-6",
+        "ANTHROPIC_BASE_URL": "https://test.cloud.databricks.com/ai-gateway/anthropic/v1",
+        "ANTHROPIC_CUSTOM_HEADERS": "x-databricks-use-coding-agent-mode: true",
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+        "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "1800000",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL": "databricks-claude-opus-4-6",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL": "databricks-claude-sonnet-4-6",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL": "databricks-claude-haiku-4-5",
+    },
+}
+
+SAMPLE_GEMINI_ENV = textwrap.dedent("""\
+    MY_CUSTOM_KEY="some-value"
+    ANOTHER_VAR="keep-this"
+""")
+
+
+@pytest.fixture
+def sandbox(tmp_path, monkeypatch):
+    """Set up an isolated config home and patch module-level paths."""
+    import coding_tool_gateway.cli as cli
+
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    gemini_dir = tmp_path / ".gemini"
+    gemini_dir.mkdir()
+
+    monkeypatch.setattr(cli, "CLAUDE_SETTINGS_PATH", claude_dir / "settings.json")
+    monkeypatch.setattr(cli, "GEMINI_ENV_PATH", gemini_dir / ".env")
+
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Claude merge tests
+# ---------------------------------------------------------------------------
+
+class TestClaudeMerge:
+    def test_merge_preserves_all_existing_keys(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(SAMPLE_CLAUDE_SETTINGS, indent=2))
+
+        merged = cli._merge_claude_settings(GATEWAY_CLAUDE_SETTINGS)
+
+        for key in SAMPLE_CLAUDE_SETTINGS:
+            assert key in merged, f"Key '{key}' was lost during merge"
+
+    def test_merge_adds_gateway_keys(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(SAMPLE_CLAUDE_SETTINGS, indent=2))
+
+        merged = cli._merge_claude_settings(GATEWAY_CLAUDE_SETTINGS)
+
+        assert merged["apiKeyHelper"] == GATEWAY_CLAUDE_SETTINGS["apiKeyHelper"]
+        assert merged["env"]["ANTHROPIC_MODEL"] == "databricks-claude-opus-4-6"
+        assert merged["env"]["ANTHROPIC_BASE_URL"].endswith("/ai-gateway/anthropic/v1")
+
+    def test_merge_preserves_user_env_vars(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(SAMPLE_CLAUDE_SETTINGS, indent=2))
+
+        merged = cli._merge_claude_settings(GATEWAY_CLAUDE_SETTINGS)
+
+        assert merged["env"]["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] == "1"
+        assert merged["env"]["MY_CUSTOM_VAR"] == "keep-me"
+
+    def test_merge_preserves_mcp_servers(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(SAMPLE_CLAUDE_SETTINGS, indent=2))
+
+        merged = cli._merge_claude_settings(GATEWAY_CLAUDE_SETTINGS)
+
+        assert set(merged["mcpServers"].keys()) == {"slack", "jira"}
+
+    def test_merge_preserves_allow_rules(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(SAMPLE_CLAUDE_SETTINGS, indent=2))
+
+        merged = cli._merge_claude_settings(GATEWAY_CLAUDE_SETTINGS)
+
+        assert merged["allow"] == ["Bash", "Read", "Write"]
+
+    def test_merge_preserves_hooks(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(SAMPLE_CLAUDE_SETTINGS, indent=2))
+
+        merged = cli._merge_claude_settings(GATEWAY_CLAUDE_SETTINGS)
+
+        assert "PreToolUse" in merged["hooks"]
+
+    def test_merge_with_no_existing_file(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.CLAUDE_SETTINGS_PATH.unlink(missing_ok=True)
+
+        merged = cli._merge_claude_settings(GATEWAY_CLAUDE_SETTINGS)
+
+        assert merged["apiKeyHelper"] == GATEWAY_CLAUDE_SETTINGS["apiKeyHelper"]
+        assert "ANTHROPIC_MODEL" in merged["env"]
+
+    def test_merge_with_corrupt_json(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.CLAUDE_SETTINGS_PATH.write_text("{ not valid json !!!")
+
+        merged = cli._merge_claude_settings(GATEWAY_CLAUDE_SETTINGS)
+
+        assert merged["apiKeyHelper"] == GATEWAY_CLAUDE_SETTINGS["apiKeyHelper"]
+
+    def test_merge_with_empty_file(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.CLAUDE_SETTINGS_PATH.write_text("{}")
+
+        merged = cli._merge_claude_settings(GATEWAY_CLAUDE_SETTINGS)
+
+        assert merged["apiKeyHelper"] == GATEWAY_CLAUDE_SETTINGS["apiKeyHelper"]
+        assert "ANTHROPIC_MODEL" in merged["env"]
+
+    def test_merge_is_idempotent(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(SAMPLE_CLAUDE_SETTINGS, indent=2))
+
+        first = cli._merge_claude_settings(GATEWAY_CLAUDE_SETTINGS)
+        cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(first, indent=2))
+        second = cli._merge_claude_settings(GATEWAY_CLAUDE_SETTINGS)
+
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Claude unmerge tests
+# ---------------------------------------------------------------------------
+
+class TestClaudeUnmerge:
+    def test_unmerge_removes_gateway_keys(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(SAMPLE_CLAUDE_SETTINGS, indent=2))
+
+        merged = cli._merge_claude_settings(GATEWAY_CLAUDE_SETTINGS)
+        cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(merged, indent=2))
+        cli._unmerge_claude_settings()
+
+        restored = json.loads(cli.CLAUDE_SETTINGS_PATH.read_text())
+        assert "apiKeyHelper" not in restored
+        assert "ANTHROPIC_MODEL" not in restored.get("env", {})
+        assert "ANTHROPIC_BASE_URL" not in restored.get("env", {})
+
+    def test_unmerge_preserves_user_settings(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(SAMPLE_CLAUDE_SETTINGS, indent=2))
+
+        merged = cli._merge_claude_settings(GATEWAY_CLAUDE_SETTINGS)
+        cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(merged, indent=2))
+        cli._unmerge_claude_settings()
+
+        restored = json.loads(cli.CLAUDE_SETTINGS_PATH.read_text())
+        assert set(restored.keys()) == set(SAMPLE_CLAUDE_SETTINGS.keys())
+        assert restored["mcpServers"] == SAMPLE_CLAUDE_SETTINGS["mcpServers"]
+        assert restored["allow"] == SAMPLE_CLAUDE_SETTINGS["allow"]
+        assert restored["hooks"] == SAMPLE_CLAUDE_SETTINGS["hooks"]
+
+    def test_unmerge_preserves_user_env_vars(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(SAMPLE_CLAUDE_SETTINGS, indent=2))
+
+        merged = cli._merge_claude_settings(GATEWAY_CLAUDE_SETTINGS)
+        cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(merged, indent=2))
+        cli._unmerge_claude_settings()
+
+        restored = json.loads(cli.CLAUDE_SETTINGS_PATH.read_text())
+        assert restored["env"]["MY_CUSTOM_VAR"] == "keep-me"
+        assert restored["env"]["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] == "1"
+
+    def test_unmerge_no_file_returns_false(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.CLAUDE_SETTINGS_PATH.unlink(missing_ok=True)
+
+        assert cli._unmerge_claude_settings() is False
+
+    def test_full_roundtrip(self, sandbox):
+        """configure -> launch -> launch -> logout should leave settings intact."""
+        import coding_tool_gateway.cli as cli
+        original = dict(SAMPLE_CLAUDE_SETTINGS)
+        cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(original, indent=2))
+
+        # Simulate multiple configures (merges)
+        for _ in range(3):
+            merged = cli._merge_claude_settings(GATEWAY_CLAUDE_SETTINGS)
+            cli.CLAUDE_SETTINGS_PATH.write_text(json.dumps(merged, indent=2))
+
+        # Simulate logout (unmerge)
+        cli._unmerge_claude_settings()
+
+        restored = json.loads(cli.CLAUDE_SETTINGS_PATH.read_text())
+        assert set(restored.keys()) == set(original.keys())
+        assert restored["mcpServers"] == original["mcpServers"]
+        assert restored["env"] == original["env"]
+
+
+# ---------------------------------------------------------------------------
+# Gemini merge tests
+# ---------------------------------------------------------------------------
+
+class TestGeminiMerge:
+    def test_merge_preserves_existing_vars(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.GEMINI_ENV_PATH.write_text(SAMPLE_GEMINI_ENV)
+
+        new_vars = {
+            "GEMINI_MODEL": "databricks-gemini-3-1-pro",
+            "GOOGLE_GEMINI_BASE_URL": "https://test.cloud.databricks.com/ai-gateway/gemini/v1",
+            "GEMINI_API_KEY_AUTH_MECHANISM": "bearer",
+            "GEMINI_API_KEY": "dapi-test-token",
+        }
+        result = cli._merge_gemini_env(new_vars)
+
+        assert 'MY_CUSTOM_KEY="some-value"' in result
+        assert 'ANOTHER_VAR="keep-this"' in result
+        assert 'GEMINI_MODEL="databricks-gemini-3-1-pro"' in result
+        assert 'GEMINI_API_KEY="dapi-test-token"' in result
+
+    def test_merge_updates_existing_gateway_vars(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        existing = 'GEMINI_MODEL="old-model"\nMY_VAR="keep"\n'
+        cli.GEMINI_ENV_PATH.write_text(existing)
+
+        new_vars = {"GEMINI_MODEL": "new-model"}
+        result = cli._merge_gemini_env(new_vars)
+
+        assert result.count("GEMINI_MODEL") == 1
+        assert 'GEMINI_MODEL="new-model"' in result
+        assert 'MY_VAR="keep"' in result
+
+    def test_merge_with_no_existing_file(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.GEMINI_ENV_PATH.unlink(missing_ok=True)
+
+        new_vars = {"GEMINI_MODEL": "test-model", "GEMINI_API_KEY": "token"}
+        result = cli._merge_gemini_env(new_vars)
+
+        assert 'GEMINI_MODEL="test-model"' in result
+        assert 'GEMINI_API_KEY="token"' in result
+
+
+class TestGeminiUnmerge:
+    def test_unmerge_removes_only_gateway_vars(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        content = textwrap.dedent("""\
+            # Managed by coding-gateway. Run `coding-gateway logout` to restore the prior config.
+            MY_CUSTOM_KEY="keep"
+            GEMINI_MODEL="databricks-gemini-3-1-pro"
+            GEMINI_API_KEY="secret-token"
+            ANOTHER_VAR="also-keep"
+        """)
+        cli.GEMINI_ENV_PATH.write_text(content)
+
+        cli._unmerge_gemini_env()
+
+        result = cli.GEMINI_ENV_PATH.read_text()
+        assert "MY_CUSTOM_KEY" in result
+        assert "ANOTHER_VAR" in result
+        assert "GEMINI_MODEL" not in result
+        assert "GEMINI_API_KEY" not in result
+        assert "Managed by coding-gateway" not in result
+
+    def test_unmerge_deletes_file_if_only_gateway_vars(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        content = textwrap.dedent("""\
+            # Managed by coding-gateway. Run `coding-gateway logout` to restore the prior config.
+            GEMINI_MODEL="model"
+            GEMINI_API_KEY="token"
+            GOOGLE_GEMINI_BASE_URL="url"
+            GEMINI_API_KEY_AUTH_MECHANISM="bearer"
+        """)
+        cli.GEMINI_ENV_PATH.write_text(content)
+
+        cli._unmerge_gemini_env()
+
+        assert not cli.GEMINI_ENV_PATH.exists()
+
+    def test_unmerge_no_file_returns_false(self, sandbox):
+        import coding_tool_gateway.cli as cli
+        cli.GEMINI_ENV_PATH.unlink(missing_ok=True)
+
+        assert cli._unmerge_gemini_env() is False

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
@@ -19,7 +19,7 @@ wheels = [
 [[package]]
 name = "certifi"
 version = "2026.4.22"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
@@ -28,7 +28,7 @@ wheels = [
 [[package]]
 name = "charset-normalizer"
 version = "3.4.7"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
@@ -101,7 +101,7 @@ wheels = [
 [[package]]
 name = "click"
 version = "8.3.3"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -119,16 +119,24 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "databricks-sql-connector", specifier = ">=3.6.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]
 
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0" }]
+
 [[package]]
 name = "colorama"
 version = "0.4.6"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
@@ -137,7 +145,7 @@ wheels = [
 [[package]]
 name = "databricks-sql-connector"
 version = "4.2.5"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "lz4" },
     { name = "oauthlib" },
@@ -158,7 +166,7 @@ wheels = [
 [[package]]
 name = "et-xmlfile"
 version = "2.0.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
@@ -167,16 +175,25 @@ wheels = [
 [[package]]
 name = "idna"
 version = "3.13"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "lz4"
 version = "4.4.5"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/51/f1b86d93029f418033dddf9b9f79c8d2641e7454080478ee2aab5123173e/lz4-4.4.5.tar.gz", hash = "sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0", size = 172886, upload-time = "2025-11-03T13:02:36.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/ac/016e4f6de37d806f7cc8f13add0a46c9a7cfc41a5ddc2bc831d7954cf1ce/lz4-4.4.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:df5aa4cead2044bab83e0ebae56e0944cc7fcc1505c7787e9e1057d6d549897e", size = 207163, upload-time = "2025-11-03T13:01:45.895Z" },
@@ -216,7 +233,7 @@ wheels = [
 [[package]]
 name = "markdown-it-py"
 version = "4.0.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "mdurl" },
 ]
@@ -228,7 +245,7 @@ wheels = [
 [[package]]
 name = "mdurl"
 version = "0.1.2"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
@@ -237,7 +254,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "2.4.4"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
@@ -298,7 +315,7 @@ wheels = [
 [[package]]
 name = "oauthlib"
 version = "3.3.1"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
@@ -307,7 +324,7 @@ wheels = [
 [[package]]
 name = "openpyxl"
 version = "3.1.5"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "et-xmlfile" },
 ]
@@ -317,9 +334,18 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "pandas"
 version = "2.3.3"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
@@ -364,9 +390,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pybreaker"
 version = "1.4.1"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/89/fbf98e383f1ec6d117af2cd983efdb3eb7018b63834c427025764194cac2/pybreaker-1.4.1.tar.gz", hash = "sha256:8df2d245c73ba40c8242c56ffb4f12138fbadc23e296224740c2028ea9dc1178", size = 15555, upload-time = "2025-09-21T15:12:04.499Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/75/e64d3d40a741e2be21d69154f4e5c43a66f0c603c5ef11f49e01429a5932/pybreaker-1.4.1-py3-none-any.whl", hash = "sha256:b4dab4a05195b7f2a64a6c1a6c4ba7a96534ef56ea7210e6bcb59f28897160e0", size = 12915, upload-time = "2025-09-21T15:12:02.284Z" },
@@ -375,7 +410,7 @@ wheels = [
 [[package]]
 name = "pygments"
 version = "2.20.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
@@ -384,16 +419,32 @@ wheels = [
 [[package]]
 name = "pyjwt"
 version = "2.12.1"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
 ]
 
 [[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "six" },
 ]
@@ -405,7 +456,7 @@ wheels = [
 [[package]]
 name = "pytz"
 version = "2026.1.post1"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
@@ -414,7 +465,7 @@ wheels = [
 [[package]]
 name = "requests"
 version = "2.33.1"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
@@ -429,7 +480,7 @@ wheels = [
 [[package]]
 name = "rich"
 version = "15.0.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
@@ -442,7 +493,7 @@ wheels = [
 [[package]]
 name = "shellingham"
 version = "1.5.4"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
@@ -451,7 +502,7 @@ wheels = [
 [[package]]
 name = "six"
 version = "1.17.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
@@ -460,7 +511,7 @@ wheels = [
 [[package]]
 name = "thrift"
 version = "0.20.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "six" },
 ]
@@ -469,7 +520,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3c/2d/8946864f716ac82dc
 [[package]]
 name = "typer"
 version = "0.24.2"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "click" },
@@ -484,7 +535,7 @@ wheels = [
 [[package]]
 name = "tzdata"
 version = "2026.1"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
@@ -493,7 +544,7 @@ wheels = [
 [[package]]
 name = "urllib3"
 version = "2.6.3"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple/" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },


### PR DESCRIPTION
## Summary

- **Fix config replacement**: Previously, `configure` and `launch` would back up the existing config file and then replace it with a new file containing only gateway-managed keys. This effectively removed all user settings — MCP servers, hooks, permissions, plugins, and custom env vars — from the active config, even though a backup existed. Now uses read-merge-write: only gateway-managed keys are added to the existing config, preserving everything else.
- **Surgical logout**: `logout` now removes only gateway-managed keys from the active config instead of restoring a potentially stale backup (the backup was only captured on the very first run and never updated).
- **Sandbox dev mode**: `CODING_GATEWAY_CONFIG_HOME` env var redirects all config paths to an alternate directory, protecting developers' real CLI configs during testing.
- **21 unit tests** covering merge, unmerge, round-trips, edge cases (corrupt JSON, empty files, idempotency).

Closes #10
Closes #11

## The problem

When running `coding-gateway configure` or launching a tool, the CLI would:

1. Back up the existing config file (e.g., `~/.claude/settings.json`) to `~/.coding-gateway/`
2. Replace the active config with a new file containing **only** gateway keys (`apiKeyHelper` + `env`)

This meant the running config no longer had the user's pre-configured MCP servers, permissions, hooks, plugins, or custom environment variables. While a backup existed, it was only taken on the first run — subsequent runs would skip the backup step, so any settings the user added after the first configure were lost with no recovery path.

This replacement happened **on every launch**, not just during explicit configuration.

## The fix

Read-merge-write: read the existing config, deep-merge only the keys the gateway manages, write back. Everything else is untouched. On logout, surgically remove only the gateway-managed keys instead of restoring a stale backup.

## What changed

| File | Change |
|------|--------|
| `cli.py` | `_CONFIG_HOME` env var override; `_merge_claude_settings()`, `_unmerge_claude_settings()`, `_merge_gemini_env()`, `_unmerge_gemini_env()` functions; updated `write_claude_tool_config`, `write_gemini_tool_config`, `refresh_gemini_token_once`, `logout` |
| `pyproject.toml` | Added `pytest` dev dependency |
| `.gitignore` | Added `CLAUDE.md`, `.omc/` |
| `Makefile` | Sandbox-aware dev commands |
| `sandbox.sh` | Wrapper script for sandboxed runs |
| `tests/test_config_merge.py` | 21 tests for merge/unmerge logic |

## How to verify (step-by-step)

### 1. Run the unit tests

```bash
uv sync --group dev
uv run pytest tests/test_config_merge.py -v
```

All 21 tests should pass.

### 2. Verify sandbox isolation

```bash
# Set up sandbox with a copy of your real Claude settings
mkdir -p /tmp/coding-gateway-sandbox/.claude
cp ~/.claude/settings.json /tmp/coding-gateway-sandbox/.claude/settings.json

# Check paths are redirected
CODING_GATEWAY_CONFIG_HOME=/tmp/coding-gateway-sandbox uv run python -c \
  "from coding_tool_gateway.cli import CLAUDE_SETTINGS_PATH; print(CLAUDE_SETTINGS_PATH)"
# Should print: /tmp/coding-gateway-sandbox/.claude/settings.json

# Verify default (no env var) still uses real HOME
uv run python -c \
  "from coding_tool_gateway.cli import CLAUDE_SETTINGS_PATH; print(CLAUDE_SETTINGS_PATH)"
# Should print: /Users/<you>/.claude/settings.json
```

### 3. Verify Claude settings merge preserves user config

```bash
CODING_GATEWAY_CONFIG_HOME=/tmp/coding-gateway-sandbox uv run python3 << 'PYEOF'
import json
from coding_tool_gateway.cli import _merge_claude_settings, _unmerge_claude_settings, CLAUDE_SETTINGS_PATH

original = json.loads(CLAUDE_SETTINGS_PATH.read_text())
print(f"BEFORE: {len(original)} keys, mcpServers={list(original.get('mcpServers',{}).keys())}")

# Simulate gateway merge
gateway = {
    "apiKeyHelper": "sh -c 'databricks auth token --host https://test.databricks.com'",
    "env": {"ANTHROPIC_MODEL": "databricks-claude-opus-4-6", "ANTHROPIC_BASE_URL": "https://test/v1"},
}
merged = _merge_claude_settings(gateway)
CLAUDE_SETTINGS_PATH.write_text(json.dumps(merged, indent=2) + "\n")
print(f"AFTER MERGE: {len(merged)} keys, mcpServers={list(merged.get('mcpServers',{}).keys())}")

# Simulate logout
_unmerge_claude_settings()
restored = json.loads(CLAUDE_SETTINGS_PATH.read_text())
print(f"AFTER LOGOUT: {len(restored)} keys, mcpServers={list(restored.get('mcpServers',{}).keys())}")
print(f"apiKeyHelper removed: {'apiKeyHelper' not in restored}")
print(f"Keys lost: {set(original.keys()) - set(restored.keys()) or 'NONE'}")
PYEOF
```

Expected output: zero keys lost, MCP servers intact, `apiKeyHelper` cleanly removed on logout.

### 4. End-to-end test on a dev machine (optional)

```bash
# Clean sandbox
rm -rf /tmp/coding-gateway-sandbox

# Copy your real settings
mkdir -p /tmp/coding-gateway-sandbox/.claude
cp ~/.claude/settings.json /tmp/coding-gateway-sandbox/.claude/settings.json

# Run configure against a real workspace
make configure

# Inspect what was written
make inspect
cat /tmp/coding-gateway-sandbox/.claude/settings.json | python3 -c "import json,sys; d=json.load(sys.stdin); print(json.dumps(list(d.keys()), indent=2))"

# Verify your MCP servers survived
cat /tmp/coding-gateway-sandbox/.claude/settings.json | python3 -c "import json,sys; d=json.load(sys.stdin); print('mcpServers:', list(d.get('mcpServers',{}).keys()))"

# Test logout
make logout

# Verify gateway keys are gone but user settings remain
cat /tmp/coding-gateway-sandbox/.claude/settings.json | python3 -c "import json,sys; d=json.load(sys.stdin); print('apiKeyHelper present:', 'apiKeyHelper' in d); print('mcpServers:', list(d.get('mcpServers',{}).keys()))"
```

## Test plan

- [x] Unit tests: 21 tests covering merge, unmerge, round-trips, edge cases
- [ ] Reviewer: run `uv run pytest tests/test_config_merge.py -v` — all 21 pass
- [ ] Reviewer: run sandbox isolation check (step 2 above)
- [ ] Reviewer: run merge verification against a real settings file (step 3 above)
- [ ] Optional: end-to-end test with `make configure` on a dev machine (step 4)

This pull request and its description were written by Isaac.