### PR TITLE
Refactor cli.py into focused modules + add tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,33 @@ coding-gateway = "coding_tool_gateway.cli:main"
 
 [tool.uv.build-backend]
 module-name = "coding_tool_gateway"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "ruff>=0.15.12",
+    "ty",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+]
+ignore = [
+    "E501",  # line too long — formatter handles this
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["B011"]  # assert False in tests is fine

--- a/src/coding_tool_gateway/agents/__init__.py
+++ b/src/coding_tool_gateway/agents/__init__.py
@@ -1,0 +1,264 @@
+"""Per-agent modules + dispatch helpers.
+
+Each `agents.<tool>` module owns its own config layout, overlay rendering,
+config-file writer, default-model selection, launch logic, and validation
+command. This `__init__` aggregates the registry and exposes uniform
+dispatchers for the rest of the codebase.
+
+Adding a new agent: create `agents/<name>.py` exposing `SPEC`, `write_tool_config`,
+`default_model`, `launch`, `validate_cmd`. Then add an entry to `_MODULES`
+below and to `TOOL_ALIASES` if needed.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+
+from coding_tool_gateway.config_io import ToolSpec
+from coding_tool_gateway.databricks import (
+    ensure_databricks_auth,
+    install_databricks_cli,
+)
+from coding_tool_gateway.state import load_state, save_state
+from coding_tool_gateway.ui import (
+    console,
+    print_err,
+    print_section,
+    print_success,
+    print_warning,
+    spinner,
+)
+
+from . import claude, codex, gemini, opencode
+
+_MODULES = {
+    "codex": codex,
+    "claude": claude,
+    "gemini": gemini,
+    "opencode": opencode,
+}
+
+TOOL_SPECS: dict[str, ToolSpec] = {name: module.SPEC for name, module in _MODULES.items()}
+
+TOOL_ALIASES = {
+    "codex": "codex",
+    "claude": "claude",
+    "claude-code": "claude",
+    "gemini": "gemini",
+    "gemini-cli": "gemini",
+    "opencode": "opencode",
+}
+
+DEFAULT_TOOL = "codex"
+BUNDLE_VERSION = 1
+
+
+def normalize_tool(tool: str) -> str:
+    normalized = TOOL_ALIASES.get(tool.strip().lower())
+    if not normalized:
+        raise RuntimeError(
+            f"Unsupported tool '{tool}'. Use one of: codex, claude, gemini, opencode."
+        )
+    return normalized
+
+
+def install_tool_binary(tool: str) -> None:
+    spec = TOOL_SPECS[tool]
+    binary = spec["binary"]
+    package = spec["package"]
+
+    if shutil.which(binary):
+        return
+
+    if not shutil.which("npm"):
+        raise RuntimeError(f"`{binary}` is not installed and npm is not available to install it.")
+
+    print_section("Bootstrap")
+    print_warning(f"`{binary}` was not found. Installing {spec['display']}...")
+    try:
+        subprocess.run(["npm", "install", "-g", package], check=True, timeout=300)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(f"Failed to install {spec['display']} automatically.") from exc
+
+    if not shutil.which(binary):
+        raise RuntimeError(
+            f"{spec['display']} install completed, but `{binary}` is still not on PATH."
+        )
+
+
+def ensure_bootstrap_dependencies(tool: str) -> None:
+    install_databricks_cli()
+    install_tool_binary(tool)
+
+
+def default_model_for_tool(tool: str, state: dict) -> str | None:
+    return _MODULES[tool].default_model(state)
+
+
+def resolve_launch_model(
+    tool: str,
+    state: dict,
+    explicit_model: str | None,
+) -> tuple[dict, str | None]:
+    if tool == "codex":
+        return state, None
+    model = explicit_model or default_model_for_tool(tool, state)
+    if not model:
+        raise RuntimeError(
+            f"No models available for {tool}. "
+            f"Run `coding-gateway configure` to set up your workspace."
+        )
+    return state, model
+
+
+def configure_tool(tool: str, state: dict, model: str | None = None) -> dict:
+    result: dict | tuple[dict, str]
+    if tool == "codex":
+        result = codex.write_tool_config(state)
+    else:
+        if not model:
+            raise RuntimeError(f"A {tool} model must be selected before configuration.")
+        if tool == "claude":
+            result = claude.write_tool_config(state, model)
+        elif tool == "gemini":
+            result = gemini.write_tool_config(state, model)
+        else:
+            result = opencode.write_tool_config(state, model)
+    # gemini/opencode return (state, token); codex/claude return state
+    if isinstance(result, tuple):
+        return result[0]
+    return result
+
+
+def launch(tool: str, state: dict, tool_args: list[str]) -> None:
+    _MODULES[tool].launch(state, tool_args)
+
+
+def check_gateway_endpoint(state: dict, tool: str) -> bool:
+    """V2-only: a tool is available iff we discovered models for it."""
+    if tool == "claude":
+        return bool(state.get("claude_models"))
+    if tool == "opencode":
+        return bool(state.get("opencode_models"))
+    if tool == "codex":
+        return bool(state.get("codex_models"))
+    if tool == "gemini":
+        return bool(state.get("gemini_models"))
+    return False
+
+
+def configure_all_tools(state: dict) -> dict:
+    available_tools: list[str] = []
+    unavailable_tools: list[str] = []
+
+    for tool in TOOL_SPECS:
+        with spinner(f"Checking {TOOL_SPECS[tool]['display']} availability..."):
+            ok = check_gateway_endpoint(state, tool)
+        if ok:
+            available_tools.append(tool)
+        else:
+            unavailable_tools.append(tool)
+
+    for tool in unavailable_tools:
+        print_err(f"{TOOL_SPECS[tool]['display']} is not available on this workspace")
+
+    for tool in available_tools:
+        if tool == "codex":
+            state = configure_tool("codex", state)
+        else:
+            state, model = resolve_launch_model(tool, state, None)
+            state = configure_tool(tool, state, model)
+
+    state["available_tools"] = available_tools
+    save_state(state)
+    return state
+
+
+def ensure_provider_state(tool: str) -> dict:
+    state = load_state()
+    workspace = state.get("workspace")
+    if not workspace:
+        raise RuntimeError("No workspace configured. Run `coding-gateway configure` first.")
+    available_tools = state.get("available_tools") or []
+    if tool not in available_tools:
+        raise RuntimeError(
+            f"{TOOL_SPECS[tool]['display']} is not available on this workspace. "
+            f"Run `coding-gateway configure` to set up your agents."
+        )
+    ensure_databricks_auth(workspace)
+    return state
+
+
+def validate_tool(tool: str) -> tuple[bool, str]:
+    """Invoke a tool with a simple prompt to verify it works. Returns (ok, error_msg)."""
+    spec = TOOL_SPECS[tool]
+    binary = spec["binary"]
+    cmd = _MODULES[tool].validate_cmd(binary)
+    try:
+        result = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=60)
+        if result.returncode == 0:
+            return True, ""
+        output = (result.stderr or result.stdout or "").strip()
+        for line in output.splitlines():
+            if "error" in line.lower() and ("message" in line.lower() or ":" in line):
+                msg = line.strip()
+                if "error_code" in msg:
+                    try:
+                        payload = json.loads(msg[msg.index("{") : msg.rindex("}") + 1])
+                        return False, payload.get("message", msg)
+                    except (json.JSONDecodeError, ValueError):
+                        pass
+                return False, msg
+        last_line = output.splitlines()[-1] if output else "unknown error"
+        return False, last_line
+    except OSError as exc:
+        return False, str(exc)
+    except subprocess.TimeoutExpired:
+        return False, "timed out"
+
+
+def validate_all_tools(state: dict) -> None:
+    from rich.panel import Panel  # local to avoid bumping module-level deps
+
+    from coding_tool_gateway.config_io import restore_file
+
+    console.print()
+    console.print(
+        Panel(
+            "Testing each tool with a quick message...",
+            title="Validating",
+            style="bold blue",
+            expand=False,
+        )
+    )
+    results: list[tuple[str, bool]] = []
+    available_tools = list(state.get("available_tools") or [])
+    for tool, spec in TOOL_SPECS.items():
+        if tool not in available_tools:
+            continue
+        with spinner(f"Validating {spec['display']}..."):
+            ok, err = validate_tool(tool)
+        results.append((tool, ok))
+        if ok:
+            print_success(f"{spec['display']} is working")
+        else:
+            print_err(f"{spec['display']}: {err}")
+            managed = bool(state.get("managed_configs", {}).get(tool))
+            restore_file(spec["config_path"], spec["backup_path"], managed)
+            available_tools.remove(tool)
+    state["available_tools"] = available_tools
+    save_state(state)
+
+    console.print()
+    success_tools = [(t, s) for t, s in results if s]
+    if success_tools:
+        lines = []
+        for tool, _ in success_tools:
+            spec = TOOL_SPECS[tool]
+            lines.append(
+                f"[green]✓[/green] [bold]{spec['display']}[/bold] — "
+                f"run with [cyan]coding-gateway --agent {tool}[/cyan]"
+            )
+        console.print(Panel("\n".join(lines), title="Ready", style="green", expand=False))

--- a/src/coding_tool_gateway/agents/claude.py
+++ b/src/coding_tool_gateway/agents/claude.py
@@ -1,0 +1,87 @@
+"""Claude Code agent: writes ~/.claude/settings.json env block."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from coding_tool_gateway.config_io import (
+    APP_DIR,
+    ToolSpec,
+    backup_existing_file,
+    deep_merge_dict,
+    read_json_safe,
+    write_json_file,
+)
+from coding_tool_gateway.databricks import (
+    build_auth_shell_command,
+    build_tool_base_url,
+)
+from coding_tool_gateway.state import mark_tool_managed, save_state
+
+CLAUDE_CONFIG_DIR = Path.home() / ".claude"
+CLAUDE_SETTINGS_PATH = CLAUDE_CONFIG_DIR / "settings.json"
+CLAUDE_BACKUP_PATH = APP_DIR / "claude-settings.backup.json"
+
+SPEC: ToolSpec = {
+    "binary": "claude",
+    "package": "@anthropic-ai/claude-code",
+    "display": "Claude Code",
+    "config_path": CLAUDE_SETTINGS_PATH,
+    "backup_path": CLAUDE_BACKUP_PATH,
+}
+
+
+def render_overlay(
+    workspace: str,
+    model: str,
+    claude_models: dict[str, str] | None = None,
+) -> tuple[dict, list[list[str]]]:
+    """Return (overlay, managed_key_paths) for Claude settings.json."""
+    base_url = build_tool_base_url("claude", workspace)
+    env: dict[str, str] = {
+        "ANTHROPIC_MODEL": model,
+        "ANTHROPIC_BASE_URL": base_url,
+        "ANTHROPIC_CUSTOM_HEADERS": "x-databricks-use-coding-agent-mode: true",
+        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+        "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "1800000",
+    }
+    if claude_models:
+        if claude_models.get("opus"):
+            env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = claude_models["opus"]
+        if claude_models.get("sonnet"):
+            env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = claude_models["sonnet"]
+        if claude_models.get("haiku"):
+            env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = claude_models["haiku"]
+    overlay = {"apiKeyHelper": build_auth_shell_command(workspace), "env": env}
+    keys: list[list[str]] = [["apiKeyHelper"]] + [["env", k] for k in env]
+    return overlay, keys
+
+
+def write_tool_config(state: dict, model: str) -> dict:
+    backup_existing_file(CLAUDE_SETTINGS_PATH, CLAUDE_BACKUP_PATH)
+    overlay, managed_keys = render_overlay(
+        state["workspace"],
+        model,
+        state.get("claude_models") or {},
+    )
+    existing = read_json_safe(CLAUDE_SETTINGS_PATH)
+    merged = deep_merge_dict(existing, overlay)
+    write_json_file(CLAUDE_SETTINGS_PATH, merged)
+    state = mark_tool_managed(state, "claude", managed_keys)
+    save_state(state)
+    return state
+
+
+def default_model(state: dict) -> str | None:
+    claude_models = state.get("claude_models") or {}
+    return claude_models.get("sonnet") or claude_models.get("opus") or claude_models.get("haiku")
+
+
+def launch(state: dict, tool_args: list[str]) -> None:
+    binary = SPEC["binary"]
+    os.execvp(binary, [binary, *tool_args])
+
+
+def validate_cmd(binary: str) -> list[str]:
+    return [binary, "-p", "say hi in 5 words or less", "--max-turns", "1"]

--- a/src/coding_tool_gateway/agents/codex.py
+++ b/src/coding_tool_gateway/agents/codex.py
@@ -1,0 +1,84 @@
+"""Codex agent: writes ~/.codex/config.toml with a Databricks-backed model provider."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from coding_tool_gateway.config_io import (
+    APP_DIR,
+    ToolSpec,
+    backup_existing_file,
+    deep_merge_dict,
+    read_toml_safe,
+    write_toml_file,
+)
+from coding_tool_gateway.databricks import (
+    build_auth_shell_command,
+    build_tool_base_url,
+)
+from coding_tool_gateway.state import mark_tool_managed, save_state
+
+CODEX_CONFIG_DIR = Path.home() / ".codex"
+CODEX_CONFIG_PATH = CODEX_CONFIG_DIR / "config.toml"
+CODEX_BACKUP_PATH = APP_DIR / "codex-config.backup.toml"
+
+SPEC: ToolSpec = {
+    "binary": "codex",
+    "package": "@openai/codex",
+    "display": "Codex",
+    "config_path": CODEX_CONFIG_PATH,
+    "backup_path": CODEX_BACKUP_PATH,
+}
+
+MANAGED_KEYS: list[list[str]] = [
+    ["profile"],
+    ["profiles", "default", "model_provider"],
+    ["model_providers", "Databricks"],
+]
+
+
+def render_overlay(workspace: str) -> dict:
+    auth_command = build_auth_shell_command(workspace)
+    base_url = build_tool_base_url("codex", workspace)
+    return {
+        "profile": "default",
+        "profiles": {"default": {"model_provider": "Databricks"}},
+        "model_providers": {
+            "Databricks": {
+                "name": "Databricks AI Gateway",
+                "base_url": base_url,
+                "wire_api": "responses",
+                "auth": {
+                    "command": "sh",
+                    "args": ["-c", auth_command],
+                    "timeout_ms": 5000,
+                    "refresh_interval_ms": 1800000,
+                },
+            }
+        },
+    }
+
+
+def write_tool_config(state: dict, model: str | None = None) -> dict:
+    backup_existing_file(CODEX_CONFIG_PATH, CODEX_BACKUP_PATH)
+    overlay = render_overlay(state["workspace"])
+    doc = read_toml_safe(CODEX_CONFIG_PATH)
+    deep_merge_dict(doc, overlay)
+    write_toml_file(CODEX_CONFIG_PATH, doc)
+    state = mark_tool_managed(state, "codex", MANAGED_KEYS)
+    save_state(state)
+    return state
+
+
+def default_model(state: dict) -> str | None:
+    return None
+
+
+def launch(state: dict, tool_args: list[str]) -> None:
+    binary = SPEC["binary"]
+    os.execvp(binary, [binary, *tool_args])
+
+
+def validate_cmd(binary: str) -> list[str]:
+    return [binary, "exec", "say hi in 5 words or less"]

--- a/src/coding_tool_gateway/agents/gemini.py
+++ b/src/coding_tool_gateway/agents/gemini.py
@@ -1,0 +1,130 @@
+"""Gemini CLI agent: writes ~/.gemini/.env and runs with periodic token refresh."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import threading
+from pathlib import Path
+
+from coding_tool_gateway.config_io import (
+    APP_DIR,
+    ToolSpec,
+    backup_existing_file,
+    parse_dotenv,
+    write_dotenv,
+)
+from coding_tool_gateway.databricks import (
+    TOKEN_REFRESH_INTERVAL_SECONDS,
+    build_tool_base_url,
+    get_databricks_token,
+)
+from coding_tool_gateway.state import mark_tool_managed, save_state
+
+GEMINI_CONFIG_DIR = Path.home() / ".gemini"
+GEMINI_ENV_PATH = GEMINI_CONFIG_DIR / ".env"
+GEMINI_BACKUP_PATH = APP_DIR / "gemini-env.backup"
+
+SPEC: ToolSpec = {
+    "binary": "gemini",
+    "package": "@google/gemini-cli",
+    "display": "Gemini CLI",
+    "config_path": GEMINI_ENV_PATH,
+    "backup_path": GEMINI_BACKUP_PATH,
+}
+
+MANAGED_KEYS: list[str] = [
+    "GEMINI_MODEL",
+    "GOOGLE_GEMINI_BASE_URL",
+    "GEMINI_API_KEY_AUTH_MECHANISM",
+    "GEMINI_API_KEY",
+]
+
+
+def render_env_overlay(workspace: str, model: str, token: str) -> dict[str, str]:
+    return {
+        "GEMINI_MODEL": model,
+        "GOOGLE_GEMINI_BASE_URL": build_tool_base_url("gemini", workspace),
+        "GEMINI_API_KEY_AUTH_MECHANISM": "bearer",
+        "GEMINI_API_KEY": token,
+    }
+
+
+def build_runtime_env(workspace: str, model: str, token: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env["GEMINI_MODEL"] = model
+    env["GOOGLE_GEMINI_BASE_URL"] = build_tool_base_url("gemini", workspace)
+    env["GEMINI_API_KEY_AUTH_MECHANISM"] = "bearer"
+    env["GEMINI_API_KEY"] = token
+    return env
+
+
+def write_tool_config(
+    state: dict,
+    model: str,
+    token: str | None = None,
+) -> tuple[dict, str]:
+    backup_existing_file(GEMINI_ENV_PATH, GEMINI_BACKUP_PATH)
+    if token is None:
+        token = get_databricks_token(state["workspace"])
+    overlay = render_env_overlay(state["workspace"], model, token)
+    existing = parse_dotenv(GEMINI_ENV_PATH)
+    existing.update(overlay)
+    write_dotenv(GEMINI_ENV_PATH, existing)
+    state = mark_tool_managed(state, "gemini", MANAGED_KEYS)
+    save_state(state)
+    return state, token
+
+
+def default_model(state: dict) -> str | None:
+    gemini_models = state.get("gemini_models") or []
+    return gemini_models[0] if gemini_models else None
+
+
+def _refresh_token_once(state: dict) -> str:
+    model = default_model(state)
+    if not model:
+        raise RuntimeError("No Gemini model is configured.")
+    _, token = write_tool_config(state, model)
+    return token
+
+
+def _refresh_forever(state: dict, stop_event: threading.Event) -> None:
+    while not stop_event.wait(TOKEN_REFRESH_INTERVAL_SECONDS):
+        try:
+            _refresh_token_once(state)
+        except RuntimeError:
+            continue
+
+
+def launch(state: dict, tool_args: list[str]) -> None:
+    token = _refresh_token_once(state)
+    model = default_model(state)
+    if not model:
+        raise RuntimeError("No Gemini model is configured.")
+    env = build_runtime_env(state["workspace"], model, token)
+
+    stop_event = threading.Event()
+    refresher = threading.Thread(
+        target=_refresh_forever,
+        args=(state, stop_event),
+        daemon=True,
+    )
+    refresher.start()
+
+    proc = subprocess.Popen([SPEC["binary"], *tool_args], env=env)
+    try:
+        returncode = proc.wait()
+    except KeyboardInterrupt:
+        proc.send_signal(signal.SIGINT)
+        returncode = proc.wait()
+    finally:
+        stop_event.set()
+        refresher.join(timeout=1)
+
+    raise SystemExit(returncode)
+
+
+def validate_cmd(binary: str) -> list[str]:
+    return [binary, "-p", "say hi in 5 words or less"]

--- a/src/coding_tool_gateway/agents/opencode.py
+++ b/src/coding_tool_gateway/agents/opencode.py
@@ -1,0 +1,166 @@
+"""OpenCode agent: writes opencode.json with two Databricks-backed providers."""
+
+from __future__ import annotations
+
+import signal
+import subprocess
+import threading
+from pathlib import Path
+
+from coding_tool_gateway.config_io import (
+    APP_DIR,
+    ToolSpec,
+    backup_existing_file,
+    deep_merge_dict,
+    read_json_safe,
+    write_json_file,
+)
+from coding_tool_gateway.databricks import (
+    TOKEN_REFRESH_INTERVAL_SECONDS,
+    build_opencode_base_urls,
+    get_databricks_token,
+)
+from coding_tool_gateway.state import mark_tool_managed, save_state
+
+OPENCODE_CONFIG_DIR = Path.home() / ".config" / "opencode"
+OPENCODE_CONFIG_PATH = OPENCODE_CONFIG_DIR / "opencode.json"
+OPENCODE_BACKUP_PATH = APP_DIR / "opencode-config.backup.json"
+
+SPEC: ToolSpec = {
+    "binary": "opencode",
+    "package": "opencode-ai",
+    "display": "OpenCode",
+    "config_path": OPENCODE_CONFIG_PATH,
+    "backup_path": OPENCODE_BACKUP_PATH,
+}
+
+PROVIDER_KEYS: list[list[str]] = [
+    ["provider", "databricks-anthropic"],
+    ["provider", "databricks-google"],
+]
+
+
+def render_overlay(
+    model: str,
+    token: str,
+    opencode_base_urls: dict[str, str],
+    opencode_models: dict[str, list[str]],
+) -> tuple[dict, list[list[str]]]:
+    """Return (overlay, managed_key_paths) for opencode.json."""
+    auth_headers = {"Authorization": f"Bearer {token}"}
+
+    anthropic_models = opencode_models.get("anthropic") or []
+    gemini_models = opencode_models.get("gemini") or []
+
+    providers: dict = {}
+    keys: list[list[str]] = [["model"]]
+    if anthropic_models:
+        providers["databricks-anthropic"] = {
+            "npm": "@ai-sdk/anthropic",
+            "options": {
+                "baseURL": opencode_base_urls["anthropic"],
+                "apiKey": token,
+                "headers": auth_headers,
+            },
+            "models": {m: {} for m in anthropic_models},
+        }
+        keys.append(["provider", "databricks-anthropic"])
+    if gemini_models:
+        providers["databricks-google"] = {
+            "npm": "@ai-sdk/google",
+            "options": {
+                "baseURL": opencode_base_urls["gemini"],
+                "apiKey": token,
+                "headers": auth_headers,
+            },
+            "models": {m: {} for m in gemini_models},
+        }
+        keys.append(["provider", "databricks-google"])
+
+    overlay: dict = {"model": model}
+    if providers:
+        overlay["provider"] = providers
+    return overlay, keys
+
+
+def write_tool_config(
+    state: dict,
+    model: str,
+    token: str | None = None,
+) -> tuple[dict, str]:
+    backup_existing_file(OPENCODE_CONFIG_PATH, OPENCODE_BACKUP_PATH)
+    if token is None:
+        token = get_databricks_token(state["workspace"])
+    opencode_base_urls = state.get("base_urls", {}).get("opencode") or build_opencode_base_urls(
+        state["workspace"]
+    )
+    overlay, managed_keys = render_overlay(
+        model,
+        token,
+        opencode_base_urls,
+        state.get("opencode_models") or {},
+    )
+    existing = read_json_safe(OPENCODE_CONFIG_PATH)
+    providers = existing.get("provider")
+    if isinstance(providers, dict):
+        for stale in ("databricks-anthropic", "databricks-google"):
+            providers.pop(stale, None)
+    merged = deep_merge_dict(existing, overlay)
+    write_json_file(OPENCODE_CONFIG_PATH, merged)
+    state = mark_tool_managed(state, "opencode", managed_keys)
+    save_state(state)
+    return state, token
+
+
+def default_model(state: dict) -> str | None:
+    opencode_models = state.get("opencode_models") or {}
+    anthropic = opencode_models.get("anthropic") or []
+    if anthropic:
+        return anthropic[0]
+    gemini = opencode_models.get("gemini") or []
+    return gemini[0] if gemini else None
+
+
+def _refresh_token_once(state: dict) -> str:
+    model = default_model(state)
+    if not model:
+        raise RuntimeError("No OpenCode model is configured.")
+    _, token = write_tool_config(state, model)
+    return token
+
+
+def _refresh_forever(state: dict, stop_event: threading.Event) -> None:
+    while not stop_event.wait(TOKEN_REFRESH_INTERVAL_SECONDS):
+        try:
+            _refresh_token_once(state)
+        except RuntimeError:
+            continue
+
+
+def launch(state: dict, tool_args: list[str]) -> None:
+    """Launch opencode with background token refresh (same pattern as Gemini)."""
+    _refresh_token_once(state)
+
+    stop_event = threading.Event()
+    refresher = threading.Thread(
+        target=_refresh_forever,
+        args=(state, stop_event),
+        daemon=True,
+    )
+    refresher.start()
+
+    proc = subprocess.Popen([SPEC["binary"], *tool_args])
+    try:
+        returncode = proc.wait()
+    except KeyboardInterrupt:
+        proc.send_signal(signal.SIGINT)
+        returncode = proc.wait()
+    finally:
+        stop_event.set()
+        refresher.join(timeout=1)
+
+    raise SystemExit(returncode)
+
+
+def validate_cmd(binary: str) -> list[str]:
+    return [binary, "run", "say hi in 5 words or less"]

--- a/src/coding_tool_gateway/bootstrap.py
+++ b/src/coding_tool_gateway/bootstrap.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from coding_tool_gateway.cli import TOOL_SPECS, ensure_bootstrap_dependencies, print_err
+from coding_tool_gateway.agents import TOOL_SPECS, ensure_bootstrap_dependencies
+from coding_tool_gateway.ui import print_err
 
 
 def main() -> int:

--- a/src/coding_tool_gateway/cli.py
+++ b/src/coding_tool_gateway/cli.py
@@ -3,2032 +3,130 @@
 
 from __future__ import annotations
 
-import json
-import logging
-import os
-import platform
-import shutil
-import signal
-import subprocess
-import sys
-import itertools
-import threading
-import time
-import textwrap
-from contextlib import contextmanager
-from datetime import date, datetime, timedelta
-from pathlib import Path
 from typing import Annotated
-from urllib import error as urllib_error
-from urllib import request as urllib_request
-from urllib.parse import urlparse
 
-import questionary
-import tomlkit
 import typer
-from rich.console import Console
 from rich.panel import Panel
 
-
-APP_DIR = Path.home() / ".coding-gateway"
-STATE_PATH = APP_DIR / "state.json"
-STATE_VERSION = 2
-
-CODEX_CONFIG_DIR = Path.home() / ".codex"
-CODEX_CONFIG_PATH = CODEX_CONFIG_DIR / "config.toml"
-CLAUDE_CONFIG_DIR = Path.home() / ".claude"
-CLAUDE_SETTINGS_PATH = CLAUDE_CONFIG_DIR / "settings.json"
-GEMINI_CONFIG_DIR = Path.home() / ".gemini"
-GEMINI_ENV_PATH = GEMINI_CONFIG_DIR / ".env"
-
-CODEX_BACKUP_PATH = APP_DIR / "codex-config.backup.toml"
-CLAUDE_BACKUP_PATH = APP_DIR / "claude-settings.backup.json"
-GEMINI_BACKUP_PATH = APP_DIR / "gemini-env.backup"
-OPENCODE_CONFIG_DIR = Path.home() / ".config" / "opencode"
-OPENCODE_CONFIG_PATH = OPENCODE_CONFIG_DIR / "opencode.json"
-OPENCODE_BACKUP_PATH = APP_DIR / "opencode-config.backup.json"
-
-UNIX_DATABRICKS_INSTALL_URL = (
-    "https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh"
+from coding_tool_gateway.agents import (
+    DEFAULT_TOOL,
+    TOOL_SPECS,
+    configure_all_tools,
+    configure_tool,
+    default_model_for_tool,
+    ensure_bootstrap_dependencies,
+    ensure_provider_state,
+    install_tool_binary,
+    normalize_tool,
+    resolve_launch_model,
+    validate_all_tools,
 )
-WINDOWS_DATABRICKS_INSTALL_URL = (
-    "https://raw.githubusercontent.com/databricks/setup-cli/main/install.ps1"
+from coding_tool_gateway.agents import (
+    launch as launch_agent,
 )
-AI_GATEWAY_V2_DOCS_URL = "https://docs.databricks.com/aws/en/ai-gateway/overview-beta"
-TOKEN_REFRESH_INTERVAL_SECONDS = 1800
-SCRUBBED_DATABRICKS_ENV_VARS = (
-    "DATABRICKS_TOKEN",
-    "DATABRICKS_CLIENT_ID",
-    "DATABRICKS_CLIENT_SECRET",
-    "DATABRICKS_USERNAME",
-    "DATABRICKS_PASSWORD",
-    "DATABRICKS_AUTH_TYPE",
+from coding_tool_gateway.config_io import restore_file, set_dry_run
+from coding_tool_gateway.databricks import (
+    build_shared_base_urls,
+    ensure_ai_gateway_v2,
+    fetch_ai_gateway_claude_models,
+    fetch_codex_models,
+    fetch_gemini_models,
+    get_databricks_profiles,
+    get_databricks_token,
+    install_databricks_cli,
+    normalize_workspace_url,
+    run_databricks_login,
 )
-
-TOOL_SPECS = {
-    "codex": {
-        "binary": "codex",
-        "package": "@openai/codex",
-        "display": "Codex",
-        "config_path": CODEX_CONFIG_PATH,
-        "backup_path": CODEX_BACKUP_PATH,
-    },
-    "claude": {
-        "binary": "claude",
-        "package": "@anthropic-ai/claude-code",
-        "display": "Claude Code",
-        "config_path": CLAUDE_SETTINGS_PATH,
-        "backup_path": CLAUDE_BACKUP_PATH,
-    },
-    "gemini": {
-        "binary": "gemini",
-        "package": "@google/gemini-cli",
-        "display": "Gemini CLI",
-        "config_path": GEMINI_ENV_PATH,
-        "backup_path": GEMINI_BACKUP_PATH,
-    },
-    "opencode": {
-        "binary": "opencode",
-        "package": "opencode-ai",
-        "display": "OpenCode",
-        "config_path": OPENCODE_CONFIG_PATH,
-        "backup_path": OPENCODE_BACKUP_PATH,
-    },
-}
-TOOL_ALIASES = {
-    "codex": "codex",
-    "claude": "claude",
-    "claude-code": "claude",
-    "gemini": "gemini",
-    "gemini-cli": "gemini",
-    "opencode": "opencode",
-}
-DEFAULT_TOOL = "codex"
-USAGE_BREAKDOWN_DAYS = 7
-USAGE_SUMMARY_DAYS = 30
-BUNDLE_VERSION = 1
-
-_dry_run = False
-
-
-console = Console(highlight=False)
-err_console = Console(stderr=True, highlight=False)
-
-
-def print_section(title: str) -> None:
-    console.print()
-    console.print(Panel(title, style="bold blue", expand=False))
-
-
-def print_heading(text: str) -> None:
-    console.print()
-    console.print(f"[bold]{text}[/bold]")
-
-
-def print_kv(key: str, val: str) -> None:
-    console.print(f"  [bold]{key}:[/bold] [cyan]{val}[/cyan]")
-
-
-def print_note(text: str) -> None:
-    console.print(f"[dim]•[/dim] {text}")
-
-
-def print_success(message: str) -> None:
-    console.print(f"[bold green]✔[/bold green] {message}")
-
-
-def print_warning(message: str) -> None:
-    console.print(f"[bold yellow]![/bold yellow] {message}")
-
-
-def print_err(message: str) -> None:
-    err_console.print(f"[bold red]ERROR[/bold red] {message}")
-
-
-def heading(text: str) -> str:
-    return f"[bold blue]{text}[/bold blue]"
-
-
-def label(text: str) -> str:
-    return f"[bold]{text}[/bold]"
-
-
-def value(text: str) -> str:
-    return f"[cyan]{text}[/cyan]"
-
-
-def muted(text: str) -> str:
-    return f"[dim]{text}[/dim]"
-
-
-def status_badge(text: str, kind: str) -> str:
-    color = {"ok": "green", "warn": "yellow", "error": "red", "info": "blue"}.get(kind, "bold")
-    return f"[bold {color}]{text}[/bold {color}]"
-
-
-@contextmanager
-def spinner(message: str):
-    if not sys.stdout.isatty():
-        yield
-        return
-
-    stop_event = threading.Event()
-
-    def spin() -> None:
-        for frame in itertools.cycle("|/-\\"):
-            if stop_event.is_set():
-                break
-            sys.stdout.write(f"\r\033[2m{frame}\033[0m {message}")
-            sys.stdout.flush()
-            time.sleep(0.1)
-        sys.stdout.write("\r" + " " * (len(message) + 4) + "\r")
-        sys.stdout.flush()
-
-    thread = threading.Thread(target=spin, daemon=True)
-    thread.start()
-    try:
-        yield
-    finally:
-        stop_event.set()
-        thread.join(timeout=1)
-
-
-def run(
-    args: list[str],
-    *,
-    check: bool = True,
-    capture_output: bool = False,
-    text: bool = False,
-    env: dict[str, str] | None = None,
-    timeout: int | None = None,
-) -> subprocess.CompletedProcess[str] | subprocess.CompletedProcess[bytes]:
-    return subprocess.run(
-        args,
-        check=check,
-        capture_output=capture_output,
-        text=text,
-        env=env,
-        timeout=timeout,
-    )
-
-
-def build_databricks_cli_env(workspace: str) -> dict[str, str]:
-    env = os.environ.copy()
-    env["DATABRICKS_HOST"] = workspace
-    for key in SCRUBBED_DATABRICKS_ENV_VARS:
-        env.pop(key, None)
-    return env
-
-
-def workspace_hostname(workspace: str) -> str:
-    parsed = urlparse(normalize_workspace_url(workspace))
-    if not parsed.hostname:
-        raise RuntimeError(f"Unable to derive hostname from workspace URL: {workspace}")
-    return parsed.hostname
-
-
-def normalize_workspace_url(workspace: str) -> str:
-    workspace = workspace.strip()
-    if not workspace:
-        raise ValueError("Workspace URL cannot be empty.")
-    if not workspace.startswith(("http://", "https://")):
-        workspace = f"https://{workspace}"
-    return workspace.rstrip("/")
-
-
-def normalize_tool(tool: str) -> str:
-    normalized = TOOL_ALIASES.get(tool.strip().lower())
-    if not normalized:
-        raise RuntimeError(
-            f"Unsupported tool '{tool}'. Use one of: codex, claude, gemini, opencode."
-        )
-    return normalized
-
-
-def load_full_state() -> dict:
-    """Load the entire state file. Returns empty structure if missing or wrong version."""
-    if not STATE_PATH.exists():
-        return {"state_version": STATE_VERSION, "current_workspace": None, "workspaces": {}}
-    try:
-        data = json.loads(STATE_PATH.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {"state_version": STATE_VERSION, "current_workspace": None, "workspaces": {}}
-    if not isinstance(data, dict) or data.get("state_version") != STATE_VERSION:
-        return {"state_version": STATE_VERSION, "current_workspace": None, "workspaces": {}}
-    return data
-
-
-def load_state() -> dict:
-    """Load the current workspace's state as a flat dict."""
-    full = load_full_state()
-    workspace = full.get("current_workspace")
-    if not workspace:
-        return {}
-    ws_state = full.get("workspaces", {}).get(workspace, {})
-    ws_state["workspace"] = workspace
-    return hydrate_state(ws_state)
-
-
-def save_state(state: dict) -> None:
-    """Save workspace state back into the per-workspace structure."""
-    if _dry_run:
-        return
-    full = load_full_state()
-    workspace = state.get("workspace") or full.get("current_workspace")
-    if workspace:
-        full["current_workspace"] = workspace
-        full["workspaces"][workspace] = hydrate_state(state)
-    try:
-        APP_DIR.mkdir(parents=True, exist_ok=True)
-        STATE_PATH.write_text(json.dumps(full, indent=2), encoding="utf-8")
-    except OSError as exc:
-        raise RuntimeError(f"Failed to write state file: {STATE_PATH}") from exc
-
-
-
-def hydrate_state(state: dict) -> dict:
-    if not isinstance(state, dict):
-        return {}
-
-    hydrated = dict(state)
-    managed_configs = hydrated.get("managed_configs")
-    if not isinstance(managed_configs, dict):
-        managed_configs = {}
-    normalized: dict[str, dict] = {}
-    for tool, entry in managed_configs.items():
-        if isinstance(entry, dict):
-            keys = entry.get("keys") if isinstance(entry.get("keys"), list) else []
-            normalized[tool] = {"keys": keys}
-        elif entry:
-            normalized[tool] = {"keys": []}
-    hydrated["managed_configs"] = normalized
-
-    workspace = hydrated.get("workspace")
-    if workspace:
-        use_ai_gateway_v2 = bool(hydrated.get("use_ai_gateway_v2"))
-        hydrated["base_urls"] = build_shared_base_urls(workspace, use_ai_gateway_v2)
-    else:
-        hydrated["base_urls"] = {}
-
-    return hydrated
-
-
-def clear_state() -> None:
-    """Remove the current workspace entry from state."""
-    full = load_full_state()
-    workspace = full.get("current_workspace")
-    if workspace:
-        full.get("workspaces", {}).pop(workspace, None)
-        full["current_workspace"] = None
-    try:
-        APP_DIR.mkdir(parents=True, exist_ok=True)
-        STATE_PATH.write_text(json.dumps(full, indent=2), encoding="utf-8")
-    except OSError as exc:
-        raise RuntimeError(f"Failed to clear state file: {STATE_PATH}") from exc
-
-
-def ensure_parent_dir(path: Path) -> None:
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        raise RuntimeError(f"Failed to create directory for {path}") from exc
-
-
-def backup_existing_file(config_path: Path, backup_path: Path) -> bool:
-    if _dry_run:
-        return False
-    try:
-        APP_DIR.mkdir(parents=True, exist_ok=True)
-        if backup_path.exists():
-            return True
-        if not config_path.exists():
-            return False
-        backup_path.write_text(config_path.read_text(encoding="utf-8"), encoding="utf-8")
-        return True
-    except OSError as exc:
-        raise RuntimeError(f"Failed to back up config from {config_path}") from exc
-
-
-def restore_file(config_path: Path, backup_path: Path, managed: bool) -> bool:
-    try:
-        if backup_path.exists():
-            ensure_parent_dir(config_path)
-            config_path.write_text(backup_path.read_text(encoding="utf-8"), encoding="utf-8")
-            backup_path.unlink()
-            return True
-        if managed and config_path.exists():
-            config_path.unlink()
-            return True
-        return False
-    except OSError as exc:
-        raise RuntimeError(f"Failed to restore config at {config_path}") from exc
-
-
-def write_text_file(path: Path, content: str) -> None:
-    if _dry_run:
-        console.print(f"\n[bold]\\[dry run] {path}[/bold]\n{content}")
-        return
-    ensure_parent_dir(path)
-    try:
-        path.write_text(content, encoding="utf-8")
-    except OSError as exc:
-        raise RuntimeError(f"Failed to write config file: {path}") from exc
-
-
-def write_json_file(path: Path, payload: dict) -> None:
-    content = json.dumps(payload, indent=2) + "\n"
-    if _dry_run:
-        console.print(f"\n[bold]\\[dry run] {path}[/bold]\n{content}")
-        return
-    ensure_parent_dir(path)
-    try:
-        path.write_text(content, encoding="utf-8")
-    except OSError as exc:
-        raise RuntimeError(f"Failed to write config file: {path}") from exc
-
-
-def deep_merge_dict(base: dict, overlay: dict) -> dict:
-    """Recursively merge overlay into base; overlay wins for conflicting leaves.
-
-    Mutates and returns base. Nested dicts are merged; everything else is replaced.
-    """
-    for key, value in overlay.items():
-        if isinstance(value, dict) and isinstance(base.get(key), dict):
-            deep_merge_dict(base[key], value)
-        else:
-            base[key] = value
-    return base
-
-
-def read_json_safe(path: Path) -> dict:
-    if not path.exists():
-        return {}
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return {}
-    return data if isinstance(data, dict) else {}
-
-
-def read_toml_safe(path: Path) -> tomlkit.TOMLDocument:
-    if not path.exists():
-        return tomlkit.document()
-    try:
-        return tomlkit.parse(path.read_text(encoding="utf-8"))
-    except (OSError, tomlkit.exceptions.TOMLKitError):
-        return tomlkit.document()
-
-
-def write_toml_file(path: Path, doc: tomlkit.TOMLDocument) -> None:
-    content = tomlkit.dumps(doc)
-    if _dry_run:
-        console.print(f"\n[bold]\\[dry run] {path}[/bold]\n{content}")
-        return
-    ensure_parent_dir(path)
-    try:
-        path.write_text(content, encoding="utf-8")
-    except OSError as exc:
-        raise RuntimeError(f"Failed to write config file: {path}") from exc
-
-
-def parse_dotenv(path: Path) -> dict[str, str]:
-    """Parse a simple KEY=VALUE / KEY=\"VALUE\" .env file, preserving insertion order.
-
-    Comments and blank lines are dropped on round-trip. Lines that don't look like
-    KEY=... are skipped.
-    """
-    if not path.exists():
-        return {}
-    env: dict[str, str] = {}
-    try:
-        text = path.read_text(encoding="utf-8")
-    except OSError:
-        return {}
-    for raw_line in text.splitlines():
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if "=" not in line:
-            continue
-        key, _, value = line.partition("=")
-        key = key.strip()
-        if not key:
-            continue
-        value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
-            value = value[1:-1]
-        env[key] = value
-    return env
-
-
-def write_dotenv(path: Path, env: dict[str, str]) -> None:
-    content = "".join(f'{key}="{value}"\n' for key, value in env.items())
-    write_text_file(path, content)
-
-
-def install_databricks_cli() -> None:
-    if shutil.which("databricks"):
-        return
-
-    system = platform.system()
-    print_section("Bootstrap")
-    print_warning("`databricks` was not found. Installing Databricks CLI...")
-
-    try:
-        if system == "Windows":
-            run(
-                [
-                    "powershell",
-                    "-Command",
-                    f"irm {WINDOWS_DATABRICKS_INSTALL_URL} | iex",
-                ],
-                timeout=240,
-            )
-        elif shutil.which("curl"):
-            run(
-                ["sh", "-c", f"curl -fsSL {UNIX_DATABRICKS_INSTALL_URL} | sh"],
-                timeout=240,
-            )
-        elif shutil.which("wget"):
-            run(
-                ["sh", "-c", f"wget -qO- {UNIX_DATABRICKS_INSTALL_URL} | sh"],
-                timeout=240,
-            )
-        else:
-            raise RuntimeError("Neither curl nor wget is available.")
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, RuntimeError) as exc:
-        raise RuntimeError("Failed to install Databricks CLI automatically.") from exc
-
-    if not shutil.which("databricks"):
-        raise RuntimeError(
-            "Databricks CLI install completed, but `databricks` is still not on PATH."
-        )
-
-
-def install_tool_binary(tool: str) -> None:
-    spec = TOOL_SPECS[tool]
-    binary = spec["binary"]
-    package = spec["package"]
-
-    if shutil.which(binary):
-        return
-
-    if not shutil.which("npm"):
-        raise RuntimeError(
-            f"`{binary}` is not installed and npm is not available to install it."
-        )
-
-    print_section("Bootstrap")
-    print_warning(f"`{binary}` was not found. Installing {spec['display']}...")
-    try:
-        run(["npm", "install", "-g", package], timeout=300)
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-        raise RuntimeError(f"Failed to install {spec['display']} automatically.") from exc
-
-    if not shutil.which(binary):
-        raise RuntimeError(
-            f"{spec['display']} install completed, but `{binary}` is still not on PATH."
-        )
-
-
-def ensure_bootstrap_dependencies(tool: str) -> None:
-    install_databricks_cli()
-    install_tool_binary(tool)
-
-
-def has_valid_databricks_auth(workspace: str) -> bool:
-    try:
-        env = build_databricks_cli_env(workspace)
-        result = run(
-            ["databricks", "auth", "token", "--host", workspace, "--output", "json"],
-            check=False,
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=15,
-        )
-        if result.returncode != 0:
-            return False
-        data = json.loads(result.stdout or "{}")
-        return bool(data.get("access_token"))
-    except (json.JSONDecodeError, OSError, subprocess.TimeoutExpired):
-        return False
-
-
-def find_profile_name_for_host(workspace: str) -> str | None:
-    """Find the Databricks CLI profile name matching a workspace URL."""
-    normalized = workspace.rstrip("/")
-    for host, name in get_databricks_profiles():
-        if host == normalized:
-            return name
-    return None
-
-
-def run_databricks_login(workspace: str) -> None:
-    """Run databricks auth login unconditionally."""
-    print_section("Databricks Login")
-    print_kv("Workspace", workspace)
-    print_note("A browser may open for `databricks auth login`.")
-    try:
-        cmd = ["databricks", "auth", "login", "--host", workspace]
-        profile_name = find_profile_name_for_host(workspace)
-        if profile_name:
-            cmd += ["--profile", profile_name]
-        run(cmd, env=build_databricks_cli_env(workspace), timeout=300)
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError("`databricks auth login` failed.") from exc
-    except subprocess.TimeoutExpired as exc:
-        raise RuntimeError("`databricks auth login` timed out.") from exc
-    print_success("Databricks authentication complete")
-
-
-def ensure_databricks_auth(workspace: str) -> None:
-    """Check auth and login only if needed (used by launch path)."""
-    with spinner("Checking Databricks auth..."):
-        auth_is_valid = has_valid_databricks_auth(workspace)
-    if auth_is_valid:
-        print_success(f"Databricks auth already available for {workspace}")
-        return
-    run_databricks_login(workspace)
-
-
-def fetch_ai_gateway_claude_models(workspace: str, token: str) -> dict[str, str]:
-    hostname = workspace_hostname(workspace)
-    request = urllib_request.Request(
-        f"https://{hostname}/ai-gateway/anthropic/v1/models",
-        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
-    )
-    try:
-        with urllib_request.urlopen(request, timeout=10) as response:
-            data = json.loads(response.read().decode("utf-8"))
-    except (urllib_error.URLError, urllib_error.HTTPError, json.JSONDecodeError):
-        return {}
-
-    models = [
-        m["id"] for m in data.get("data", [])
-        if isinstance(m.get("id"), str) and not m["id"].endswith("-anthropic")
-    ]
-
-    result = {}
-    for family, key in [("opus", "opus"), ("sonnet", "sonnet"), ("haiku", "haiku")]:
-        candidates = sorted(
-            [m for m in models if f"databricks-claude-{family}-" in m],
-            reverse=True,
-        )
-        if candidates:
-            result[key] = candidates[0]
-    return result
-
-
-def fetch_gemini_models(workspace: str, token: str) -> list[str]:
-    """Return Gemini model names from serving-endpoints:foundation-models."""
-    hostname = workspace_hostname(workspace)
-    request = urllib_request.Request(
-        f"https://{hostname}/api/2.0/serving-endpoints:foundation-models",
-        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
-    )
-    try:
-        with urllib_request.urlopen(request, timeout=10) as response:
-            data = json.loads(response.read().decode("utf-8"))
-    except (urllib_error.URLError, urllib_error.HTTPError, json.JSONDecodeError):
-        return []
-
-    gemini: list[str] = []
-    for ep in data.get("endpoints", []):
-        name = ep.get("name", "")
-        entities = ep.get("config", {}).get("served_entities", [])
-        api_types: set[str] = set()
-        for se in entities:
-            fm = se.get("foundation_model", {})
-            if fm.get("ai_gateway_v2_supported") is True:
-                api_types.update(fm.get("api_types", []))
-        if "gemini/v1/generateContent" in api_types:
-            gemini.append(name)
-
-    return sorted(gemini)
-
-
-def fetch_codex_models(workspace: str, token: str) -> list[str]:
-    """Return Codex/OpenAI model names from serving-endpoints:foundation-models."""
-    hostname = workspace_hostname(workspace)
-    request = urllib_request.Request(
-        f"https://{hostname}/api/2.0/serving-endpoints:foundation-models",
-        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
-    )
-    try:
-        with urllib_request.urlopen(request, timeout=10) as response:
-            data = json.loads(response.read().decode("utf-8"))
-    except (urllib_error.URLError, urllib_error.HTTPError, json.JSONDecodeError):
-        return []
-
-    codex: list[str] = []
-    for ep in data.get("endpoints", []):
-        name = ep.get("name", "")
-        entities = ep.get("config", {}).get("served_entities", [])
-        api_types: set[str] = set()
-        for se in entities:
-            fm = se.get("foundation_model", {})
-            if fm.get("ai_gateway_v2_supported") is True:
-                api_types.update(fm.get("api_types", []))
-        if "openai/v1/responses" in api_types:
-            codex.append(name)
-
-    return sorted(codex)
-
-
-def detect_ai_gateway_v2(workspace: str, token: str) -> bool:
-    hostname = workspace_hostname(workspace)
-    request = urllib_request.Request(
-        f"https://{hostname}/ai-gateway/anthropic/v1/messages",
-        method="HEAD",
-        headers={"Authorization": f"Bearer {token}"},
-    )
-    try:
-        urllib_request.urlopen(request, timeout=10)
-        return True
-    except urllib_error.HTTPError as exc:
-        return exc.code != 404
-    except urllib_error.URLError:
-        return False
-
-
-def get_databricks_token(workspace: str) -> str:
-    try:
-        env = build_databricks_cli_env(workspace)
-        result = run(
-            ["databricks", "auth", "token", "--host", workspace, "--output", "json"],
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=15,
-        )
-        data = json.loads(result.stdout or "{}")
-        token = data.get("access_token")
-        if not token:
-            raise RuntimeError("Databricks CLI returned no access token.")
-        return token
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
-        raise RuntimeError("Failed to retrieve Databricks access token.") from exc
-
-
-def discover_sql_warehouse_http_path(
-    workspace: str,
-    token: str,
-    *,
-    quiet: bool = False,
-) -> str:
-    hostname = workspace_hostname(workspace)
-    request = urllib_request.Request(
-        f"https://{hostname}/api/2.0/sql/warehouses",
-        headers={
-            "Authorization": f"Bearer {token}",
-            "Accept": "application/json",
-        },
-    )
-
-    try:
-        with urllib_request.urlopen(request, timeout=20) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-    except urllib_error.HTTPError as exc:
-        body = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
-        detail = body.strip() or f"HTTP {exc.code}"
-        raise RuntimeError(f"Failed to list SQL warehouses: {detail}") from exc
-    except urllib_error.URLError as exc:
-        raise RuntimeError(f"Could not reach workspace hostname {hostname}: {exc.reason}") from exc
-    except json.JSONDecodeError as exc:
-        raise RuntimeError("Databricks warehouse discovery returned invalid JSON.") from exc
-
-    warehouses = payload.get("warehouses")
-    if not isinstance(warehouses, list) or not warehouses:
-        raise RuntimeError(
-            "No SQL warehouses found in this workspace. Create one or pass `--http-path`."
-        )
-
-    running = [item for item in warehouses if isinstance(item, dict) and item.get("state") == "RUNNING"]
-    chosen = running[0] if running else next(
-        (item for item in warehouses if isinstance(item, dict) and item.get("id")),
-        None,
-    )
-    if not chosen:
-        raise RuntimeError("No usable SQL warehouse was returned by Databricks.")
-
-    warehouse_id = chosen.get("id")
-    if not isinstance(warehouse_id, str) or not warehouse_id.strip():
-        raise RuntimeError("Databricks returned a warehouse without an ID.")
-
-    warehouse_name = chosen.get("name")
-    warehouse_state = chosen.get("state", "UNKNOWN")
-    label_value = warehouse_name if isinstance(warehouse_name, str) and warehouse_name else warehouse_id
-    if not quiet:
-        print_note(f"Using SQL warehouse `{label_value}` ({warehouse_state}).")
-    return f"/sql/1.0/warehouses/{warehouse_id}"
-
-
-def run_usage_query(
-    workspace: str,
-    http_path: str,
-    token: str,
-    query: str,
-) -> tuple[list[str], list[tuple]]:
-    try:
-        logging.getLogger("databricks.sql").setLevel(logging.ERROR)
-        from databricks import sql
-    except ImportError as exc:
-        raise RuntimeError(
-            "`databricks-sql-connector` is not installed. Install it with `pip install databricks-sql-connector`."
-        ) from exc
-
-    try:
-        with sql.connect(
-            server_hostname=workspace_hostname(workspace),
-            http_path=http_path,
-            access_token=token,
-        ) as connection:
-            with connection.cursor() as cursor:
-                cursor.execute(query)
-                columns = [desc[0] for desc in (cursor.description or [])]
-                rows = cursor.fetchall()
-    except Exception as exc:
-        raise RuntimeError(f"Usage query failed: {exc}") from exc
-
-    return columns, rows
-
-
-def build_usage_report_query() -> str:
-    return f"""
-SELECT
-  current_user() AS requester_name,
-  CASE
-    WHEN lower(user_agent) LIKE '%codex%' THEN 'codex'
-    WHEN lower(user_agent) LIKE '%claude%' THEN 'claude'
-    WHEN lower(user_agent) LIKE '%gemini%' THEN 'gemini'
-    WHEN lower(user_agent) LIKE '%opencode%' THEN 'opencode'
-    ELSE 'other'
-  END AS tool,
-  date(event_time) AS usage_day,
-  SUM(COALESCE(total_tokens, 0)) AS total_tokens_used,
-  COUNT(DISTINCT request_id) AS sessions,
-  MIN(event_time) AS first_event_time,
-  MAX(event_time) AS last_event_time,
-  CONCAT_WS(', ', SORT_ARRAY(COLLECT_SET(destination_model))) AS models
-FROM system.ai_gateway.usage
-WHERE event_time >= current_timestamp() - interval {USAGE_SUMMARY_DAYS} days
-  AND requester = current_user()
-  AND (
-    lower(user_agent) LIKE '%codex%'
-    OR lower(user_agent) LIKE '%claude%'
-    OR lower(user_agent) LIKE '%gemini%'
-    OR lower(user_agent) LIKE '%opencode%'
-  )
-GROUP BY 1, 2, 3
-ORDER BY usage_day DESC, tool ASC
-""".strip()
-
-
-def build_current_user_query() -> str:
-    return "SELECT current_user() AS requester_name"
-
-
-def parse_usage_rows(columns: list[str], rows: list[tuple]) -> list[dict[str, object]]:
-    return [dict(zip(columns, row)) for row in rows]
-
-
-def coerce_date(value_obj: object) -> date | None:
-    if isinstance(value_obj, date) and not isinstance(value_obj, datetime):
-        return value_obj
-    if isinstance(value_obj, datetime):
-        return value_obj.date()
-    if isinstance(value_obj, str):
-        try:
-            return datetime.fromisoformat(value_obj).date()
-        except ValueError:
-            return None
-    return None
-
-
-def coerce_datetime(value_obj: object) -> datetime | None:
-    if isinstance(value_obj, datetime):
-        return value_obj
-    if isinstance(value_obj, str):
-        candidate = value_obj.replace("Z", "+00:00")
-        try:
-            return datetime.fromisoformat(candidate)
-        except ValueError:
-            return None
-    return None
-
-
-def format_token_count(token_count: int) -> str:
-    value_float = float(token_count)
-    if token_count >= 1_000_000_000:
-        return f"{value_float / 1_000_000_000:.1f}B"
-    if token_count >= 1_000_000:
-        return f"{value_float / 1_000_000:.1f}M"
-    if token_count >= 1_000:
-        return f"{value_float / 1_000:.1f}K"
-    return str(token_count)
-
-
-def format_duration(duration_value: timedelta | None) -> str:
-    if not duration_value or duration_value.total_seconds() <= 0:
-        return "-"
-    total_minutes = duration_value.total_seconds() / 60
-    if total_minutes < 60:
-        return f"{int(round(total_minutes))}m"
-    total_hours = total_minutes / 60
-    if total_hours < 10:
-        return f"{total_hours:.1f}h"
-    if total_hours < 24:
-        return f"{round(total_hours):.0f}h"
-    return f"{total_hours / 24:.1f}d"
-
-
-def simplify_model_name(tool: str, model_name: str) -> str:
-    normalized = (model_name or "").strip()
-    if not normalized:
-        return "-"
-
-    prefix = "databricks-"
-    if normalized.startswith(prefix):
-        normalized = normalized[len(prefix):]
-
-    tool_prefixes = {
-        "claude": "claude-",
-        "gemini": "gemini-",
-        "codex": "gpt-",
-    }
-    tool_prefix = tool_prefixes.get(tool)
-    if tool_prefix and normalized.startswith(tool_prefix):
-        normalized = normalized[len(tool_prefix):]
-    return normalized
-
-
-def summarize_models(tool: str, raw_models: object) -> str:
-    if not isinstance(raw_models, str) or not raw_models.strip():
-        return "-"
-    parts = extract_model_names(tool, raw_models)
-    return ", ".join(parts) if parts else "-"
-
-
-def extract_model_names(tool: str, raw_models: object) -> list[str]:
-    if not isinstance(raw_models, str) or not raw_models.strip():
-        return []
-
-    unique_models: list[str] = []
-    for item in raw_models.split(","):
-        simplified = simplify_model_name(tool, item.strip())
-        if simplified != "-" and simplified not in unique_models:
-            unique_models.append(simplified)
-    return unique_models
-
-
-def render_box_table(headers: list[str], rows: list[list[str]], max_widths: list[int] | None = None) -> str:
-    wrapped_rows: list[list[list[str]]] = []
-    widths = [len(header) for header in headers]
-
-    for row in rows:
-        wrapped_row: list[list[str]] = []
-        for index, cell in enumerate(row):
-            raw_cell = cell if cell else "-"
-            width_limit = max_widths[index] if max_widths and index < len(max_widths) else None
-            if width_limit:
-                cell_lines = textwrap.wrap(raw_cell, width=width_limit) or ["-"]
-            else:
-                cell_lines = raw_cell.splitlines() or ["-"]
-            wrapped_row.append(cell_lines)
-            widths[index] = max(widths[index], max(len(line) for line in cell_lines))
-        wrapped_rows.append(wrapped_row)
-
-    top = "┏" + "┳".join("━" * (width + 2) for width in widths) + "┓"
-    header = "┃ " + " ┃ ".join(headers[index].ljust(widths[index]) for index in range(len(headers))) + " ┃"
-    middle = "┡" + "╇".join("━" * (width + 2) for width in widths) + "┩"
-    bottom = "└" + "┴".join("─" * (width + 2) for width in widths) + "┘"
-
-    body_lines: list[str] = []
-    for wrapped_row in wrapped_rows:
-        row_height = max(len(cell_lines) for cell_lines in wrapped_row)
-        for line_index in range(row_height):
-            body_lines.append(
-                "│ "
-                + " │ ".join(
-                    (
-                        wrapped_row[column_index][line_index]
-                        if line_index < len(wrapped_row[column_index])
-                        else ""
-                    ).ljust(widths[column_index])
-                    for column_index in range(len(headers))
-                )
-                + " │"
-            )
-
-    return "\n".join([top, header, middle, *body_lines, bottom])
-
-
-def empty_tool_day(tool: str, usage_day: date) -> dict[str, object]:
-    return {
-        "tool": tool,
-        "usage_day": usage_day,
-        "total_tokens_used": 0,
-        "sessions": 0,
-        "first_event_time": None,
-        "last_event_time": None,
-        "models": "-",
-    }
-
-
-def build_tool_breakdown_rows(records: list[dict[str, object]], tool: str) -> list[list[str]]:
-    today = date.today()
-    rows_by_day: dict[date, dict[str, object]] = {}
-    for record in records:
-        if record.get("tool") != tool:
-            continue
-        usage_day = coerce_date(record.get("usage_day"))
-        if usage_day:
-            rows_by_day[usage_day] = record
-
-    rendered_rows: list[list[str]] = []
-    for day_offset in range(USAGE_BREAKDOWN_DAYS):
-        usage_day = today - timedelta(days=day_offset)
-        record = rows_by_day.get(usage_day) or empty_tool_day(tool, usage_day)
-        first_event_time = coerce_datetime(record.get("first_event_time"))
-        last_event_time = coerce_datetime(record.get("last_event_time"))
-        duration = None
-        if first_event_time and last_event_time:
-            duration = last_event_time - first_event_time
-        token_total = int(record.get("total_tokens_used") or 0)
-        session_total = int(record.get("sessions") or 0)
-        rendered_rows.append(
-            [
-                usage_day.strftime("%m-%d"),
-                usage_day.strftime("%a"),
-                format_token_count(token_total) if token_total else "-",
-                str(session_total) if session_total else "-",
-                format_duration(duration),
-                summarize_models(tool, record.get("models")),
-            ]
-        )
-
-    return rendered_rows
-
-
-def find_requester_name(
-    workspace: str,
-    http_path: str,
-    token: str,
-    records: list[dict[str, object]],
-) -> str:
-    for record in records:
-        requester_name = record.get("requester_name")
-        if isinstance(requester_name, str) and requester_name.strip():
-            return requester_name.strip()
-
-    columns, rows = run_usage_query(workspace, http_path, token, build_current_user_query())
-    parsed_rows = parse_usage_rows(columns, rows)
-    if parsed_rows:
-        requester_name = parsed_rows[0].get("requester_name")
-        if isinstance(requester_name, str) and requester_name.strip():
-            return requester_name.strip()
-    return "current user"
-
-
-def render_usage_summary(
-    records: list[dict[str, object]],
-    requester_name: str,
-) -> str:
-    today = date.today()
-    week_start = today - timedelta(days=USAGE_BREAKDOWN_DAYS - 1)
-    month_start = today - timedelta(days=USAGE_SUMMARY_DAYS - 1)
-
-    daily_total = 0
-    weekly_total = 0
-    monthly_total = 0
-    active_tools_last_week: list[str] = []
-    weekly_model_tokens: dict[str, int] = {}
-    for record in records:
-        usage_day = coerce_date(record.get("usage_day"))
-        if not usage_day:
-            continue
-        token_total = int(record.get("total_tokens_used") or 0)
-        tool = record.get("tool")
-        if usage_day >= month_start:
-            monthly_total += token_total
-        if usage_day >= week_start:
-            weekly_total += token_total
-            if isinstance(tool, str) and tool in TOOL_SPECS and tool not in active_tools_last_week:
-                active_tools_last_week.append(tool)
-            if isinstance(tool, str):
-                for model_name in extract_model_names(tool, record.get("models")):
-                    weekly_model_tokens[model_name] = (
-                        weekly_model_tokens.get(model_name, 0) + token_total
-                    )
-        if usage_day == today:
-            daily_total += token_total
-
-    lines = [
-        heading(f"Usage Summary for {requester_name}"),
-        "",
-        "[bold green]✓[/bold green] Databricks AI Gateway usage",
-        f"{label('Today:')} {value(format_token_count(daily_total) + ' tokens')}",
-        f"{label('Last 7 days:')} {value(format_token_count(weekly_total) + ' tokens')}",
-        f"{label('Last 30 days:')} {value(format_token_count(monthly_total) + ' tokens')}",
-    ]
-    if active_tools_last_week:
-        tool_text = ", ".join(TOOL_SPECS[tool]["display"] for tool in active_tools_last_week)
-        lines.append(f"{label('Active tools:')} {value(tool_text)}")
-    if weekly_model_tokens:
-        top_models = sorted(
-            weekly_model_tokens.items(),
-            key=lambda item: (-item[1], item[0].lower()),
-        )[:3]
-        models_text = ", ".join(
-            f"{model_name} ({format_token_count(token_total)})"
-            for model_name, token_total in top_models
-        )
-        lines.append(f"{label('Top models this week:')} {value(models_text)}")
-    return "\n".join(lines)
-
-
-def build_auth_shell_command(workspace: str) -> str:
-    python_expr = "import json,sys; print(json.load(sys.stdin).get('access_token', ''))"
-    unset_prefix = " ".join(f"-u {key}" for key in SCRUBBED_DATABRICKS_ENV_VARS)
-    return (
-        f"env {unset_prefix} databricks auth token --host {workspace} --output json "
-        f'| python3 -c "{python_expr}"'
-    )
-
-
-def build_tool_base_url(
-    tool: str,
-    workspace: str,
-    use_ai_gateway_v2: bool,
-) -> str:
-    if tool == "codex":
-        return (
-            f"{workspace}/ai-gateway/codex/v1"
-            if use_ai_gateway_v2
-            else f"{workspace}/serving-endpoints/codex/v1"
-        )
-    if tool == "claude":
-        return (
-            f"{workspace}/ai-gateway/anthropic"
-            if use_ai_gateway_v2
-            else f"{workspace}/serving-endpoints/anthropic"
-        )
-    if tool == "gemini":
-        return (
-            f"{workspace}/ai-gateway/gemini"
-            if use_ai_gateway_v2
-            else f"{workspace}/serving-endpoints/gemini"
-        )
-    if tool == "opencode":
-        raise RuntimeError("OpenCode has multiple base URLs — use build_opencode_base_urls() instead.")
-    raise RuntimeError(f"Unsupported tool '{tool}'.")
-
-
-def build_opencode_base_urls(workspace: str, use_ai_gateway_v2: bool) -> dict[str, str]:
-    return {
-        "anthropic": build_tool_base_url("claude", workspace, use_ai_gateway_v2) + "/v1",
-        "gemini": build_tool_base_url("gemini", workspace, use_ai_gateway_v2) + "/v1beta",
-    }
-
-
-def build_shared_base_urls(
-    workspace: str,
-    use_ai_gateway_v2: bool,
-) -> dict[str, str | dict[str, str]]:
-    urls: dict[str, str | dict[str, str]] = {
-        tool: build_tool_base_url(tool, workspace, use_ai_gateway_v2)
-        for tool in TOOL_SPECS
-        if tool != "opencode"
-    }
-    urls["opencode"] = build_opencode_base_urls(workspace, use_ai_gateway_v2)
-    return urls
-
-
-
-
-def default_model_for_tool(tool: str, state: dict) -> str | None:
-    """Pick a sensible default model from the fetched model lists."""
-    if tool == "claude":
-        claude_models = state.get("claude_models") or {}
-        return claude_models.get("sonnet") or claude_models.get("opus") or claude_models.get("haiku")
-    elif tool == "opencode":
-        opencode_models = state.get("opencode_models") or {}
-        anthropic = opencode_models.get("anthropic") or []
-        if anthropic:
-            return anthropic[0]
-        gemini = opencode_models.get("gemini") or []
-        return gemini[0] if gemini else None
-    elif tool == "gemini":
-        gemini_models = state.get("gemini_models") or []
-        return gemini_models[0] if gemini_models else None
-    return None
-
-
-def resolve_launch_model(
-    tool: str,
-    state: dict,
-    explicit_model: str | None,
-) -> tuple[dict, str | None]:
-    if tool == "codex":
-        return state, None
-
-    model = explicit_model or default_model_for_tool(tool, state)
-    if not model:
-        raise RuntimeError(f"No models available for {tool}. Run `coding-gateway configure` to set up your workspace.")
-    return state, model
-
-
-CODEX_MANAGED_KEYS: list[list[str]] = [
-    ["profile"],
-    ["profiles", "default", "model_provider"],
-    ["model_providers", "Databricks"],
-]
-
-
-def render_codex_overlay(workspace: str, use_ai_gateway_v2: bool) -> dict:
-    auth_command = build_auth_shell_command(workspace)
-    base_url = build_tool_base_url("codex", workspace, use_ai_gateway_v2)
-    return {
-        "profile": "default",
-        "profiles": {"default": {"model_provider": "Databricks"}},
-        "model_providers": {
-            "Databricks": {
-                "name": "Databricks AI Gateway",
-                "base_url": base_url,
-                "wire_api": "responses",
-                "auth": {
-                    "command": "sh",
-                    "args": ["-c", auth_command],
-                    "timeout_ms": 5000,
-                    "refresh_interval_ms": 1800000,
-                },
-            }
-        },
-    }
-
-
-def render_claude_overlay(
-    workspace: str,
-    use_ai_gateway_v2: bool,
-    model: str,
-    claude_models: dict[str, str] | None = None,
-) -> tuple[dict, list[list[str]]]:
-    """Return (overlay, managed_key_paths) for Claude settings.json."""
-    base_url = build_tool_base_url("claude", workspace, use_ai_gateway_v2)
-    env: dict[str, str] = {
-        "ANTHROPIC_MODEL": model,
-        "ANTHROPIC_BASE_URL": base_url,
-        "ANTHROPIC_CUSTOM_HEADERS": "x-databricks-use-coding-agent-mode: true",
-        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
-        "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "1800000",
-    }
-    if claude_models:
-        if claude_models.get("opus"):
-            env["ANTHROPIC_DEFAULT_OPUS_MODEL"] = claude_models["opus"]
-        if claude_models.get("sonnet"):
-            env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = claude_models["sonnet"]
-        if claude_models.get("haiku"):
-            env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = claude_models["haiku"]
-    overlay = {"apiKeyHelper": build_auth_shell_command(workspace), "env": env}
-    keys: list[list[str]] = [["apiKeyHelper"]] + [["env", k] for k in env]
-    return overlay, keys
-
-
-GEMINI_MANAGED_KEYS: list[str] = [
-    "GEMINI_MODEL",
-    "GOOGLE_GEMINI_BASE_URL",
-    "GEMINI_API_KEY_AUTH_MECHANISM",
-    "GEMINI_API_KEY",
-]
-
-
-def render_gemini_env_overlay(
-    workspace: str,
-    use_ai_gateway_v2: bool,
-    model: str,
-    token: str,
-) -> dict[str, str]:
-    base_url = build_tool_base_url("gemini", workspace, use_ai_gateway_v2)
-    return {
-        "GEMINI_MODEL": model,
-        "GOOGLE_GEMINI_BASE_URL": base_url,
-        "GEMINI_API_KEY_AUTH_MECHANISM": "bearer",
-        "GEMINI_API_KEY": token,
-    }
-
-
-OPENCODE_PROVIDER_KEYS: list[list[str]] = [
-    ["provider", "databricks-anthropic"],
-    ["provider", "databricks-google"],
-]
-
-
-def render_opencode_overlay(
-    model: str,
-    token: str,
-    opencode_base_urls: dict[str, str],
-    opencode_models: dict[str, list[str]],
-) -> tuple[dict, list[list[str]]]:
-    """Return (overlay, managed_key_paths) for opencode.json."""
-    auth_headers = {"Authorization": f"Bearer {token}"}
-
-    anthropic_models = opencode_models.get("anthropic") or []
-    gemini_models = opencode_models.get("gemini") or []
-
-    providers: dict = {}
-    keys: list[list[str]] = [["model"]]
-    if anthropic_models:
-        providers["databricks-anthropic"] = {
-            "npm": "@ai-sdk/anthropic",
-            "options": {
-                "baseURL": opencode_base_urls["anthropic"],
-                "apiKey": token,
-                "headers": auth_headers,
-            },
-            "models": {m: {} for m in anthropic_models},
-        }
-        keys.append(["provider", "databricks-anthropic"])
-    if gemini_models:
-        providers["databricks-google"] = {
-            "npm": "@ai-sdk/google",
-            "options": {
-                "baseURL": opencode_base_urls["gemini"],
-                "apiKey": token,
-                "headers": auth_headers,
-            },
-            "models": {m: {} for m in gemini_models},
-        }
-        keys.append(["provider", "databricks-google"])
-
-    overlay: dict = {"model": model}
-    if providers:
-        overlay["provider"] = providers
-    return overlay, keys
-
-
-def build_gemini_runtime_env(
-    workspace: str,
-    use_ai_gateway_v2: bool,
-    model: str,
-    token: str,
-) -> dict[str, str]:
-    env = os.environ.copy()
-    env["GEMINI_MODEL"] = model
-    env["GOOGLE_GEMINI_BASE_URL"] = build_tool_base_url("gemini", workspace, use_ai_gateway_v2)
-    env["GEMINI_API_KEY_AUTH_MECHANISM"] = "bearer"
-    env["GEMINI_API_KEY"] = token
-    return env
-
-
-def get_databricks_profiles() -> list[tuple[str, str]]:
-    """Return [(host_url, profile_name), ...] from Databricks CLI profiles."""
-    try:
-        result = run(
-            ["databricks", "auth", "profiles", "--output", "json"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        if result.returncode != 0:
-            return []
-        data = json.loads(result.stdout or "{}")
-        profiles = data.get("profiles") or []
-        seen: set[str] = set()
-        result = []
-        for p in profiles:
-            host = p.get("host", "").rstrip("/")
-            if host and host not in seen and p.get("auth_type") != "pat":
-                seen.add(host)
-                result.append((host, p["name"]))
-        return result
-    except (json.JSONDecodeError, OSError, subprocess.TimeoutExpired, KeyError):
-        return []
-
-
-def prompt_for_workspace(description: str = "Enter your Databricks workspace URL") -> str:
-    console.print()
-    console.print(Panel(description, title="coding-gateway Setup", style="bold blue", expand=False))
-
-    profiles = get_databricks_profiles()
-    if profiles:
-        choices = [
-            questionary.Choice(title=host, value=host)
-            for host, name in profiles
-        ]
-        choices.append(questionary.Choice(title="Enter a different URL", value="__manual__"))
-        style = questionary.Style([
-            ("highlighted", "fg:cyan bold"),
-            ("pointer", "fg:cyan bold"),
-            ("answer", "fg:cyan"),
-        ])
-        choice = questionary.select(
-            "Select workspace:", choices=choices, style=style, pointer="›", qmark=""
-        ).ask()
-        if choice is not None and choice != "__manual__":
-            return normalize_workspace_url(choice)
-
-    while True:
-        raw_value = console.input(f"  [bold]Workspace URL[/bold] {muted('›')} ").strip()
-        try:
-            return normalize_workspace_url(raw_value)
-        except ValueError as exc:
-            print_err(str(exc))
-
-
-def prompt_yes_no(prompt: str) -> bool:
-    while True:
-        response = console.input(f"{label(prompt)} {muted('[y/n]')} {muted('›')} ").strip().lower()
-        if response in {"y", "yes"}:
-            return True
-        if response in {"n", "no"}:
-            return False
-        print_err("Please answer yes or no.")
-
-
-def prompt_for_choice(prompt: str, options: list[tuple[str, str]]) -> str:
-    console.print()
-    for index, (_, option_label) in enumerate(options, start=1):
-        console.print(f"  [bold]{index}.[/bold] [cyan]{option_label}[/cyan]")
-
-    while True:
-        raw_value = console.input(f"{label(prompt)} {muted('›')} ").strip()
-        if raw_value.isdigit():
-            selected_index = int(raw_value)
-            if 1 <= selected_index <= len(options):
-                return options[selected_index - 1][0]
-        print_err("Please enter a valid option number.")
-
-
-def prompt_for_client_id() -> str:
-    while True:
-        client_id = console.input(
-            f"{label('OAuth client ID')} {muted('›')} "
-        ).strip()
-        if client_id:
-            return client_id
-        print_err("Client ID cannot be empty.")
-
-
-def prompt_for_client_secret() -> str:
-    while True:
-        client_secret = console.input(
-            f"{label('OAuth client secret')} {muted('›')} "
-        ).strip()
-        if client_secret:
-            return client_secret
-        print_err("Client secret cannot be empty.")
-
-
-def prompt_for_configuration(tool: str | None = None) -> str:
+from coding_tool_gateway.mcp import configure_mcp_command
+from coding_tool_gateway.state import STATE_PATH, clear_state, load_state, save_state
+from coding_tool_gateway.ui import (
+    console,
+    heading,
+    print_err,
+    print_heading,
+    print_kv,
+    print_note,
+    print_section,
+    print_success,
+    prompt_for_workspace,
+    spinner,
+    status_badge,
+)
+from coding_tool_gateway.usage import usage as usage_report
+
+
+def _prompt_for_configuration(tool: str | None = None) -> str:
     if tool is None:
         desc = "Configure your Databricks workspace"
     else:
         desc = f"Configure {TOOL_SPECS[tool]['display']} to use your Databricks endpoint."
-    return prompt_for_workspace(desc)
-
-
-def mark_tool_managed(state: dict, tool: str, managed_keys: list) -> dict:
-    managed_configs = dict(state.get("managed_configs") or {})
-    managed_configs[tool] = {"keys": list(managed_keys)}
-    state["managed_configs"] = managed_configs
-    state["last_tool"] = tool
-    return state
+    profiles = get_databricks_profiles()
+    return prompt_for_workspace(desc, profiles)
 
 
 def configure_shared_state(workspace: str) -> dict:
+    """Log into Databricks, enforce AI Gateway v2, fetch model lists, persist state."""
     workspace = normalize_workspace_url(workspace)
     run_databricks_login(workspace)
-    with spinner("Detecting AI Gateway..."):
+    with spinner("Verifying AI Gateway V2..."):
         token = get_databricks_token(workspace)
-        use_ai_gateway_v2 = detect_ai_gateway_v2(workspace, token)
-    if use_ai_gateway_v2:
-        print_success("AI Gateway detected — using AI Gateway endpoints")
-        with spinner("Fetching available models..."):
-            claude_models = fetch_ai_gateway_claude_models(workspace, token)
-            gemini_models = fetch_gemini_models(workspace, token)
-            codex_models = fetch_codex_models(workspace, token)
-    else:
-        print_note("AI Gateway not detected — using workspace serving endpoints")
-        claude_models = {}
-        gemini_models = []
-        codex_models = []
+        ensure_ai_gateway_v2(workspace, token)
+    print_success("AI Gateway V2 detected")
+
+    with spinner("Fetching available models..."):
+        claude_models = fetch_ai_gateway_claude_models(workspace, token)
+        gemini_models = fetch_gemini_models(workspace, token)
+        codex_models = fetch_codex_models(workspace, token)
+
     opencode_models: dict[str, list[str]] = {}
     if claude_models:
         opencode_models["anthropic"] = list(claude_models.values())
     if gemini_models:
         opencode_models["gemini"] = gemini_models
+
     state = {
         "workspace": workspace,
-        "use_ai_gateway_v2": use_ai_gateway_v2,
         "claude_models": claude_models,
         "gemini_models": gemini_models,
         "codex_models": codex_models,
         "opencode_models": opencode_models,
-        "base_urls": build_shared_base_urls(workspace, use_ai_gateway_v2),
+        "base_urls": build_shared_base_urls(workspace),
     }
     save_state(state)
     return state
 
 
-def write_codex_tool_config(state: dict) -> dict:
-    backup_existing_file(CODEX_CONFIG_PATH, CODEX_BACKUP_PATH)
-    overlay = render_codex_overlay(
-        state["workspace"],
-        bool(state.get("use_ai_gateway_v2")),
-    )
-    doc = read_toml_safe(CODEX_CONFIG_PATH)
-    deep_merge_dict(doc, overlay)
-    write_toml_file(CODEX_CONFIG_PATH, doc)
-    state = mark_tool_managed(state, "codex", CODEX_MANAGED_KEYS)
-    save_state(state)
-    return state
-
-
-def write_claude_tool_config(state: dict, model: str) -> dict:
-    backup_existing_file(CLAUDE_SETTINGS_PATH, CLAUDE_BACKUP_PATH)
-    overlay, managed_keys = render_claude_overlay(
-        state["workspace"],
-        bool(state.get("use_ai_gateway_v2")),
-        model,
-        state.get("claude_models") or {},
-    )
-    existing = read_json_safe(CLAUDE_SETTINGS_PATH)
-    merged = deep_merge_dict(existing, overlay)
-    write_json_file(CLAUDE_SETTINGS_PATH, merged)
-    state = mark_tool_managed(state, "claude", managed_keys)
-    save_state(state)
-    return state
-
-
-def write_gemini_tool_config(state: dict, model: str, token: str | None = None) -> tuple[dict, str]:
-    backup_existing_file(GEMINI_ENV_PATH, GEMINI_BACKUP_PATH)
-    if token is None:
-        token = get_databricks_token(state["workspace"])
-    overlay = render_gemini_env_overlay(
-        state["workspace"],
-        bool(state.get("use_ai_gateway_v2")),
-        model,
-        token,
-    )
-    existing = parse_dotenv(GEMINI_ENV_PATH)
-    existing.update(overlay)
-    write_dotenv(GEMINI_ENV_PATH, existing)
-    state = mark_tool_managed(state, "gemini", GEMINI_MANAGED_KEYS)
-    save_state(state)
-    return state, token
-
-
-def write_opencode_tool_config(state: dict, model: str, token: str | None = None) -> tuple[dict, str]:
-    backup_existing_file(OPENCODE_CONFIG_PATH, OPENCODE_BACKUP_PATH)
-    if token is None:
-        token = get_databricks_token(state["workspace"])
-    opencode_base_urls = state.get("base_urls", {}).get("opencode") or build_opencode_base_urls(
-        state["workspace"], bool(state.get("use_ai_gateway_v2"))
-    )
-    overlay, managed_keys = render_opencode_overlay(
-        model,
-        token,
-        opencode_base_urls,
-        state.get("opencode_models") or {},
-    )
-    existing = read_json_safe(OPENCODE_CONFIG_PATH)
-    providers = existing.get("provider")
-    if isinstance(providers, dict):
-        for stale in ("databricks-anthropic", "databricks-google"):
-            providers.pop(stale, None)
-    merged = deep_merge_dict(existing, overlay)
-    write_json_file(OPENCODE_CONFIG_PATH, merged)
-    state = mark_tool_managed(state, "opencode", managed_keys)
-    save_state(state)
-    return state, token
-
-
-def refresh_gemini_token_once(state: dict) -> str:
-    model = default_model_for_tool("gemini", state)
-    if not model:
-        raise RuntimeError("No Gemini model is configured.")
-    _, token = write_gemini_tool_config(state, model)
-    return token
-
-
-def refresh_gemini_env_forever(state: dict, stop_event: threading.Event) -> None:
-    while not stop_event.wait(TOKEN_REFRESH_INTERVAL_SECONDS):
-        try:
-            refresh_gemini_token_once(state)
-        except RuntimeError:
-            continue
-
-
-def refresh_opencode_token_once(state: dict) -> str:
-    model = default_model_for_tool("opencode", state)
-    if not model:
-        raise RuntimeError("No OpenCode model is configured.")
-    _, token = write_opencode_tool_config(state, model)
-    return token
-
-
-def refresh_opencode_config_forever(state: dict, stop_event: threading.Event) -> None:
-    while not stop_event.wait(TOKEN_REFRESH_INTERVAL_SECONDS):
-        try:
-            refresh_opencode_token_once(state)
-        except RuntimeError:
-            continue
-
-
-def configure_tool(tool: str, state: dict, model: str | None = None) -> dict:
-    if tool == "codex":
-        return write_codex_tool_config(state)
-    if tool == "claude":
-        if not model:
-            raise RuntimeError("A Claude model must be selected before configuration.")
-        return write_claude_tool_config(state, model)
-    if tool == "gemini":
-        if not model:
-            raise RuntimeError("A Gemini model must be selected before configuration.")
-        state, _ = write_gemini_tool_config(state, model)
-        return state
-    if tool == "opencode":
-        if not model:
-            raise RuntimeError("An OpenCode model must be selected before configuration.")
-        state, _ = write_opencode_tool_config(state, model)
-        return state
-    raise RuntimeError(f"Unsupported tool '{tool}'.")
-
-
-def check_gateway_endpoint(state: dict, tool: str) -> bool:
-    """Check if a tool has models available based on state, or fall back to HEAD check."""
-    use_ai_gateway_v2 = bool(state.get("use_ai_gateway_v2"))
-    if use_ai_gateway_v2:
-        if tool == "claude":
-            return bool(state.get("claude_models"))
-        elif tool == "opencode":
-            return bool(state.get("opencode_models"))
-        elif tool == "codex":
-            return bool(state.get("codex_models"))
-        elif tool == "gemini":
-            return bool(state.get("gemini_models"))
-        return False
-    # Non-v2: fall back to HEAD check
-    workspace = state["workspace"]
-    token = get_databricks_token(workspace)
-    if tool == "opencode":
-        base_url = build_tool_base_url("claude", workspace, False)
-        url = f"{base_url}/v1/messages"
-    elif tool == "claude":
-        base_url = build_tool_base_url(tool, workspace, False)
-        url = f"{base_url}/v1/messages"
-    elif tool == "codex":
-        base_url = build_tool_base_url(tool, workspace, False)
-        url = f"{base_url}/responses"
-    elif tool == "gemini":
-        base_url = build_tool_base_url(tool, workspace, False)
-        url = f"{base_url}/v1beta/models"
-    else:
-        return False
-    req = urllib_request.Request(url, method="HEAD", headers={"Authorization": f"Bearer {token}"})
-    try:
-        urllib_request.urlopen(req, timeout=10)
-        return True
-    except urllib_error.HTTPError as exc:
-        return exc.code in (400, 401, 422)
-    except (urllib_error.URLError, OSError):
-        return False
-
-
-def configure_all_tools(state: dict) -> dict:
-    available_tools: list[str] = []
-    unavailable_tools: list[str] = []
-
-    for tool in TOOL_SPECS:
-        with spinner(f"Checking {TOOL_SPECS[tool]['display']} availability..."):
-            ok = check_gateway_endpoint(state, tool)
-        if ok:
-            available_tools.append(tool)
-        else:
-            unavailable_tools.append(tool)
-
-    for tool in unavailable_tools:
-        print_err(f"{TOOL_SPECS[tool]['display']} is not available on this workspace")
-
-    for tool in available_tools:
-        if tool == "codex":
-            state = configure_tool("codex", state, None)
-        else:
-            state, model = resolve_launch_model(tool, state, None)
-            state = configure_tool(tool, state, model)
-
-    state["available_tools"] = available_tools
-    save_state(state)
-    return state
-
-
-def ensure_provider_state(tool: str) -> dict:
-    state = load_state()
-    workspace = state.get("workspace")
-    if not workspace:
-        raise RuntimeError(
-            "No workspace configured. Run `coding-gateway configure` first."
-        )
-    available_tools = state.get("available_tools") or []
-    if tool not in available_tools:
-        raise RuntimeError(
-            f"{TOOL_SPECS[tool]['display']} is not available on this workspace. "
-            f"Run `coding-gateway configure` to set up your agents."
-        )
-    ensure_databricks_auth(workspace)
-    return state
-
-
-def validate_tool(tool: str) -> tuple[bool, str]:
-    """Invoke a tool with a simple prompt to verify it works. Returns (ok, error_msg)."""
-    spec = TOOL_SPECS[tool]
-    binary = spec["binary"]
-    if tool == "claude":
-        cmd = [binary, "-p", "say hi in 5 words or less", "--max-turns", "1"]
-    elif tool == "codex":
-        cmd = [binary, "exec", "say hi in 5 words or less"]
-    elif tool == "gemini":
-        cmd = [binary, "-p", "say hi in 5 words or less"]
-    elif tool == "opencode":
-        cmd = [binary, "run", "say hi in 5 words or less"]
-    else:
-        return False, "unsupported tool"
-    try:
-        result = run(cmd, check=False, capture_output=True, text=True, timeout=60)
-        if result.returncode == 0:
-            return True, ""
-        output = (result.stderr or result.stdout or "").strip()
-        for line in output.splitlines():
-            if "error" in line.lower() and ("message" in line.lower() or ":" in line):
-                msg = line.strip()
-                if "error_code" in msg:
-                    try:
-                        payload = json.loads(msg[msg.index("{"):msg.rindex("}") + 1])
-                        return False, payload.get("message", msg)
-                    except (json.JSONDecodeError, ValueError):
-                        pass
-                return False, msg
-        last_line = output.splitlines()[-1] if output else "unknown error"
-        return False, last_line
-    except OSError as exc:
-        return False, str(exc)
-    except subprocess.TimeoutExpired:
-        return False, "timed out"
-
-
-def validate_all_tools(state: dict) -> None:
-    console.print()
-    console.print(Panel("Testing each tool with a quick message...", title="Validating", style="bold blue", expand=False))
-    results: list[tuple[str, bool]] = []
-    available_tools = list(state.get("available_tools") or [])
-    for tool, spec in TOOL_SPECS.items():
-        if tool not in available_tools:
-            continue
-        with spinner(f"Validating {spec['display']}..."):
-            ok, err = validate_tool(tool)
-        results.append((tool, ok))
-        if ok:
-            print_success(f"{spec['display']} is working")
-        else:
-            print_err(f"{spec['display']}: {err}")
-            managed = bool(state.get("managed_configs", {}).get(tool))
-            restore_file(spec["config_path"], spec["backup_path"], managed)
-            available_tools.remove(tool)
-    state["available_tools"] = available_tools
-    save_state(state)
-
-    console.print()
-    success_tools = [(t, s) for t, s in results if s]
-    if success_tools:
-        lines = []
-        for tool, _ in success_tools:
-            spec = TOOL_SPECS[tool]
-            lines.append(f"[green]✓[/green] [bold]{spec['display']}[/bold] — run with [cyan]coding-gateway --agent {tool}[/cyan]")
-        console.print(Panel("\n".join(lines), title="Ready", style="green", expand=False))
-
-
 def configure_workspace_command() -> int:
-    workspace = prompt_for_configuration()
+    workspace = _prompt_for_configuration()
     state = configure_shared_state(workspace)
     state = configure_all_tools(state)
 
-    mode = (
-        "Databricks AI Gateway V2"
-        if state.get("use_ai_gateway_v2")
-        else "Workspace serving endpoint"
-    )
     available_tools = state.get("available_tools") or []
     summary_lines = [
         f"[bold]Workspace:[/bold] [cyan]{state['workspace']}[/cyan]",
-        f"[bold]Mode:[/bold] [cyan]{mode}[/cyan]",
     ]
     for tool, spec in TOOL_SPECS.items():
         if tool in available_tools:
             summary_lines.append(f"[bold]{spec['display']}:[/bold] [green]configured[/green]")
         else:
             summary_lines.append(f"[bold]{spec['display']}:[/bold] [dim]not available[/dim]")
-    console.print(Panel("\n".join(summary_lines), title="Configuration Complete", style="green", expand=False))
+    console.print(
+        Panel(
+            "\n".join(summary_lines),
+            title="Configuration Complete",
+            style="green",
+            expand=False,
+        )
+    )
 
     if available_tools:
         validate_all_tools(state)
     return 0
 
 
-
-def build_mcp_http_entry(url: str, client_id: str, callback_port: int = 8080) -> dict:
-    return {
-        "type": "http",
-        "url": url,
-        "oauth": {
-            "clientId": client_id,
-            "callbackPort": callback_port,
-        },
-    }
-
-
-def add_claude_mcp_server(name: str, entry: dict, client_secret: str) -> None:
-    env = os.environ.copy()
-    env["MCP_CLIENT_SECRET"] = client_secret
-    try:
-        run(
-            ["claude", "mcp", "add-json", name, json.dumps(entry),
-             "--client-secret"],
-            env=env,
-            timeout=30,
-        )
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError(f"Failed to add MCP server '{name}' via claude CLI.") from exc
-
-
-def configure_mcp_command() -> int:
-    state = load_state()
-    workspace = state.get("workspace")
-    if not workspace:
-        raise RuntimeError(
-            "Workspace is not configured. Run `coding-gateway configure` first."
-        )
-
-    if not shutil.which("claude"):
-        raise RuntimeError(
-            "`claude` CLI is not installed. Install it with: npm install -g @anthropic-ai/claude-code"
-        )
-
-    ensure_databricks_auth(workspace)
-
-    print_section("MCP Server Configuration")
-    print_note("Configure Claude Code to connect to Databricks MCP servers.")
-    print_note(f"Workspace: {workspace}")
-
-    print_heading("OAuth Credentials")
-    print_note("These will be used for all MCP servers added in this session.")
-    client_id = prompt_for_client_id()
-    client_secret = prompt_for_client_secret()
-
-    state["mcp_oauth"] = {"client_id": client_id, "client_secret": client_secret}
-    mcp_servers: list[dict] = list(state.get("mcp_servers") or [])
-
-    added: list[str] = []
-
-    print_section("Add MCP Server")
-    while True:
-        selection = prompt_for_choice(
-            "Select server type",
-            [
-                ("external", "External MCP server (e.g. confluence-mcp, jira-mcp)"),
-                ("uc-functions", "UC Functions (Unity Catalog AI functions)"),
-                ("genie", "Genie (AI/BI dashboard)"),
-                ("custom", "Custom MCP server URL"),
-                ("done", "Done — exit"),
-            ],
-        )
-
-        if selection == "done":
-            break
-
-        if selection == "external":
-            server_name = console.input(
-                f"  {label('MCP server name')} {muted('(e.g. confluence-mcp, jira-mcp)')} {muted('›')} "
-            ).strip()
-            if not server_name:
-                print_err("Server name cannot be empty.")
-                continue
-            url = f"{workspace}/api/2.0/mcp/external/{server_name}"
-            entry_name = server_name
-
-        elif selection == "uc-functions":
-            catalog = console.input(f"  {label('Catalog name')} {muted('›')} ").strip()
-            schema = console.input(f"  {label('Schema name')} {muted('›')} ").strip()
-            if not catalog or not schema:
-                print_err("Catalog and schema cannot be empty.")
-                continue
-            url = f"{workspace}/api/2.0/mcp/functions/{catalog}/{schema}"
-            entry_name = f"databricks-uc-{catalog}-{schema}"
-
-        elif selection == "genie":
-            space_id = console.input(f"  {label('Genie space ID')} {muted('›')} ").strip()
-            if not space_id:
-                print_err("Space ID cannot be empty.")
-                continue
-            url = f"{workspace}/api/2.0/mcp/genie/{space_id}"
-            entry_name = f"databricks-genie-{space_id}"
-
-        elif selection == "custom":
-            url = console.input(f"  {label('Full MCP server URL')} {muted('›')} ").strip()
-            if not url:
-                print_err("URL cannot be empty.")
-                continue
-            entry_name = console.input(f"  {label('Server name')} {muted('›')} ").strip()
-            if not entry_name:
-                print_err("Server name cannot be empty.")
-                continue
-
-        else:
-            continue
-
-        entry = build_mcp_http_entry(url, client_id)
-        add_claude_mcp_server(entry_name, entry, client_secret)
-        added.append(entry_name)
-        mcp_servers.append(
-            {
-                "name": entry_name,
-                "url": url,
-                "client_id": client_id,
-                "client_secret": client_secret,
-            }
-        )
-        state["mcp_servers"] = mcp_servers
-        save_state(state)
-        print_success(f"Added {entry_name}")
-
-    if not added:
-        print_note("No MCP servers added.")
-        return 0
-
-    print_heading("MCP Configured")
-    for name in added:
-        console.print(f"  [bold green]●[/bold green] [cyan]{name}[/cyan]")
-    print_success("MCP servers registered via `claude mcp add-json`")
-    print_note("Run `claude mcp list` to see all configured servers.")
-    return 0
-
-
-def usage() -> int:
-    state = load_state()
-    workspace = state.get("workspace")
-    if not workspace:
-        raise RuntimeError("Workspace is not configured. Run `coding-gateway configure` first.")
-    if not bool(state.get("use_ai_gateway_v2")):
-        raise RuntimeError(
-            "Usage summary requires Databricks AI Gateway V2. "
-            f"Run `coding-gateway configure`, enable AI Gateway V2, then try again. Docs: {AI_GATEWAY_V2_DOCS_URL}"
-        )
-
-    ensure_databricks_auth(workspace)
-    with spinner("Retrieving Databricks access token..."):
-        token = get_databricks_token(workspace)
-
-    with spinner("Discovering SQL warehouse..."):
-        resolved_http_path = discover_sql_warehouse_http_path(workspace, token, quiet=False)
-
-    with spinner("Querying system.ai_gateway.usage..."):
-        columns, rows = run_usage_query(
-            workspace,
-            resolved_http_path,
-            token,
-            build_usage_report_query(),
-        )
-    records = parse_usage_rows(columns, rows)
-    requester_name = find_requester_name(workspace, resolved_http_path, token, records)
-
-    console.print(render_usage_summary(records, requester_name))
-
-    table_headers = ["Date", "Day", "Tokens", "Sessions", "Duration", "Models"]
-    table_widths = [8, 5, 10, 8, 8, 24]
-
-    for tool, spec in TOOL_SPECS.items():
-        print_heading(f"{spec['display']} · Last {USAGE_BREAKDOWN_DAYS} Days")
-        console.print(
-            render_box_table(
-                table_headers,
-                build_tool_breakdown_rows(records, tool),
-                max_widths=table_widths,
-            )
-        )
-    return 0
-
-
-def launch_tool(tool: str, tool_args: list[str]) -> None:
-    if tool == "gemini":
-        raise RuntimeError("Use launch_gemini_tool for Gemini.")
-    if tool == "opencode":
-        raise RuntimeError("Use launch_opencode_tool for OpenCode.")
-    binary = TOOL_SPECS[tool]["binary"]
-    os.execvp(binary, [binary, *tool_args])
-
-
-def launch_gemini_tool(state: dict, tool_args: list[str]) -> None:
-    token = refresh_gemini_token_once(state)
-    model = default_model_for_tool("gemini", state)
-    if not model:
-        raise RuntimeError("No Gemini model is configured.")
-    env = build_gemini_runtime_env(
-        state["workspace"],
-        bool(state.get("use_ai_gateway_v2")),
-        model,
-        token,
-    )
-
-    stop_event = threading.Event()
-    refresher = threading.Thread(
-        target=refresh_gemini_env_forever,
-        args=(state, stop_event),
-        daemon=True,
-    )
-    refresher.start()
-
-    proc = subprocess.Popen([TOOL_SPECS["gemini"]["binary"], *tool_args], env=env)
-    try:
-        returncode = proc.wait()
-    except KeyboardInterrupt:
-        proc.send_signal(signal.SIGINT)
-        returncode = proc.wait()
-    finally:
-        stop_event.set()
-        refresher.join(timeout=1)
-
-    raise SystemExit(returncode)
-
-
-def launch_opencode_tool(state: dict, tool_args: list[str]) -> None:
-    """Launch opencode with background token refresh (same pattern as Gemini)."""
-    refresh_opencode_token_once(state)
-
-    stop_event = threading.Event()
-    refresher = threading.Thread(
-        target=refresh_opencode_config_forever,
-        args=(state, stop_event),
-        daemon=True,
-    )
-    refresher.start()
-
-    proc = subprocess.Popen([TOOL_SPECS["opencode"]["binary"], *tool_args])
-    try:
-        returncode = proc.wait()
-    except KeyboardInterrupt:
-        proc.send_signal(signal.SIGINT)
-        returncode = proc.wait()
-    finally:
-        stop_event.set()
-        refresher.join(timeout=1)
-
-    raise SystemExit(returncode)
-
-
 def status() -> int:
     state = load_state()
     workspace = state.get("workspace")
-    use_ai_gateway_v2 = bool(state.get("use_ai_gateway_v2"))
     managed_configs = state.get("managed_configs") or {}
 
     console.print(heading("coding-gateway status"))
@@ -2038,12 +136,6 @@ def status() -> int:
 
     print_heading("Provider")
     print_kv("Workspace URL", workspace or "not configured")
-    print_kv(
-        "Mode",
-        "Databricks AI Gateway V2"
-        if use_ai_gateway_v2
-        else "Workspace serving endpoint",
-    )
 
     print_heading("Tools")
     for tool, spec in TOOL_SPECS.items():
@@ -2075,7 +167,9 @@ def revert() -> int:
     managed_configs = state.get("managed_configs") or {}
 
     results: dict[str, bool] = {
-        tool: restore_file(spec["config_path"], spec["backup_path"], bool(managed_configs.get(tool)))
+        tool: restore_file(
+            spec["config_path"], spec["backup_path"], bool(managed_configs.get(tool))
+        )
         for tool, spec in TOOL_SPECS.items()
     }
     clear_state()
@@ -2086,6 +180,11 @@ def revert() -> int:
         print_kv(f"{spec['display']} config", "restored" if results[tool] else "unchanged")
     print_success("coding-gateway state cleared")
     return 0
+
+
+# ---------------------------------------------------------------------------
+# typer app
+# ---------------------------------------------------------------------------
 
 
 app = typer.Typer(
@@ -2100,49 +199,51 @@ app.add_typer(configure_app, name="configure", help="Configure workspace and too
 @app.callback(invoke_without_command=True)
 def launch(
     ctx: typer.Context,
-    agent: Annotated[str, typer.Option("--agent", help="Agent to launch: codex, claude, gemini, or opencode.")] = DEFAULT_TOOL,
+    agent: Annotated[
+        str,
+        typer.Option("--agent", help="Agent to launch: codex, claude, gemini, or opencode."),
+    ] = DEFAULT_TOOL,
 ) -> None:
     """Launch Codex, Claude Code, Gemini CLI, or OpenCode via Databricks."""
     if ctx.invoked_subcommand is not None:
         return
     try:
-        _tool = normalize_tool(agent)
-        ensure_bootstrap_dependencies(_tool)
-        state = ensure_provider_state(_tool)
-        state, resolved_model = resolve_launch_model(_tool, state, None)
-        state = configure_tool(_tool, state, resolved_model)
+        tool = normalize_tool(agent)
+        ensure_bootstrap_dependencies(tool)
+        state = ensure_provider_state(tool)
+        state, resolved_model = resolve_launch_model(tool, state, None)
+        state = configure_tool(tool, state, resolved_model)
         print_section("Launching")
-        print_kv("Tool", TOOL_SPECS[_tool]["display"])
+        print_kv("Tool", TOOL_SPECS[tool]["display"])
         if resolved_model:
             print_kv("Model", resolved_model)
-        print_kv("Base URL", state["base_urls"][_tool])
-        if _tool in ("gemini", "opencode"):
-            print_note(f"{TOOL_SPECS[_tool]['display']} token refresh is managed automatically every 30 minutes while the session is running.")
-        print_success(f"Starting {TOOL_SPECS[_tool]['display']}")
-        if _tool == "gemini":
-            launch_gemini_tool(state, ctx.args)
-        elif _tool == "opencode":
-            launch_opencode_tool(state, ctx.args)
-        else:
-            launch_tool(_tool, ctx.args)
+        print_kv("Base URL", str(state["base_urls"][tool]))
+        if tool in ("gemini", "opencode"):
+            print_note(
+                f"{TOOL_SPECS[tool]['display']} token refresh is managed automatically "
+                f"every 30 minutes while the session is running."
+            )
+        print_success(f"Starting {TOOL_SPECS[tool]['display']}")
+        launch_agent(tool, state, ctx.args)
     except RuntimeError as exc:
         print_err(str(exc))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     except KeyboardInterrupt:
         print_err("Interrupted.")
-        raise typer.Exit(130)
+        raise typer.Exit(130) from None
 
 
 @configure_app.callback(invoke_without_command=True)
 def configure(
     ctx: typer.Context,
-    dry_run: Annotated[bool, typer.Option("--dry-run", help="Print config files without writing them.")] = False,
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", help="Print config files without writing them.")
+    ] = False,
 ) -> None:
-    """Configure workspace URL and auto-detect AI Gateway."""
+    """Configure workspace URL and AI Gateway."""
     if ctx.invoked_subcommand is not None:
         return
-    global _dry_run
-    _dry_run = dry_run
+    set_dry_run(dry_run)
     try:
         install_databricks_cli()
         for t in TOOL_SPECS:
@@ -2150,10 +251,10 @@ def configure(
         configure_workspace_command()
     except RuntimeError as exc:
         print_err(str(exc))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     except KeyboardInterrupt:
         print_err("Interrupted.")
-        raise typer.Exit(130)
+        raise typer.Exit(130) from None
 
 
 @configure_app.command("mcp")
@@ -2163,10 +264,10 @@ def configure_mcp() -> None:
         configure_mcp_command()
     except RuntimeError as exc:
         print_err(str(exc))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
     except KeyboardInterrupt:
         print_err("Interrupted.")
-        raise typer.Exit(130)
+        raise typer.Exit(130) from None
 
 
 @app.command("status")
@@ -2176,7 +277,7 @@ def status_cmd() -> None:
         status()
     except RuntimeError as exc:
         print_err(str(exc))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command("revert")
@@ -2186,7 +287,7 @@ def revert_cmd() -> None:
         revert()
     except RuntimeError as exc:
         print_err(str(exc))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 @app.command("usage")
@@ -2194,10 +295,10 @@ def usage_cmd() -> None:
     """Show Databricks AI Gateway usage summary (last 7 days)."""
     try:
         install_databricks_cli()
-        usage()
+        usage_report()
     except RuntimeError as exc:
         print_err(str(exc))
-        raise typer.Exit(1)
+        raise typer.Exit(1) from None
 
 
 def main() -> None:

--- a/src/coding_tool_gateway/config_io.py
+++ b/src/coding_tool_gateway/config_io.py
@@ -1,0 +1,173 @@
+"""File I/O, dry-run flag, backup/restore, deep-merge, dotenv parsing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TypedDict
+
+import tomlkit
+import tomlkit.exceptions
+
+from coding_tool_gateway.ui import console
+
+
+class ToolSpec(TypedDict):
+    binary: str
+    package: str
+    display: str
+    config_path: Path
+    backup_path: Path
+
+
+APP_DIR = Path.home() / ".coding-gateway"
+
+_dry_run = False
+
+
+def set_dry_run(value: bool) -> None:
+    global _dry_run
+    _dry_run = bool(value)
+
+
+def is_dry_run() -> bool:
+    return _dry_run
+
+
+def ensure_parent_dir(path: Path) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RuntimeError(f"Failed to create directory for {path}") from exc
+
+
+def backup_existing_file(config_path: Path, backup_path: Path) -> bool:
+    if _dry_run:
+        return False
+    try:
+        APP_DIR.mkdir(parents=True, exist_ok=True)
+        if backup_path.exists():
+            return True
+        if not config_path.exists():
+            return False
+        backup_path.write_text(config_path.read_text(encoding="utf-8"), encoding="utf-8")
+        return True
+    except OSError as exc:
+        raise RuntimeError(f"Failed to back up config from {config_path}") from exc
+
+
+def restore_file(config_path: Path, backup_path: Path, managed: bool) -> bool:
+    try:
+        if backup_path.exists():
+            ensure_parent_dir(config_path)
+            config_path.write_text(backup_path.read_text(encoding="utf-8"), encoding="utf-8")
+            backup_path.unlink()
+            return True
+        if managed and config_path.exists():
+            config_path.unlink()
+            return True
+        return False
+    except OSError as exc:
+        raise RuntimeError(f"Failed to restore config at {config_path}") from exc
+
+
+def write_text_file(path: Path, content: str) -> None:
+    if _dry_run:
+        console.print(f"\n[bold]\\[dry run] {path}[/bold]\n{content}")
+        return
+    ensure_parent_dir(path)
+    try:
+        path.write_text(content, encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"Failed to write config file: {path}") from exc
+
+
+def write_json_file(path: Path, payload: dict) -> None:
+    content = json.dumps(payload, indent=2) + "\n"
+    if _dry_run:
+        console.print(f"\n[bold]\\[dry run] {path}[/bold]\n{content}")
+        return
+    ensure_parent_dir(path)
+    try:
+        path.write_text(content, encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"Failed to write config file: {path}") from exc
+
+
+def deep_merge_dict(base: dict, overlay: dict) -> dict:
+    """Recursively merge overlay into base; overlay wins for conflicting leaves.
+
+    Mutates and returns base. Nested dicts are merged; everything else is replaced.
+    """
+    for key, val in overlay.items():
+        if isinstance(val, dict) and isinstance(base.get(key), dict):
+            deep_merge_dict(base[key], val)
+        else:
+            base[key] = val
+    return base
+
+
+def read_json_safe(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def read_toml_safe(path: Path) -> tomlkit.TOMLDocument:
+    if not path.exists():
+        return tomlkit.document()
+    try:
+        return tomlkit.parse(path.read_text(encoding="utf-8"))
+    except (OSError, tomlkit.exceptions.TOMLKitError):
+        return tomlkit.document()
+
+
+def write_toml_file(path: Path, doc: tomlkit.TOMLDocument) -> None:
+    content = tomlkit.dumps(doc)
+    if _dry_run:
+        console.print(f"\n[bold]\\[dry run] {path}[/bold]\n{content}")
+        return
+    ensure_parent_dir(path)
+    try:
+        path.write_text(content, encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"Failed to write config file: {path}") from exc
+
+
+def parse_dotenv(path: Path) -> dict[str, str]:
+    """Parse a simple KEY=VALUE / KEY="VALUE" .env file, preserving insertion order.
+
+    Comments and blank lines are dropped on round-trip. Lines that don't look
+    like KEY=... are skipped.
+    """
+    if not path.exists():
+        return {}
+    env: dict[str, str] = {}
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        if not key:
+            continue
+        val = val.strip()
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
+            val = val[1:-1]
+        env[key] = val
+    return env
+
+
+def write_dotenv(path: Path, env: dict[str, str]) -> None:
+    content = "".join(f'{key}="{val}"\n' for key, val in env.items())
+    write_text_file(path, content)

--- a/src/coding_tool_gateway/databricks.py
+++ b/src/coding_tool_gateway/databricks.py
@@ -1,0 +1,439 @@
+"""Databricks workspace integration: CLI auth, token retrieval, model
+discovery, AI Gateway v2 enforcement, SQL warehouse discovery, URL builders."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import shutil
+import subprocess
+from typing import cast
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+from urllib.parse import urlparse
+
+from coding_tool_gateway.ui import (
+    normalize_workspace_url,
+    print_kv,
+    print_note,
+    print_section,
+    print_success,
+    print_warning,
+    spinner,
+)
+
+UNIX_DATABRICKS_INSTALL_URL = (
+    "https://raw.githubusercontent.com/databricks/setup-cli/main/install.sh"
+)
+WINDOWS_DATABRICKS_INSTALL_URL = (
+    "https://raw.githubusercontent.com/databricks/setup-cli/main/install.ps1"
+)
+AI_GATEWAY_V2_DOCS_URL = "https://docs.databricks.com/aws/en/ai-gateway/overview-beta"
+TOKEN_REFRESH_INTERVAL_SECONDS = 1800
+SCRUBBED_DATABRICKS_ENV_VARS = (
+    "DATABRICKS_TOKEN",
+    "DATABRICKS_CLIENT_ID",
+    "DATABRICKS_CLIENT_SECRET",
+    "DATABRICKS_USERNAME",
+    "DATABRICKS_PASSWORD",
+    "DATABRICKS_AUTH_TYPE",
+)
+
+
+def run(
+    args: list[str],
+    *,
+    check: bool = True,
+    capture_output: bool = False,
+    text: bool = False,
+    env: dict[str, str] | None = None,
+    timeout: int | None = None,
+) -> subprocess.CompletedProcess[str] | subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        args,
+        check=check,
+        capture_output=capture_output,
+        text=text,
+        env=env,
+        timeout=timeout,
+    )
+
+
+def build_databricks_cli_env(workspace: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env["DATABRICKS_HOST"] = workspace
+    for key in SCRUBBED_DATABRICKS_ENV_VARS:
+        env.pop(key, None)
+    return env
+
+
+def workspace_hostname(workspace: str) -> str:
+    parsed = urlparse(normalize_workspace_url(workspace))
+    if not parsed.hostname:
+        raise RuntimeError(f"Unable to derive hostname from workspace URL: {workspace}")
+    return parsed.hostname
+
+
+def install_databricks_cli() -> None:
+    if shutil.which("databricks"):
+        return
+
+    system = platform.system()
+    print_section("Bootstrap")
+    print_warning("`databricks` was not found. Installing Databricks CLI...")
+
+    try:
+        if system == "Windows":
+            run(
+                [
+                    "powershell",
+                    "-Command",
+                    f"irm {WINDOWS_DATABRICKS_INSTALL_URL} | iex",
+                ],
+                timeout=240,
+            )
+        elif shutil.which("curl"):
+            run(
+                ["sh", "-c", f"curl -fsSL {UNIX_DATABRICKS_INSTALL_URL} | sh"],
+                timeout=240,
+            )
+        elif shutil.which("wget"):
+            run(
+                ["sh", "-c", f"wget -qO- {UNIX_DATABRICKS_INSTALL_URL} | sh"],
+                timeout=240,
+            )
+        else:
+            raise RuntimeError("Neither curl nor wget is available.")
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, RuntimeError) as exc:
+        raise RuntimeError("Failed to install Databricks CLI automatically.") from exc
+
+    if not shutil.which("databricks"):
+        raise RuntimeError(
+            "Databricks CLI install completed, but `databricks` is still not on PATH."
+        )
+
+
+def has_valid_databricks_auth(workspace: str) -> bool:
+    try:
+        env = build_databricks_cli_env(workspace)
+        result = run(
+            ["databricks", "auth", "token", "--host", workspace, "--output", "json"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return False
+        data = json.loads(result.stdout or "{}")
+        return bool(data.get("access_token"))
+    except (json.JSONDecodeError, OSError, subprocess.TimeoutExpired):
+        return False
+
+
+def get_databricks_profiles() -> list[tuple[str, str]]:
+    """Return [(host_url, profile_name), ...] from Databricks CLI profiles."""
+    try:
+        result = run(
+            ["databricks", "auth", "profiles", "--output", "json"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return []
+        data = json.loads(result.stdout or "{}")
+        profiles = data.get("profiles") or []
+        seen: set[str] = set()
+        out: list[tuple[str, str]] = []
+        for p in profiles:
+            host = p.get("host", "").rstrip("/")
+            if host and host not in seen and p.get("auth_type") != "pat":
+                seen.add(host)
+                out.append((host, p["name"]))
+        return out
+    except (json.JSONDecodeError, OSError, subprocess.TimeoutExpired, KeyError):
+        return []
+
+
+def find_profile_name_for_host(workspace: str) -> str | None:
+    """Find the Databricks CLI profile name matching a workspace URL."""
+    normalized = workspace.rstrip("/")
+    for host, name in get_databricks_profiles():
+        if host == normalized:
+            return name
+    return None
+
+
+def run_databricks_login(workspace: str) -> None:
+    """Run databricks auth login unconditionally."""
+    print_section("Databricks Login")
+    print_kv("Workspace", workspace)
+    print_note("A browser may open for `databricks auth login`.")
+    try:
+        cmd = ["databricks", "auth", "login", "--host", workspace]
+        profile_name = find_profile_name_for_host(workspace)
+        if profile_name:
+            cmd += ["--profile", profile_name]
+        run(cmd, env=build_databricks_cli_env(workspace), timeout=300)
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError("`databricks auth login` failed.") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("`databricks auth login` timed out.") from exc
+    print_success("Databricks authentication complete")
+
+
+def ensure_databricks_auth(workspace: str) -> None:
+    """Check auth and login only if needed (used by launch path)."""
+    with spinner("Checking Databricks auth..."):
+        auth_is_valid = has_valid_databricks_auth(workspace)
+    if auth_is_valid:
+        print_success(f"Databricks auth already available for {workspace}")
+        return
+    run_databricks_login(workspace)
+
+
+def get_databricks_token(workspace: str) -> str:
+    try:
+        env = build_databricks_cli_env(workspace)
+        result = run(
+            ["databricks", "auth", "token", "--host", workspace, "--output", "json"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=15,
+        )
+        data = json.loads(result.stdout or "{}")
+        token = data.get("access_token")
+        if not token:
+            raise RuntimeError("Databricks CLI returned no access token.")
+        return token
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+        raise RuntimeError("Failed to retrieve Databricks access token.") from exc
+
+
+def build_auth_shell_command(workspace: str) -> str:
+    python_expr = "import json,sys; print(json.load(sys.stdin).get('access_token', ''))"
+    unset_prefix = " ".join(f"-u {key}" for key in SCRUBBED_DATABRICKS_ENV_VARS)
+    return (
+        f"env {unset_prefix} databricks auth token --host {workspace} --output json "
+        f'| python3 -c "{python_expr}"'
+    )
+
+
+def fetch_ai_gateway_claude_models(workspace: str, token: str) -> dict[str, str]:
+    hostname = workspace_hostname(workspace)
+    request = urllib_request.Request(
+        f"https://{hostname}/ai-gateway/anthropic/v1/models",
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    try:
+        with urllib_request.urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except (urllib_error.URLError, urllib_error.HTTPError, json.JSONDecodeError):
+        return {}
+
+    models = [
+        m["id"]
+        for m in data.get("data", [])
+        if isinstance(m.get("id"), str) and not m["id"].endswith("-anthropic")
+    ]
+
+    result: dict[str, str] = {}
+    for family, key in [("opus", "opus"), ("sonnet", "sonnet"), ("haiku", "haiku")]:
+        candidates = sorted(
+            [m for m in models if f"databricks-claude-{family}-" in m],
+            reverse=True,
+        )
+        if candidates:
+            result[key] = candidates[0]
+    return result
+
+
+def _fetch_endpoints_with_api_type(workspace: str, token: str, api_type: str) -> list[str]:
+    """Generic helper: list endpoint names whose served_entities expose api_type."""
+    hostname = workspace_hostname(workspace)
+    request = urllib_request.Request(
+        f"https://{hostname}/api/2.0/serving-endpoints:foundation-models",
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    try:
+        with urllib_request.urlopen(request, timeout=10) as response:
+            data = json.loads(response.read().decode("utf-8"))
+    except (urllib_error.URLError, urllib_error.HTTPError, json.JSONDecodeError):
+        return []
+
+    out: list[str] = []
+    for ep in data.get("endpoints", []):
+        name = ep.get("name", "")
+        entities = ep.get("config", {}).get("served_entities", [])
+        api_types: set[str] = set()
+        for se in entities:
+            fm = se.get("foundation_model", {})
+            if fm.get("ai_gateway_v2_supported") is True:
+                api_types.update(fm.get("api_types", []))
+        if api_type in api_types:
+            out.append(name)
+    return sorted(out)
+
+
+def fetch_gemini_models(workspace: str, token: str) -> list[str]:
+    return _fetch_endpoints_with_api_type(workspace, token, "gemini/v1/generateContent")
+
+
+def fetch_codex_models(workspace: str, token: str) -> list[str]:
+    return _fetch_endpoints_with_api_type(workspace, token, "openai/v1/responses")
+
+
+def ensure_ai_gateway_v2(workspace: str, token: str) -> None:
+    """Probe AI Gateway v2 and raise if unavailable.
+
+    Replaces the prior detect/fall-back pattern: v2 is now mandatory.
+    """
+    hostname = workspace_hostname(workspace)
+    request = urllib_request.Request(
+        f"https://{hostname}/ai-gateway/anthropic/v1/messages",
+        method="HEAD",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    try:
+        urllib_request.urlopen(request, timeout=10)
+        return
+    except urllib_error.HTTPError as exc:
+        if exc.code != 404:
+            return
+    except urllib_error.URLError:
+        pass
+    raise RuntimeError(
+        "Databricks AI Gateway V2 is required but not available on this workspace. "
+        f"See {AI_GATEWAY_V2_DOCS_URL}"
+    )
+
+
+def discover_sql_warehouse_http_path(
+    workspace: str,
+    token: str,
+    *,
+    quiet: bool = False,
+) -> str:
+    hostname = workspace_hostname(workspace)
+    request = urllib_request.Request(
+        f"https://{hostname}/api/2.0/sql/warehouses",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        },
+    )
+
+    try:
+        with urllib_request.urlopen(request, timeout=20) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except urllib_error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
+        detail = body.strip() or f"HTTP {exc.code}"
+        raise RuntimeError(f"Failed to list SQL warehouses: {detail}") from exc
+    except urllib_error.URLError as exc:
+        raise RuntimeError(f"Could not reach workspace hostname {hostname}: {exc.reason}") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Databricks warehouse discovery returned invalid JSON.") from exc
+
+    warehouses = payload.get("warehouses")
+    if not isinstance(warehouses, list) or not warehouses:
+        raise RuntimeError(
+            "No SQL warehouses found in this workspace. Create one or pass `--http-path`."
+        )
+
+    running = [w for w in warehouses if isinstance(w, dict) and w.get("state") == "RUNNING"]
+    chosen = (
+        running[0]
+        if running
+        else next(
+            (w for w in warehouses if isinstance(w, dict) and w.get("id")),
+            None,
+        )
+    )
+    if not chosen:
+        raise RuntimeError("No usable SQL warehouse was returned by Databricks.")
+
+    warehouse_id = chosen.get("id")
+    if not isinstance(warehouse_id, str) or not warehouse_id.strip():
+        raise RuntimeError("Databricks returned a warehouse without an ID.")
+
+    warehouse_name = chosen.get("name")
+    warehouse_state = chosen.get("state", "UNKNOWN")
+    label_value = (
+        warehouse_name if isinstance(warehouse_name, str) and warehouse_name else warehouse_id
+    )
+    if not quiet:
+        print_note(f"Using SQL warehouse `{label_value}` ({warehouse_state}).")
+    return f"/sql/1.0/warehouses/{warehouse_id}"
+
+
+def run_usage_query(
+    workspace: str,
+    http_path: str,
+    token: str,
+    query: str,
+) -> tuple[list[str], list[tuple]]:
+    try:
+        logging.getLogger("databricks.sql").setLevel(logging.ERROR)
+        from databricks import sql
+    except ImportError as exc:
+        raise RuntimeError(
+            "`databricks-sql-connector` is not installed. "
+            "Install it with `pip install databricks-sql-connector`."
+        ) from exc
+
+    try:
+        with sql.connect(
+            server_hostname=workspace_hostname(workspace),
+            http_path=http_path,
+            access_token=token,
+        ) as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(query)
+                columns = [desc[0] for desc in (cursor.description or [])]
+                rows = cast(list[tuple], cursor.fetchall())
+    except Exception as exc:
+        raise RuntimeError(f"Usage query failed: {exc}") from exc
+
+    return columns, rows
+
+
+# ---------------------------------------------------------------------------
+# URL builders (AI Gateway v2 only — no fallback to /serving-endpoints)
+# ---------------------------------------------------------------------------
+
+
+def build_tool_base_url(tool: str, workspace: str) -> str:
+    if tool == "codex":
+        return f"{workspace}/ai-gateway/codex/v1"
+    if tool == "claude":
+        return f"{workspace}/ai-gateway/anthropic"
+    if tool == "gemini":
+        return f"{workspace}/ai-gateway/gemini"
+    if tool == "opencode":
+        raise RuntimeError(
+            "OpenCode has multiple base URLs — use build_opencode_base_urls() instead."
+        )
+    raise RuntimeError(f"Unsupported tool '{tool}'.")
+
+
+def build_opencode_base_urls(workspace: str) -> dict[str, str]:
+    return {
+        "anthropic": build_tool_base_url("claude", workspace) + "/v1",
+        "gemini": build_tool_base_url("gemini", workspace) + "/v1beta",
+    }
+
+
+def build_shared_base_urls(workspace: str) -> dict[str, str | dict[str, str]]:
+    urls: dict[str, str | dict[str, str]] = {
+        "codex": build_tool_base_url("codex", workspace),
+        "claude": build_tool_base_url("claude", workspace),
+        "gemini": build_tool_base_url("gemini", workspace),
+        "opencode": build_opencode_base_urls(workspace),
+    }
+    return urls

--- a/src/coding_tool_gateway/mcp.py
+++ b/src/coding_tool_gateway/mcp.py
@@ -1,0 +1,166 @@
+"""MCP (Model Context Protocol) server registration for Claude Code."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+
+from coding_tool_gateway.databricks import ensure_databricks_auth
+from coding_tool_gateway.state import load_state, save_state
+from coding_tool_gateway.ui import (
+    console,
+    label,
+    muted,
+    print_err,
+    print_heading,
+    print_note,
+    print_section,
+    print_success,
+    prompt_for_choice,
+    prompt_for_client_id,
+    prompt_for_client_secret,
+)
+
+
+def build_mcp_http_entry(url: str, client_id: str, callback_port: int = 8080) -> dict:
+    return {
+        "type": "http",
+        "url": url,
+        "oauth": {
+            "clientId": client_id,
+            "callbackPort": callback_port,
+        },
+    }
+
+
+def add_claude_mcp_server(name: str, entry: dict, client_secret: str) -> None:
+    env = os.environ.copy()
+    env["MCP_CLIENT_SECRET"] = client_secret
+    try:
+        subprocess.run(
+            [
+                "claude",
+                "mcp",
+                "add-json",
+                name,
+                json.dumps(entry),
+                "--client-secret",
+            ],
+            check=True,
+            env=env,
+            timeout=30,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"Failed to add MCP server '{name}' via claude CLI.") from exc
+
+
+def configure_mcp_command() -> int:
+    state = load_state()
+    workspace = state.get("workspace")
+    if not workspace:
+        raise RuntimeError("Workspace is not configured. Run `coding-gateway configure` first.")
+
+    if not shutil.which("claude"):
+        raise RuntimeError(
+            "`claude` CLI is not installed. Install it with: npm install -g @anthropic-ai/claude-code"
+        )
+
+    ensure_databricks_auth(workspace)
+
+    print_section("MCP Server Configuration")
+    print_note("Configure Claude Code to connect to Databricks MCP servers.")
+    print_note(f"Workspace: {workspace}")
+
+    print_heading("OAuth Credentials")
+    print_note("These will be used for all MCP servers added in this session.")
+    client_id = prompt_for_client_id()
+    client_secret = prompt_for_client_secret()
+
+    state["mcp_oauth"] = {"client_id": client_id, "client_secret": client_secret}
+    mcp_servers: list[dict] = list(state.get("mcp_servers") or [])
+
+    added: list[str] = []
+
+    print_section("Add MCP Server")
+    while True:
+        selection = prompt_for_choice(
+            "Select server type",
+            [
+                ("external", "External MCP server (e.g. confluence-mcp, jira-mcp)"),
+                ("uc-functions", "UC Functions (Unity Catalog AI functions)"),
+                ("genie", "Genie (AI/BI dashboard)"),
+                ("custom", "Custom MCP server URL"),
+                ("done", "Done — exit"),
+            ],
+        )
+
+        if selection == "done":
+            break
+
+        if selection == "external":
+            server_name = console.input(
+                f"  {label('MCP server name')} {muted('(e.g. confluence-mcp, jira-mcp)')} {muted('›')} "
+            ).strip()
+            if not server_name:
+                print_err("Server name cannot be empty.")
+                continue
+            url = f"{workspace}/api/2.0/mcp/external/{server_name}"
+            entry_name = server_name
+
+        elif selection == "uc-functions":
+            catalog = console.input(f"  {label('Catalog name')} {muted('›')} ").strip()
+            schema = console.input(f"  {label('Schema name')} {muted('›')} ").strip()
+            if not catalog or not schema:
+                print_err("Catalog and schema cannot be empty.")
+                continue
+            url = f"{workspace}/api/2.0/mcp/functions/{catalog}/{schema}"
+            entry_name = f"databricks-uc-{catalog}-{schema}"
+
+        elif selection == "genie":
+            space_id = console.input(f"  {label('Genie space ID')} {muted('›')} ").strip()
+            if not space_id:
+                print_err("Space ID cannot be empty.")
+                continue
+            url = f"{workspace}/api/2.0/mcp/genie/{space_id}"
+            entry_name = f"databricks-genie-{space_id}"
+
+        elif selection == "custom":
+            url = console.input(f"  {label('Full MCP server URL')} {muted('›')} ").strip()
+            if not url:
+                print_err("URL cannot be empty.")
+                continue
+            entry_name = console.input(f"  {label('Server name')} {muted('›')} ").strip()
+            if not entry_name:
+                print_err("Server name cannot be empty.")
+                continue
+
+        else:
+            continue
+
+        entry = build_mcp_http_entry(url, client_id)
+        add_claude_mcp_server(entry_name, entry, client_secret)
+        added.append(entry_name)
+        mcp_servers.append(
+            {
+                "name": entry_name,
+                "url": url,
+                "client_id": client_id,
+                "client_secret": client_secret,
+            }
+        )
+        state["mcp_servers"] = mcp_servers
+        save_state(state)
+        print_success(f"Added {entry_name}")
+
+    if not added:
+        print_note("No MCP servers added.")
+        return 0
+
+    print_heading("MCP Configured")
+    for name in added:
+        console.print(f"  [bold green]●[/bold green] [cyan]{name}[/cyan]")
+    print_success("MCP servers registered via `claude mcp add-json`")
+    print_note("Run `claude mcp list` to see all configured servers.")
+    return 0

--- a/src/coding_tool_gateway/state.py
+++ b/src/coding_tool_gateway/state.py
@@ -1,0 +1,99 @@
+"""Persistent state for coding-gateway (per-workspace, versioned)."""
+
+from __future__ import annotations
+
+import json
+
+from coding_tool_gateway.config_io import APP_DIR, is_dry_run
+from coding_tool_gateway.databricks import build_shared_base_urls
+
+STATE_PATH = APP_DIR / "state.json"
+STATE_VERSION = 3
+
+
+def load_full_state() -> dict:
+    """Load the entire state file. Returns empty structure if missing or wrong version."""
+    if not STATE_PATH.exists():
+        return {"state_version": STATE_VERSION, "current_workspace": None, "workspaces": {}}
+    try:
+        data = json.loads(STATE_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"state_version": STATE_VERSION, "current_workspace": None, "workspaces": {}}
+    if not isinstance(data, dict) or data.get("state_version") != STATE_VERSION:
+        return {"state_version": STATE_VERSION, "current_workspace": None, "workspaces": {}}
+    return data
+
+
+def load_state() -> dict:
+    """Load the current workspace's state as a flat dict."""
+    full = load_full_state()
+    workspace = full.get("current_workspace")
+    if not workspace:
+        return {}
+    ws_state = full.get("workspaces", {}).get(workspace, {})
+    ws_state["workspace"] = workspace
+    return hydrate_state(ws_state)
+
+
+def save_state(state: dict) -> None:
+    """Save workspace state back into the per-workspace structure."""
+    if is_dry_run():
+        return
+    full = load_full_state()
+    workspace = state.get("workspace") or full.get("current_workspace")
+    if workspace:
+        full["current_workspace"] = workspace
+        full["workspaces"][workspace] = hydrate_state(state)
+    try:
+        APP_DIR.mkdir(parents=True, exist_ok=True)
+        STATE_PATH.write_text(json.dumps(full, indent=2), encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"Failed to write state file: {STATE_PATH}") from exc
+
+
+def hydrate_state(state: dict) -> dict:
+    if not isinstance(state, dict):
+        return {}
+
+    hydrated = dict(state)
+    managed_configs = hydrated.get("managed_configs")
+    if not isinstance(managed_configs, dict):
+        managed_configs = {}
+    normalized: dict[str, dict] = {}
+    for tool, entry in managed_configs.items():
+        if isinstance(entry, dict):
+            keys = entry.get("keys") if isinstance(entry.get("keys"), list) else []
+            normalized[tool] = {"keys": keys}
+        elif entry:
+            normalized[tool] = {"keys": []}
+    hydrated["managed_configs"] = normalized
+
+    workspace = hydrated.get("workspace")
+    if workspace:
+        hydrated["base_urls"] = build_shared_base_urls(workspace)
+    else:
+        hydrated["base_urls"] = {}
+
+    return hydrated
+
+
+def clear_state() -> None:
+    """Remove the current workspace entry from state."""
+    full = load_full_state()
+    workspace = full.get("current_workspace")
+    if workspace:
+        full.get("workspaces", {}).pop(workspace, None)
+        full["current_workspace"] = None
+    try:
+        APP_DIR.mkdir(parents=True, exist_ok=True)
+        STATE_PATH.write_text(json.dumps(full, indent=2), encoding="utf-8")
+    except OSError as exc:
+        raise RuntimeError(f"Failed to clear state file: {STATE_PATH}") from exc
+
+
+def mark_tool_managed(state: dict, tool: str, managed_keys: list) -> dict:
+    managed_configs = dict(state.get("managed_configs") or {})
+    managed_configs[tool] = {"keys": list(managed_keys)}
+    state["managed_configs"] = managed_configs
+    state["last_tool"] = tool
+    return state

--- a/src/coding_tool_gateway/ui.py
+++ b/src/coding_tool_gateway/ui.py
@@ -1,0 +1,250 @@
+"""Rich/questionary presentation primitives. No project knowledge."""
+
+from __future__ import annotations
+
+import itertools
+import sys
+import textwrap
+import threading
+import time
+from contextlib import contextmanager
+from datetime import timedelta
+
+import questionary
+from rich.console import Console
+from rich.panel import Panel
+
+console = Console(highlight=False)
+err_console = Console(stderr=True, highlight=False)
+
+
+def print_section(title: str) -> None:
+    console.print()
+    console.print(Panel(title, style="bold blue", expand=False))
+
+
+def print_heading(text: str) -> None:
+    console.print()
+    console.print(f"[bold]{text}[/bold]")
+
+
+def print_kv(key: str, val: str) -> None:
+    console.print(f"  [bold]{key}:[/bold] [cyan]{val}[/cyan]")
+
+
+def print_note(text: str) -> None:
+    console.print(f"[dim]•[/dim] {text}")
+
+
+def print_success(message: str) -> None:
+    console.print(f"[bold green]✔[/bold green] {message}")
+
+
+def print_warning(message: str) -> None:
+    console.print(f"[bold yellow]![/bold yellow] {message}")
+
+
+def print_err(message: str) -> None:
+    err_console.print(f"[bold red]ERROR[/bold red] {message}")
+
+
+def heading(text: str) -> str:
+    return f"[bold blue]{text}[/bold blue]"
+
+
+def label(text: str) -> str:
+    return f"[bold]{text}[/bold]"
+
+
+def value(text: str) -> str:
+    return f"[cyan]{text}[/cyan]"
+
+
+def muted(text: str) -> str:
+    return f"[dim]{text}[/dim]"
+
+
+def status_badge(text: str, kind: str) -> str:
+    color = {"ok": "green", "warn": "yellow", "error": "red", "info": "blue"}.get(kind, "bold")
+    return f"[bold {color}]{text}[/bold {color}]"
+
+
+@contextmanager
+def spinner(message: str):
+    if not sys.stdout.isatty():
+        yield
+        return
+
+    stop_event = threading.Event()
+
+    def spin() -> None:
+        for frame in itertools.cycle("|/-\\"):
+            if stop_event.is_set():
+                break
+            sys.stdout.write(f"\r\033[2m{frame}\033[0m {message}")
+            sys.stdout.flush()
+            time.sleep(0.1)
+        sys.stdout.write("\r" + " " * (len(message) + 4) + "\r")
+        sys.stdout.flush()
+
+    thread = threading.Thread(target=spin, daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        stop_event.set()
+        thread.join(timeout=1)
+
+
+def render_box_table(
+    headers: list[str],
+    rows: list[list[str]],
+    max_widths: list[int] | None = None,
+) -> str:
+    wrapped_rows: list[list[list[str]]] = []
+    widths = [len(header) for header in headers]
+
+    for row in rows:
+        wrapped_row: list[list[str]] = []
+        for index, cell in enumerate(row):
+            raw_cell = cell if cell else "-"
+            width_limit = max_widths[index] if max_widths and index < len(max_widths) else None
+            if width_limit:
+                cell_lines = textwrap.wrap(raw_cell, width=width_limit) or ["-"]
+            else:
+                cell_lines = raw_cell.splitlines() or ["-"]
+            wrapped_row.append(cell_lines)
+            widths[index] = max(widths[index], max(len(line) for line in cell_lines))
+        wrapped_rows.append(wrapped_row)
+
+    top = "┏" + "┳".join("━" * (w + 2) for w in widths) + "┓"
+    header = "┃ " + " ┃ ".join(headers[i].ljust(widths[i]) for i in range(len(headers))) + " ┃"
+    middle = "┡" + "╇".join("━" * (w + 2) for w in widths) + "┩"
+    bottom = "└" + "┴".join("─" * (w + 2) for w in widths) + "┘"
+
+    body_lines: list[str] = []
+    for wrapped_row in wrapped_rows:
+        row_height = max(len(cell_lines) for cell_lines in wrapped_row)
+        for line_index in range(row_height):
+            body_lines.append(
+                "│ "
+                + " │ ".join(
+                    (
+                        wrapped_row[col][line_index] if line_index < len(wrapped_row[col]) else ""
+                    ).ljust(widths[col])
+                    for col in range(len(headers))
+                )
+                + " │"
+            )
+
+    return "\n".join([top, header, middle, *body_lines, bottom])
+
+
+def format_token_count(token_count: int) -> str:
+    value_float = float(token_count)
+    if token_count >= 1_000_000_000:
+        return f"{value_float / 1_000_000_000:.1f}B"
+    if token_count >= 1_000_000:
+        return f"{value_float / 1_000_000:.1f}M"
+    if token_count >= 1_000:
+        return f"{value_float / 1_000:.1f}K"
+    return str(token_count)
+
+
+def format_duration(duration_value: timedelta | None) -> str:
+    if not duration_value or duration_value.total_seconds() <= 0:
+        return "-"
+    total_minutes = duration_value.total_seconds() / 60
+    if total_minutes < 60:
+        return f"{int(round(total_minutes))}m"
+    total_hours = total_minutes / 60
+    if total_hours < 10:
+        return f"{total_hours:.1f}h"
+    if total_hours < 24:
+        return f"{round(total_hours):.0f}h"
+    return f"{total_hours / 24:.1f}d"
+
+
+def normalize_workspace_url(workspace: str) -> str:
+    workspace = workspace.strip()
+    if not workspace:
+        raise ValueError("Workspace URL cannot be empty.")
+    if not workspace.startswith(("http://", "https://")):
+        workspace = f"https://{workspace}"
+    return workspace.rstrip("/")
+
+
+def prompt_for_workspace(
+    description: str,
+    profiles: list[tuple[str, str]] | None = None,
+) -> str:
+    """Ask the user for a workspace URL, offering profiles as quick-select.
+
+    `profiles` is a list of (host_url, profile_name) tuples. Caller fetches
+    them — `ui.py` stays Databricks-agnostic. Returns a normalized URL.
+    """
+    console.print()
+    console.print(Panel(description, title="coding-gateway Setup", style="bold blue", expand=False))
+
+    if profiles:
+        choices = [questionary.Choice(title=host, value=host) for host, _ in profiles]
+        choices.append(questionary.Choice(title="Enter a different URL", value="__manual__"))
+        style = questionary.Style(
+            [
+                ("highlighted", "fg:cyan bold"),
+                ("pointer", "fg:cyan bold"),
+                ("answer", "fg:cyan"),
+            ]
+        )
+        choice = questionary.select(
+            "Select workspace:", choices=choices, style=style, pointer="›", qmark=""
+        ).ask()
+        if choice is not None and choice != "__manual__":
+            return normalize_workspace_url(choice)
+
+    while True:
+        raw_value = console.input(f"  [bold]Workspace URL[/bold] {muted('›')} ").strip()
+        try:
+            return normalize_workspace_url(raw_value)
+        except ValueError as exc:
+            print_err(str(exc))
+
+
+def prompt_yes_no(prompt: str) -> bool:
+    while True:
+        response = console.input(f"{label(prompt)} {muted('[y/n]')} {muted('›')} ").strip().lower()
+        if response in {"y", "yes"}:
+            return True
+        if response in {"n", "no"}:
+            return False
+        print_err("Please answer yes or no.")
+
+
+def prompt_for_choice(prompt: str, options: list[tuple[str, str]]) -> str:
+    console.print()
+    for index, (_, option_label) in enumerate(options, start=1):
+        console.print(f"  [bold]{index}.[/bold] [cyan]{option_label}[/cyan]")
+
+    while True:
+        raw_value = console.input(f"{label(prompt)} {muted('›')} ").strip()
+        if raw_value.isdigit():
+            selected_index = int(raw_value)
+            if 1 <= selected_index <= len(options):
+                return options[selected_index - 1][0]
+        print_err("Please enter a valid option number.")
+
+
+def prompt_for_client_id() -> str:
+    while True:
+        client_id = console.input(f"{label('OAuth client ID')} {muted('›')} ").strip()
+        if client_id:
+            return client_id
+        print_err("Client ID cannot be empty.")
+
+
+def prompt_for_client_secret() -> str:
+    while True:
+        client_secret = console.input(f"{label('OAuth client secret')} {muted('›')} ").strip()
+        if client_secret:
+            return client_secret
+        print_err("Client secret cannot be empty.")

--- a/src/coding_tool_gateway/usage.py
+++ b/src/coding_tool_gateway/usage.py
@@ -1,0 +1,307 @@
+"""Usage report querying & rendering.
+
+Reads from `system.ai_gateway.usage` via a Databricks SQL warehouse.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import cast
+
+from coding_tool_gateway.databricks import (
+    discover_sql_warehouse_http_path,
+    ensure_databricks_auth,
+    get_databricks_token,
+    run_usage_query,
+)
+from coding_tool_gateway.state import load_state
+from coding_tool_gateway.ui import (
+    console,
+    format_duration,
+    format_token_count,
+    heading,
+    label,
+    print_heading,
+    render_box_table,
+    spinner,
+    value,
+)
+
+USAGE_BREAKDOWN_DAYS = 7
+USAGE_SUMMARY_DAYS = 30
+
+
+def build_usage_report_query() -> str:
+    return f"""
+SELECT
+  current_user() AS requester_name,
+  CASE
+    WHEN lower(user_agent) LIKE '%codex%' THEN 'codex'
+    WHEN lower(user_agent) LIKE '%claude%' THEN 'claude'
+    WHEN lower(user_agent) LIKE '%gemini%' THEN 'gemini'
+    WHEN lower(user_agent) LIKE '%opencode%' THEN 'opencode'
+    ELSE 'other'
+  END AS tool,
+  date(event_time) AS usage_day,
+  SUM(COALESCE(total_tokens, 0)) AS total_tokens_used,
+  COUNT(DISTINCT request_id) AS sessions,
+  MIN(event_time) AS first_event_time,
+  MAX(event_time) AS last_event_time,
+  CONCAT_WS(', ', SORT_ARRAY(COLLECT_SET(destination_model))) AS models
+FROM system.ai_gateway.usage
+WHERE event_time >= current_timestamp() - interval {USAGE_SUMMARY_DAYS} days
+  AND requester = current_user()
+  AND (
+    lower(user_agent) LIKE '%codex%'
+    OR lower(user_agent) LIKE '%claude%'
+    OR lower(user_agent) LIKE '%gemini%'
+    OR lower(user_agent) LIKE '%opencode%'
+  )
+GROUP BY 1, 2, 3
+ORDER BY usage_day DESC, tool ASC
+""".strip()
+
+
+def build_current_user_query() -> str:
+    return "SELECT current_user() AS requester_name"
+
+
+def parse_usage_rows(columns: list[str], rows: list[tuple]) -> list[dict[str, object]]:
+    return [dict(zip(columns, row, strict=False)) for row in rows]
+
+
+def coerce_date(value_obj: object) -> date | None:
+    if isinstance(value_obj, date) and not isinstance(value_obj, datetime):
+        return value_obj
+    if isinstance(value_obj, datetime):
+        return value_obj.date()
+    if isinstance(value_obj, str):
+        try:
+            return datetime.fromisoformat(value_obj).date()
+        except ValueError:
+            return None
+    return None
+
+
+def coerce_datetime(value_obj: object) -> datetime | None:
+    if isinstance(value_obj, datetime):
+        return value_obj
+    if isinstance(value_obj, str):
+        candidate = value_obj.replace("Z", "+00:00")
+        try:
+            return datetime.fromisoformat(candidate)
+        except ValueError:
+            return None
+    return None
+
+
+def simplify_model_name(tool: str, model_name: str) -> str:
+    normalized = (model_name or "").strip()
+    if not normalized:
+        return "-"
+
+    prefix = "databricks-"
+    if normalized.startswith(prefix):
+        normalized = normalized[len(prefix) :]
+
+    tool_prefixes = {
+        "claude": "claude-",
+        "gemini": "gemini-",
+        "codex": "gpt-",
+    }
+    tool_prefix = tool_prefixes.get(tool)
+    if tool_prefix and normalized.startswith(tool_prefix):
+        normalized = normalized[len(tool_prefix) :]
+    return normalized
+
+
+def extract_model_names(tool: str, raw_models: object) -> list[str]:
+    if not isinstance(raw_models, str) or not raw_models.strip():
+        return []
+
+    unique_models: list[str] = []
+    for item in raw_models.split(","):
+        simplified = simplify_model_name(tool, item.strip())
+        if simplified != "-" and simplified not in unique_models:
+            unique_models.append(simplified)
+    return unique_models
+
+
+def summarize_models(tool: str, raw_models: object) -> str:
+    if not isinstance(raw_models, str) or not raw_models.strip():
+        return "-"
+    parts = extract_model_names(tool, raw_models)
+    return ", ".join(parts) if parts else "-"
+
+
+def empty_tool_day(tool: str, usage_day: date) -> dict[str, object]:
+    return {
+        "tool": tool,
+        "usage_day": usage_day,
+        "total_tokens_used": 0,
+        "sessions": 0,
+        "first_event_time": None,
+        "last_event_time": None,
+        "models": "-",
+    }
+
+
+def build_tool_breakdown_rows(records: list[dict[str, object]], tool: str) -> list[list[str]]:
+    today = date.today()
+    rows_by_day: dict[date, dict[str, object]] = {}
+    for record in records:
+        if record.get("tool") != tool:
+            continue
+        usage_day = coerce_date(record.get("usage_day"))
+        if usage_day:
+            rows_by_day[usage_day] = record
+
+    rendered_rows: list[list[str]] = []
+    for day_offset in range(USAGE_BREAKDOWN_DAYS):
+        usage_day = today - timedelta(days=day_offset)
+        record = rows_by_day.get(usage_day) or empty_tool_day(tool, usage_day)
+        first_event_time = coerce_datetime(record.get("first_event_time"))
+        last_event_time = coerce_datetime(record.get("last_event_time"))
+        duration = None
+        if first_event_time and last_event_time:
+            duration = last_event_time - first_event_time
+        token_total = int(cast(int, record.get("total_tokens_used") or 0))
+        session_total = int(cast(int, record.get("sessions") or 0))
+        rendered_rows.append(
+            [
+                usage_day.strftime("%m-%d"),
+                usage_day.strftime("%a"),
+                format_token_count(token_total) if token_total else "-",
+                str(session_total) if session_total else "-",
+                format_duration(duration),
+                summarize_models(tool, record.get("models")),
+            ]
+        )
+
+    return rendered_rows
+
+
+def find_requester_name(
+    workspace: str,
+    http_path: str,
+    token: str,
+    records: list[dict[str, object]],
+) -> str:
+    for record in records:
+        requester_name = record.get("requester_name")
+        if isinstance(requester_name, str) and requester_name.strip():
+            return requester_name.strip()
+
+    columns, rows = run_usage_query(workspace, http_path, token, build_current_user_query())
+    parsed_rows = parse_usage_rows(columns, rows)
+    if parsed_rows:
+        requester_name = parsed_rows[0].get("requester_name")
+        if isinstance(requester_name, str) and requester_name.strip():
+            return requester_name.strip()
+    return "current user"
+
+
+def render_usage_summary(
+    records: list[dict[str, object]],
+    requester_name: str,
+    tool_displays: dict[str, str],
+) -> str:
+    today = date.today()
+    week_start = today - timedelta(days=USAGE_BREAKDOWN_DAYS - 1)
+    month_start = today - timedelta(days=USAGE_SUMMARY_DAYS - 1)
+
+    daily_total = 0
+    weekly_total = 0
+    monthly_total = 0
+    active_tools_last_week: list[str] = []
+    weekly_model_tokens: dict[str, int] = {}
+    for record in records:
+        usage_day = coerce_date(record.get("usage_day"))
+        if not usage_day:
+            continue
+        token_total = int(cast(int, record.get("total_tokens_used") or 0))
+        tool = record.get("tool")
+        if usage_day >= month_start:
+            monthly_total += token_total
+        if usage_day >= week_start:
+            weekly_total += token_total
+            if (
+                isinstance(tool, str)
+                and tool in tool_displays
+                and tool not in active_tools_last_week
+            ):
+                active_tools_last_week.append(tool)
+            if isinstance(tool, str):
+                for model_name in extract_model_names(tool, record.get("models")):
+                    weekly_model_tokens[model_name] = (
+                        weekly_model_tokens.get(model_name, 0) + token_total
+                    )
+        if usage_day == today:
+            daily_total += token_total
+
+    lines = [
+        heading(f"Usage Summary for {requester_name}"),
+        "",
+        "[bold green]✓[/bold green] Databricks AI Gateway usage",
+        f"{label('Today:')} {value(format_token_count(daily_total) + ' tokens')}",
+        f"{label('Last 7 days:')} {value(format_token_count(weekly_total) + ' tokens')}",
+        f"{label('Last 30 days:')} {value(format_token_count(monthly_total) + ' tokens')}",
+    ]
+    if active_tools_last_week:
+        tool_text = ", ".join(tool_displays[tool] for tool in active_tools_last_week)
+        lines.append(f"{label('Active tools:')} {value(tool_text)}")
+    if weekly_model_tokens:
+        top_models = sorted(
+            weekly_model_tokens.items(),
+            key=lambda item: (-item[1], item[0].lower()),
+        )[:3]
+        models_text = ", ".join(
+            f"{model_name} ({format_token_count(token_total)})"
+            for model_name, token_total in top_models
+        )
+        lines.append(f"{label('Top models this week:')} {value(models_text)}")
+    return "\n".join(lines)
+
+
+def usage() -> int:
+    # Late import to avoid circular import (agents → state, but usage uses TOOL_SPECS for displays).
+    from coding_tool_gateway.agents import TOOL_SPECS
+
+    state = load_state()
+    workspace = state.get("workspace")
+    if not workspace:
+        raise RuntimeError("Workspace is not configured. Run `coding-gateway configure` first.")
+
+    ensure_databricks_auth(workspace)
+    with spinner("Retrieving Databricks access token..."):
+        token = get_databricks_token(workspace)
+
+    with spinner("Discovering SQL warehouse..."):
+        resolved_http_path = discover_sql_warehouse_http_path(workspace, token, quiet=False)
+
+    with spinner("Querying system.ai_gateway.usage..."):
+        columns, rows = run_usage_query(
+            workspace,
+            resolved_http_path,
+            token,
+            build_usage_report_query(),
+        )
+    records = parse_usage_rows(columns, rows)
+    requester_name = find_requester_name(workspace, resolved_http_path, token, records)
+
+    tool_displays = {tool: spec["display"] for tool, spec in TOOL_SPECS.items()}
+    console.print(render_usage_summary(records, requester_name, tool_displays))
+
+    table_headers = ["Date", "Day", "Tokens", "Sessions", "Duration", "Models"]
+    table_widths = [8, 5, 10, 8, 8, 24]
+
+    for tool, spec in TOOL_SPECS.items():
+        print_heading(f"{spec['display']} · Last {USAGE_BREAKDOWN_DAYS} Days")
+        console.print(
+            render_box_table(
+                table_headers,
+                build_tool_breakdown_rows(records, tool),
+                max_widths=table_widths,
+            )
+        )
+    return 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,58 @@
+"""Shared fixtures for E2E tests."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from coding_tool_gateway.databricks import (
+    build_shared_base_urls,
+    fetch_ai_gateway_claude_models,
+    fetch_codex_models,
+    fetch_gemini_models,
+    get_databricks_token,
+)
+from coding_tool_gateway.ui import normalize_workspace_url
+
+
+def _workspace() -> str:
+    ws = os.environ.get("CODING_GATEWAY_TEST_WORKSPACE", "").strip().rstrip("/")
+    return normalize_workspace_url(ws) if ws else ""
+
+
+@pytest.fixture(scope="session")
+def e2e_workspace():
+    ws = _workspace()
+    if not ws:
+        pytest.skip("Set CODING_GATEWAY_TEST_WORKSPACE=https://... to run E2E tests")
+    return ws
+
+
+@pytest.fixture(scope="session")
+def e2e_token(e2e_workspace):
+    return get_databricks_token(e2e_workspace)
+
+
+@pytest.fixture(scope="session")
+def e2e_state(e2e_workspace, e2e_token):
+    """Full state dict mirroring what configure_shared_state produces."""
+    claude_models = fetch_ai_gateway_claude_models(e2e_workspace, e2e_token)
+    gemini_models = fetch_gemini_models(e2e_workspace, e2e_token)
+    codex_models = fetch_codex_models(e2e_workspace, e2e_token)
+
+    opencode_models: dict = {}
+    if claude_models:
+        opencode_models["anthropic"] = list(claude_models.values())
+    if gemini_models:
+        opencode_models["gemini"] = gemini_models
+
+    return {
+        "workspace": e2e_workspace,
+        "claude_models": claude_models,
+        "gemini_models": gemini_models,
+        "codex_models": codex_models,
+        "opencode_models": opencode_models,
+        "base_urls": build_shared_base_urls(e2e_workspace),
+        "managed_configs": {},
+    }

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -1,0 +1,104 @@
+"""Tests for agents/claude.py."""
+
+from __future__ import annotations
+
+from coding_tool_gateway.agents import claude
+
+WS = "https://example.databricks.com"
+
+
+class TestClaudeSpec:
+    def test_binary(self):
+        assert claude.SPEC["binary"] == "claude"
+
+    def test_package(self):
+        assert claude.SPEC["package"] == "@anthropic-ai/claude-code"
+
+    def test_display(self):
+        assert claude.SPEC["display"] == "Claude Code"
+
+
+class TestRenderOverlay:
+    def test_sets_anthropic_model(self):
+        overlay, _ = claude.render_overlay(WS, "databricks-claude-sonnet-4")
+        assert overlay["env"]["ANTHROPIC_MODEL"] == "databricks-claude-sonnet-4"
+
+    def test_sets_anthropic_base_url(self):
+        overlay, _ = claude.render_overlay(WS, "s4")
+        assert overlay["env"]["ANTHROPIC_BASE_URL"] == f"{WS}/ai-gateway/anthropic"
+
+    def test_sets_custom_headers(self):
+        overlay, _ = claude.render_overlay(WS, "s4")
+        assert "x-databricks-use-coding-agent-mode" in overlay["env"]["ANTHROPIC_CUSTOM_HEADERS"]
+
+    def test_disables_experimental_betas(self):
+        overlay, _ = claude.render_overlay(WS, "s4")
+        assert overlay["env"]["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] == "1"
+
+    def test_sets_api_key_helper(self):
+        overlay, _ = claude.render_overlay(WS, "s4")
+        assert "apiKeyHelper" in overlay
+        assert WS in overlay["apiKeyHelper"]
+
+    def test_model_overrides_when_all_provided(self):
+        models = {"sonnet": "s4", "opus": "o4", "haiku": "h4"}
+        overlay, _ = claude.render_overlay(WS, "s4", claude_models=models)
+        env = overlay["env"]
+        assert env["ANTHROPIC_DEFAULT_SONNET_MODEL"] == "s4"
+        assert env["ANTHROPIC_DEFAULT_OPUS_MODEL"] == "o4"
+        assert env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] == "h4"
+
+    def test_model_overrides_partial(self):
+        models = {"sonnet": "s4"}
+        overlay, _ = claude.render_overlay(WS, "s4", claude_models=models)
+        env = overlay["env"]
+        assert "ANTHROPIC_DEFAULT_SONNET_MODEL" in env
+        assert "ANTHROPIC_DEFAULT_OPUS_MODEL" not in env
+
+    def test_model_overrides_not_set_when_no_models(self):
+        overlay, _ = claude.render_overlay(WS, "s4")
+        env = overlay["env"]
+        assert "ANTHROPIC_DEFAULT_SONNET_MODEL" not in env
+
+    def test_managed_keys_include_api_key_helper(self):
+        _, keys = claude.render_overlay(WS, "s4")
+        assert ["apiKeyHelper"] in keys
+
+    def test_managed_keys_include_env_entries(self):
+        _, keys = claude.render_overlay(WS, "s4")
+        env_keys = [k for k in keys if len(k) == 2 and k[0] == "env"]
+        assert len(env_keys) > 0
+
+
+class TestClaudeDefaultModel:
+    def test_prefers_sonnet(self):
+        state = {"claude_models": {"sonnet": "s4", "opus": "o4", "haiku": "h4"}}
+        assert claude.default_model(state) == "s4"
+
+    def test_falls_back_to_opus(self):
+        state = {"claude_models": {"opus": "o4", "haiku": "h4"}}
+        assert claude.default_model(state) == "o4"
+
+    def test_falls_back_to_haiku(self):
+        state = {"claude_models": {"haiku": "h4"}}
+        assert claude.default_model(state) == "h4"
+
+    def test_returns_none_when_no_models(self):
+        assert claude.default_model({}) is None
+        assert claude.default_model({"claude_models": {}}) is None
+
+
+class TestClaudeValidateCmd:
+    def test_starts_with_binary(self):
+        cmd = claude.validate_cmd("claude")
+        assert cmd[0] == "claude"
+
+    def test_has_p_flag(self):
+        cmd = claude.validate_cmd("claude")
+        assert "-p" in cmd
+
+    def test_has_max_turns(self):
+        cmd = claude.validate_cmd("claude")
+        assert "--max-turns" in cmd
+        idx = cmd.index("--max-turns")
+        assert cmd[idx + 1] == "1"

--- a/tests/test_agent_codex.py
+++ b/tests/test_agent_codex.py
@@ -1,0 +1,74 @@
+"""Tests for agents/codex.py."""
+
+from __future__ import annotations
+
+from coding_tool_gateway.agents import codex
+
+WS = "https://example.databricks.com"
+
+
+class TestCodexSpec:
+    def test_binary(self):
+        assert codex.SPEC["binary"] == "codex"
+
+    def test_package(self):
+        assert codex.SPEC["package"] == "@openai/codex"
+
+    def test_display(self):
+        assert codex.SPEC["display"] == "Codex"
+
+
+class TestRenderOverlay:
+    def test_sets_default_profile(self):
+        overlay = codex.render_overlay(WS)
+        assert overlay["profile"] == "default"
+
+    def test_sets_model_provider(self):
+        overlay = codex.render_overlay(WS)
+        assert overlay["profiles"]["default"]["model_provider"] == "Databricks"
+
+    def test_provider_base_url(self):
+        overlay = codex.render_overlay(WS)
+        provider = overlay["model_providers"]["Databricks"]
+        assert provider["base_url"] == f"{WS}/ai-gateway/codex/v1"
+
+    def test_provider_wire_api(self):
+        overlay = codex.render_overlay(WS)
+        provider = overlay["model_providers"]["Databricks"]
+        assert provider["wire_api"] == "responses"
+
+    def test_auth_uses_sh(self):
+        overlay = codex.render_overlay(WS)
+        auth = overlay["model_providers"]["Databricks"]["auth"]
+        assert auth["command"] == "sh"
+        assert "-c" in auth["args"]
+
+    def test_auth_contains_workspace(self):
+        overlay = codex.render_overlay(WS)
+        auth = overlay["model_providers"]["Databricks"]["auth"]
+        assert any(WS in arg for arg in auth["args"])
+
+    def test_auth_refresh_interval(self):
+        overlay = codex.render_overlay(WS)
+        auth = overlay["model_providers"]["Databricks"]["auth"]
+        assert auth["refresh_interval_ms"] == 1_800_000
+
+
+class TestCodexDefaultModel:
+    def test_always_none(self):
+        assert codex.default_model({}) is None
+        assert codex.default_model({"codex_models": ["gpt-4o"]}) is None
+
+
+class TestCodexValidateCmd:
+    def test_starts_with_binary(self):
+        cmd = codex.validate_cmd("codex")
+        assert cmd[0] == "codex"
+
+    def test_uses_exec_subcommand(self):
+        cmd = codex.validate_cmd("codex")
+        assert "exec" in cmd
+
+    def test_has_prompt(self):
+        cmd = codex.validate_cmd("codex")
+        assert len(cmd) > 2

--- a/tests/test_agent_gemini.py
+++ b/tests/test_agent_gemini.py
@@ -1,0 +1,89 @@
+"""Tests for agents/gemini.py."""
+
+from __future__ import annotations
+
+from coding_tool_gateway.agents import gemini
+
+WS = "https://example.databricks.com"
+
+
+class TestGeminiSpec:
+    def test_binary(self):
+        assert gemini.SPEC["binary"] == "gemini"
+
+    def test_package(self):
+        assert gemini.SPEC["package"] == "@google/gemini-cli"
+
+    def test_display(self):
+        assert gemini.SPEC["display"] == "Gemini CLI"
+
+
+class TestRenderEnvOverlay:
+    def test_sets_gemini_model(self):
+        env = gemini.render_env_overlay(WS, "gemini-2.0-flash", "tok123")
+        assert env["GEMINI_MODEL"] == "gemini-2.0-flash"
+
+    def test_sets_base_url(self):
+        env = gemini.render_env_overlay(WS, "gemini-2.0-flash", "tok123")
+        assert env["GOOGLE_GEMINI_BASE_URL"] == f"{WS}/ai-gateway/gemini"
+
+    def test_sets_api_key(self):
+        env = gemini.render_env_overlay(WS, "gemini-2.0-flash", "tok123")
+        assert env["GEMINI_API_KEY"] == "tok123"
+
+    def test_sets_bearer_auth_mechanism(self):
+        env = gemini.render_env_overlay(WS, "gemini-2.0-flash", "tok123")
+        assert env["GEMINI_API_KEY_AUTH_MECHANISM"] == "bearer"
+
+
+class TestBuildRuntimeEnv:
+    def test_merges_os_environment(self):
+        env = gemini.build_runtime_env(WS, "gemini-2", "tok")
+        assert "PATH" in env
+
+    def test_overrides_gemini_vars(self):
+        env = gemini.build_runtime_env(WS, "gemini-2.0-flash", "mytoken")
+        assert env["GEMINI_MODEL"] == "gemini-2.0-flash"
+        assert env["GEMINI_API_KEY"] == "mytoken"
+        assert env["GEMINI_API_KEY_AUTH_MECHANISM"] == "bearer"
+
+    def test_sets_base_url(self):
+        env = gemini.build_runtime_env(WS, "gemini-2", "tok")
+        assert env["GOOGLE_GEMINI_BASE_URL"] == f"{WS}/ai-gateway/gemini"
+
+
+class TestGeminiDefaultModel:
+    def test_returns_first_model(self):
+        state = {"gemini_models": ["gemini-2", "gemini-1"]}
+        assert gemini.default_model(state) == "gemini-2"
+
+    def test_returns_none_when_empty_list(self):
+        assert gemini.default_model({"gemini_models": []}) is None
+
+    def test_returns_none_when_missing(self):
+        assert gemini.default_model({}) is None
+
+
+class TestGeminiValidateCmd:
+    def test_starts_with_binary(self):
+        cmd = gemini.validate_cmd("gemini")
+        assert cmd[0] == "gemini"
+
+    def test_has_p_flag(self):
+        cmd = gemini.validate_cmd("gemini")
+        assert "-p" in cmd
+
+    def test_has_prompt_text(self):
+        cmd = gemini.validate_cmd("gemini")
+        assert len(cmd) > 2
+
+
+class TestGeminiManagedKeys:
+    def test_managed_keys_not_empty(self):
+        assert len(gemini.MANAGED_KEYS) > 0
+
+    def test_managed_keys_includes_model(self):
+        assert "GEMINI_MODEL" in gemini.MANAGED_KEYS
+
+    def test_managed_keys_includes_api_key(self):
+        assert "GEMINI_API_KEY" in gemini.MANAGED_KEYS

--- a/tests/test_agent_opencode.py
+++ b/tests/test_agent_opencode.py
@@ -1,0 +1,193 @@
+"""Tests for agents/opencode.py."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from coding_tool_gateway.agents import opencode
+
+WS = "https://example.databricks.com"
+
+
+def _base_urls() -> dict[str, str]:
+    return {
+        "anthropic": f"{WS}/ai-gateway/anthropic/v1",
+        "gemini": f"{WS}/ai-gateway/gemini/v1beta",
+    }
+
+
+class TestOpencodeSpec:
+    def test_binary(self):
+        assert opencode.SPEC["binary"] == "opencode"
+
+    def test_package(self):
+        assert opencode.SPEC["package"] == "opencode-ai"
+
+    def test_display(self):
+        assert opencode.SPEC["display"] == "OpenCode"
+
+
+class TestRenderOverlay:
+    def test_sets_model(self):
+        overlay, _ = opencode.render_overlay("claude-sonnet", "tok", _base_urls(), {})
+        assert overlay["model"] == "claude-sonnet"
+
+    def test_anthropic_provider_added_when_models_present(self):
+        models = {"anthropic": ["claude-sonnet"], "gemini": []}
+        overlay, _ = opencode.render_overlay("claude-sonnet", "tok", _base_urls(), models)
+        assert "databricks-anthropic" in overlay["provider"]
+
+    def test_gemini_provider_added_when_models_present(self):
+        models = {"anthropic": [], "gemini": ["gemini-2"]}
+        overlay, _ = opencode.render_overlay("gemini-2", "tok", _base_urls(), models)
+        assert "databricks-google" in overlay["provider"]
+
+    def test_both_providers_when_both_present(self):
+        models = {"anthropic": ["claude-sonnet"], "gemini": ["gemini-2"]}
+        overlay, _ = opencode.render_overlay("claude-sonnet", "tok", _base_urls(), models)
+        assert "databricks-anthropic" in overlay["provider"]
+        assert "databricks-google" in overlay["provider"]
+
+    def test_no_provider_key_when_no_models(self):
+        overlay, _ = opencode.render_overlay("model", "tok", _base_urls(), {})
+        assert "provider" not in overlay
+
+    def test_anthropic_base_url(self):
+        models = {"anthropic": ["claude-sonnet"]}
+        overlay, _ = opencode.render_overlay("claude-sonnet", "tok", _base_urls(), models)
+        options = overlay["provider"]["databricks-anthropic"]["options"]
+        assert options["baseURL"] == f"{WS}/ai-gateway/anthropic/v1"
+
+    def test_gemini_base_url(self):
+        models = {"gemini": ["gemini-2"]}
+        overlay, _ = opencode.render_overlay("gemini-2", "tok", _base_urls(), models)
+        options = overlay["provider"]["databricks-google"]["options"]
+        assert options["baseURL"] == f"{WS}/ai-gateway/gemini/v1beta"
+
+    def test_token_in_api_key(self):
+        models = {"anthropic": ["claude-sonnet"]}
+        overlay, _ = opencode.render_overlay("claude-sonnet", "mytoken", _base_urls(), models)
+        assert overlay["provider"]["databricks-anthropic"]["options"]["apiKey"] == "mytoken"
+
+    def test_authorization_header(self):
+        models = {"anthropic": ["claude-sonnet"]}
+        overlay, _ = opencode.render_overlay("claude-sonnet", "tok", _base_urls(), models)
+        headers = overlay["provider"]["databricks-anthropic"]["options"]["headers"]
+        assert headers["Authorization"] == "Bearer tok"
+
+    def test_managed_keys_include_model(self):
+        _, keys = opencode.render_overlay("model", "tok", _base_urls(), {})
+        assert ["model"] in keys
+
+    def test_managed_keys_include_anthropic_provider(self):
+        models = {"anthropic": ["claude-sonnet"]}
+        _, keys = opencode.render_overlay("claude-sonnet", "tok", _base_urls(), models)
+        assert ["provider", "databricks-anthropic"] in keys
+
+    def test_managed_keys_include_gemini_provider(self):
+        models = {"gemini": ["gemini-2"]}
+        _, keys = opencode.render_overlay("gemini-2", "tok", _base_urls(), models)
+        assert ["provider", "databricks-google"] in keys
+
+    def test_anthropic_models_listed(self):
+        models = {"anthropic": ["claude-sonnet", "claude-haiku"]}
+        overlay, _ = opencode.render_overlay("claude-sonnet", "tok", _base_urls(), models)
+        provider_models = overlay["provider"]["databricks-anthropic"]["models"]
+        assert "claude-sonnet" in provider_models
+        assert "claude-haiku" in provider_models
+
+
+class TestOpencodeDefaultModel:
+    def test_prefers_anthropic(self):
+        state = {"opencode_models": {"anthropic": ["claude-sonnet"], "gemini": ["gemini-2"]}}
+        assert opencode.default_model(state) == "claude-sonnet"
+
+    def test_falls_back_to_gemini(self):
+        state = {"opencode_models": {"anthropic": [], "gemini": ["gemini-2"]}}
+        assert opencode.default_model(state) == "gemini-2"
+
+    def test_returns_none_when_empty(self):
+        assert opencode.default_model({}) is None
+        assert opencode.default_model({"opencode_models": {}}) is None
+
+
+class TestOpencodeValidateCmd:
+    def test_starts_with_binary(self):
+        cmd = opencode.validate_cmd("opencode")
+        assert cmd[0] == "opencode"
+
+    def test_uses_run_subcommand(self):
+        cmd = opencode.validate_cmd("opencode")
+        assert "run" in cmd
+
+    def test_has_prompt(self):
+        cmd = opencode.validate_cmd("opencode")
+        assert len(cmd) > 2
+
+
+class TestWriteToolConfigStaleProviderCleanup:
+    def test_stale_providers_removed_before_merge(self, tmp_path, monkeypatch):
+        import coding_tool_gateway.agents.opencode as oc_mod
+        import coding_tool_gateway.config_io as config_io_mod
+
+        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
+        config_file = tmp_path / "opencode.json"
+        backup_file = tmp_path / "opencode-backup.json"
+        monkeypatch.setattr(oc_mod, "OPENCODE_CONFIG_PATH", config_file)
+        monkeypatch.setattr(oc_mod, "OPENCODE_BACKUP_PATH", backup_file)
+
+        stale = {
+            "provider": {
+                "databricks-anthropic": {"old": True},
+                "databricks-google": {"old": True},
+                "other-provider": {"keep": True},
+            }
+        }
+        config_file.write_text(json.dumps(stale), encoding="utf-8")
+
+        state = {
+            "workspace": WS,
+            "base_urls": {"opencode": _base_urls()},
+            "opencode_models": {"anthropic": ["claude-sonnet"]},
+            "managed_configs": {},
+        }
+
+        with (
+            patch("coding_tool_gateway.agents.opencode.get_databricks_token", return_value="tok"),
+            patch("coding_tool_gateway.state.save_state"),
+        ):
+            oc_mod.write_tool_config(state, "claude-sonnet", token="tok")
+
+        written = json.loads(config_file.read_text())
+        providers = written.get("provider", {})
+        # stale entry is replaced with new data, not kept as-is
+        assert providers.get("databricks-anthropic") != {"old": True}
+        # unmanaged provider entry survives
+        assert providers.get("other-provider") == {"keep": True}
+
+    def test_config_written_with_correct_model(self, tmp_path, monkeypatch):
+        import coding_tool_gateway.agents.opencode as oc_mod
+        import coding_tool_gateway.config_io as config_io_mod
+
+        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
+        config_file = tmp_path / "opencode.json"
+        backup_file = tmp_path / "opencode-backup.json"
+        monkeypatch.setattr(oc_mod, "OPENCODE_CONFIG_PATH", config_file)
+        monkeypatch.setattr(oc_mod, "OPENCODE_BACKUP_PATH", backup_file)
+
+        state = {
+            "workspace": WS,
+            "base_urls": {"opencode": _base_urls()},
+            "opencode_models": {"anthropic": ["claude-sonnet"]},
+            "managed_configs": {},
+        }
+
+        with (
+            patch("coding_tool_gateway.agents.opencode.get_databricks_token", return_value="tok"),
+            patch("coding_tool_gateway.state.save_state"),
+        ):
+            oc_mod.write_tool_config(state, "claude-sonnet", token="tok")
+
+        written = json.loads(config_file.read_text())
+        assert written["model"] == "claude-sonnet"

--- a/tests/test_agents_init.py
+++ b/tests/test_agents_init.py
@@ -1,0 +1,123 @@
+"""Tests for agents/__init__.py — registry, dispatchers, normalize_tool."""
+
+from __future__ import annotations
+
+import pytest
+
+from coding_tool_gateway.agents import (
+    DEFAULT_TOOL,
+    TOOL_SPECS,
+    check_gateway_endpoint,
+    default_model_for_tool,
+    normalize_tool,
+    resolve_launch_model,
+)
+
+
+class TestToolSpecs:
+    def test_all_four_tools_present(self):
+        assert set(TOOL_SPECS) == {"codex", "claude", "gemini", "opencode"}
+
+    def test_each_spec_has_required_keys(self):
+        required = {"binary", "package", "display", "config_path", "backup_path"}
+        for tool, spec in TOOL_SPECS.items():
+            missing = required - set(spec)
+            assert not missing, f"{tool} spec missing: {missing}"
+
+    def test_default_tool_is_codex(self):
+        assert DEFAULT_TOOL == "codex"
+
+
+class TestNormalizeTool:
+    @pytest.mark.parametrize(
+        "alias,expected",
+        [
+            ("codex", "codex"),
+            ("claude", "claude"),
+            ("claude-code", "claude"),
+            ("gemini", "gemini"),
+            ("gemini-cli", "gemini"),
+            ("opencode", "opencode"),
+            ("CODEX", "codex"),
+            ("  Claude  ", "claude"),
+        ],
+    )
+    def test_known_aliases(self, alias, expected):
+        assert normalize_tool(alias) == expected
+
+    def test_unknown_raises(self):
+        with pytest.raises(RuntimeError, match="Unsupported"):
+            normalize_tool("unknown-agent")
+
+
+class TestCheckGatewayEndpoint:
+    def test_claude_available_when_models_present(self):
+        assert check_gateway_endpoint({"claude_models": {"sonnet": "s4"}}, "claude") is True
+
+    def test_claude_unavailable_when_no_models(self):
+        assert check_gateway_endpoint({"claude_models": {}}, "claude") is False
+        assert check_gateway_endpoint({}, "claude") is False
+
+    def test_codex_available(self):
+        assert check_gateway_endpoint({"codex_models": ["model-a"]}, "codex") is True
+
+    def test_gemini_available(self):
+        assert check_gateway_endpoint({"gemini_models": ["gemini-2"]}, "gemini") is True
+
+    def test_opencode_available(self):
+        state = {"opencode_models": {"anthropic": ["claude-sonnet"]}}
+        assert check_gateway_endpoint(state, "opencode") is True
+
+
+class TestDefaultModelForTool:
+    def test_codex_always_none(self):
+        assert default_model_for_tool("codex", {}) is None
+
+    def test_claude_prefers_sonnet(self):
+        state = {"claude_models": {"sonnet": "s4", "opus": "o4", "haiku": "h4"}}
+        assert default_model_for_tool("claude", state) == "s4"
+
+    def test_claude_falls_back_to_opus(self):
+        state = {"claude_models": {"opus": "o4"}}
+        assert default_model_for_tool("claude", state) == "o4"
+
+    def test_claude_falls_back_to_haiku(self):
+        state = {"claude_models": {"haiku": "h4"}}
+        assert default_model_for_tool("claude", state) == "h4"
+
+    def test_claude_returns_none_when_no_models(self):
+        assert default_model_for_tool("claude", {}) is None
+
+    def test_gemini_returns_first_model(self):
+        state = {"gemini_models": ["gemini-2", "gemini-1"]}
+        assert default_model_for_tool("gemini", state) == "gemini-2"
+
+    def test_gemini_returns_none_when_no_models(self):
+        assert default_model_for_tool("gemini", {}) is None
+
+    def test_opencode_prefers_anthropic(self):
+        state = {"opencode_models": {"anthropic": ["claude-sonnet"], "gemini": ["gemini-2"]}}
+        assert default_model_for_tool("opencode", state) == "claude-sonnet"
+
+    def test_opencode_falls_back_to_gemini(self):
+        state = {"opencode_models": {"gemini": ["gemini-2"]}}
+        assert default_model_for_tool("opencode", state) == "gemini-2"
+
+
+class TestResolveLaunchModel:
+    def test_codex_always_returns_none_model(self):
+        state, model = resolve_launch_model("codex", {}, None)
+        assert model is None
+
+    def test_explicit_model_used_when_provided(self):
+        _, model = resolve_launch_model("claude", {}, "my-model")
+        assert model == "my-model"
+
+    def test_default_model_used_when_no_explicit(self):
+        state = {"claude_models": {"sonnet": "s4"}}
+        _, model = resolve_launch_model("claude", state, None)
+        assert model == "s4"
+
+    def test_raises_when_no_models_available(self):
+        with pytest.raises(RuntimeError, match="No models available"):
+            resolve_launch_model("claude", {}, None)

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -1,0 +1,315 @@
+"""Tests for config_io.py — file I/O helpers, dry-run flag, deep_merge_dict."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import tomlkit
+
+import coding_tool_gateway.config_io as config_io
+from coding_tool_gateway.config_io import (
+    backup_existing_file,
+    deep_merge_dict,
+    ensure_parent_dir,
+    is_dry_run,
+    parse_dotenv,
+    read_json_safe,
+    read_toml_safe,
+    restore_file,
+    set_dry_run,
+    write_dotenv,
+    write_json_file,
+    write_text_file,
+    write_toml_file,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_dry_run():
+    """Ensure dry-run flag is reset after every test."""
+    set_dry_run(False)
+    yield
+    set_dry_run(False)
+
+
+# ---------------------------------------------------------------------------
+# dry-run flag
+# ---------------------------------------------------------------------------
+
+
+class TestDryRunFlag:
+    def test_default_is_false(self):
+        assert is_dry_run() is False
+
+    def test_set_true(self):
+        set_dry_run(True)
+        assert is_dry_run() is True
+
+    def test_reset_to_false(self):
+        set_dry_run(True)
+        set_dry_run(False)
+        assert is_dry_run() is False
+
+
+# ---------------------------------------------------------------------------
+# ensure_parent_dir
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureParentDir:
+    def test_creates_missing_parents(self, tmp_path):
+        target = tmp_path / "a" / "b" / "c" / "file.txt"
+        ensure_parent_dir(target)
+        assert target.parent.exists()
+
+    def test_existing_dir_is_ok(self, tmp_path):
+        ensure_parent_dir(tmp_path / "file.txt")  # tmp_path already exists
+
+
+# ---------------------------------------------------------------------------
+# backup_existing_file / restore_file
+# ---------------------------------------------------------------------------
+
+
+class TestBackupAndRestore:
+    def test_backup_copies_file(self, tmp_path, monkeypatch):
+        config = tmp_path / "config.json"
+        backup = tmp_path / "backup.json"
+        config.write_text('{"key": "value"}', encoding="utf-8")
+        monkeypatch.setattr(config_io, "APP_DIR", tmp_path)
+
+        result = backup_existing_file(config, backup)
+
+        assert result is True
+        assert backup.exists()
+        assert backup.read_text() == config.read_text()
+
+    def test_backup_skipped_when_config_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(config_io, "APP_DIR", tmp_path)
+        result = backup_existing_file(tmp_path / "missing.json", tmp_path / "backup.json")
+        assert result is False
+
+    def test_backup_idempotent_when_backup_exists(self, tmp_path, monkeypatch):
+        config = tmp_path / "config.json"
+        backup = tmp_path / "backup.json"
+        config.write_text("new", encoding="utf-8")
+        backup.write_text("old", encoding="utf-8")
+        monkeypatch.setattr(config_io, "APP_DIR", tmp_path)
+
+        backup_existing_file(config, backup)
+
+        assert backup.read_text() == "old"  # original backup preserved
+
+    def test_backup_skipped_in_dry_run(self, tmp_path, monkeypatch):
+        config = tmp_path / "config.json"
+        backup = tmp_path / "backup.json"
+        config.write_text("data", encoding="utf-8")
+        monkeypatch.setattr(config_io, "APP_DIR", tmp_path)
+        set_dry_run(True)
+
+        result = backup_existing_file(config, backup)
+
+        assert result is False
+        assert not backup.exists()
+
+    def test_restore_from_backup(self, tmp_path):
+        config = tmp_path / "config.json"
+        backup = tmp_path / "backup.json"
+        backup.write_text("original", encoding="utf-8")
+
+        result = restore_file(config, backup, managed=True)
+
+        assert result is True
+        assert config.read_text() == "original"
+        assert not backup.exists()
+
+    def test_restore_deletes_managed_config_when_no_backup(self, tmp_path):
+        config = tmp_path / "config.json"
+        config.write_text("managed", encoding="utf-8")
+
+        result = restore_file(config, tmp_path / "no-backup.json", managed=True)
+
+        assert result is True
+        assert not config.exists()
+
+    def test_restore_returns_false_when_nothing_to_do(self, tmp_path):
+        result = restore_file(
+            tmp_path / "missing.json",
+            tmp_path / "also-missing.json",
+            managed=False,
+        )
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# write_text_file / write_json_file / write_toml_file / write_dotenv
+# ---------------------------------------------------------------------------
+
+
+class TestWriteHelpers:
+    def test_write_text_file(self, tmp_path):
+        p = tmp_path / "out.txt"
+        write_text_file(p, "hello")
+        assert p.read_text() == "hello"
+
+    def test_write_text_file_dry_run_no_write(self, tmp_path):
+        set_dry_run(True)
+        p = tmp_path / "out.txt"
+        write_text_file(p, "hello")
+        assert not p.exists()
+
+    def test_write_json_file(self, tmp_path):
+        p = tmp_path / "out.json"
+        write_json_file(p, {"a": 1})
+        data = json.loads(p.read_text())
+        assert data == {"a": 1}
+
+    def test_write_json_file_dry_run_no_write(self, tmp_path):
+        set_dry_run(True)
+        p = tmp_path / "out.json"
+        write_json_file(p, {"a": 1})
+        assert not p.exists()
+
+    def test_write_toml_file(self, tmp_path):
+        p = tmp_path / "out.toml"
+        doc = tomlkit.document()
+        doc.add("key", "val")
+        write_toml_file(p, doc)
+        assert "key" in p.read_text()
+
+    def test_write_toml_file_dry_run_no_write(self, tmp_path):
+        set_dry_run(True)
+        p = tmp_path / "out.toml"
+        doc = tomlkit.document()
+        doc.add("key", "val")
+        write_toml_file(p, doc)
+        assert not p.exists()
+
+    def test_write_dotenv(self, tmp_path):
+        p = tmp_path / ".env"
+        write_dotenv(p, {"KEY": "value", "OTHER": "123"})
+        text = p.read_text()
+        assert 'KEY="value"' in text
+        assert 'OTHER="123"' in text
+
+
+# ---------------------------------------------------------------------------
+# read_json_safe / read_toml_safe
+# ---------------------------------------------------------------------------
+
+
+class TestReadHelpers:
+    def test_read_json_safe_missing_file(self, tmp_path):
+        result = read_json_safe(tmp_path / "missing.json")
+        assert result == {}
+
+    def test_read_json_safe_valid(self, tmp_path):
+        p = tmp_path / "data.json"
+        p.write_text('{"x": 1}', encoding="utf-8")
+        assert read_json_safe(p) == {"x": 1}
+
+    def test_read_json_safe_invalid_json(self, tmp_path):
+        p = tmp_path / "bad.json"
+        p.write_text("not json", encoding="utf-8")
+        assert read_json_safe(p) == {}
+
+    def test_read_json_safe_non_dict(self, tmp_path):
+        p = tmp_path / "arr.json"
+        p.write_text("[1, 2, 3]", encoding="utf-8")
+        assert read_json_safe(p) == {}
+
+    def test_read_toml_safe_missing_file(self, tmp_path):
+        doc = read_toml_safe(tmp_path / "missing.toml")
+        assert dict(doc) == {}
+
+    def test_read_toml_safe_valid(self, tmp_path):
+        p = tmp_path / "config.toml"
+        p.write_text('[section]\nkey = "val"\n', encoding="utf-8")
+        doc = read_toml_safe(p)
+        assert doc["section"]["key"] == "val"
+
+    def test_read_toml_safe_invalid(self, tmp_path):
+        p = tmp_path / "bad.toml"
+        p.write_text("[[[ broken", encoding="utf-8")
+        doc = read_toml_safe(p)
+        assert dict(doc) == {}
+
+
+# ---------------------------------------------------------------------------
+# parse_dotenv
+# ---------------------------------------------------------------------------
+
+
+class TestParseDotenv:
+    def test_simple_pairs(self, tmp_path):
+        p = tmp_path / ".env"
+        p.write_text("KEY=value\nOTHER=123\n", encoding="utf-8")
+        assert parse_dotenv(p) == {"KEY": "value", "OTHER": "123"}
+
+    def test_quoted_values(self, tmp_path):
+        p = tmp_path / ".env"
+        p.write_text("KEY=\"quoted\"\nSINGLE='also'\n", encoding="utf-8")
+        assert parse_dotenv(p) == {"KEY": "quoted", "SINGLE": "also"}
+
+    def test_skips_comments_and_blank_lines(self, tmp_path):
+        p = tmp_path / ".env"
+        p.write_text("# comment\n\nKEY=value\n", encoding="utf-8")
+        assert parse_dotenv(p) == {"KEY": "value"}
+
+    def test_skips_lines_without_equals(self, tmp_path):
+        p = tmp_path / ".env"
+        p.write_text("NOEQUALSSIGN\nKEY=value\n", encoding="utf-8")
+        assert parse_dotenv(p) == {"KEY": "value"}
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert parse_dotenv(tmp_path / "missing.env") == {}
+
+    def test_value_with_equals(self, tmp_path):
+        p = tmp_path / ".env"
+        p.write_text("URL=http://example.com?a=1\n", encoding="utf-8")
+        assert parse_dotenv(p) == {"URL": "http://example.com?a=1"}
+
+
+# ---------------------------------------------------------------------------
+# deep_merge_dict
+# ---------------------------------------------------------------------------
+
+
+class TestDeepMergeDict:
+    def test_flat_overlay_wins(self):
+        base = {"a": 1, "b": 2}
+        result = deep_merge_dict(base, {"b": 99, "c": 3})
+        assert result == {"a": 1, "b": 99, "c": 3}
+
+    def test_nested_merge(self):
+        base = {"env": {"X": "1", "Y": "2"}}
+        overlay = {"env": {"Y": "new", "Z": "3"}}
+        result = deep_merge_dict(base, overlay)
+        assert result == {"env": {"X": "1", "Y": "new", "Z": "3"}}
+
+    def test_overlay_replaces_non_dict_with_dict(self):
+        base = {"key": "scalar"}
+        overlay = {"key": {"nested": True}}
+        result = deep_merge_dict(base, overlay)
+        assert result == {"key": {"nested": True}}
+
+    def test_overlay_replaces_dict_with_scalar(self):
+        base = {"key": {"nested": True}}
+        overlay = {"key": "scalar"}
+        result = deep_merge_dict(base, overlay)
+        assert result == {"key": "scalar"}
+
+    def test_empty_overlay_leaves_base_unchanged(self):
+        base = {"a": 1}
+        result = deep_merge_dict(base, {})
+        assert result == {"a": 1}
+
+    def test_empty_base_returns_overlay(self):
+        result = deep_merge_dict({}, {"a": 1})
+        assert result == {"a": 1}
+
+    def test_mutates_and_returns_base(self):
+        base = {"a": 1}
+        result = deep_merge_dict(base, {"b": 2})
+        assert result is base

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -1,0 +1,156 @@
+"""Tests for databricks.py — pure helpers and URL builders that don't hit the network."""
+
+from __future__ import annotations
+
+import pytest
+
+from coding_tool_gateway.databricks import (
+    AI_GATEWAY_V2_DOCS_URL,
+    build_auth_shell_command,
+    build_databricks_cli_env,
+    build_opencode_base_urls,
+    build_shared_base_urls,
+    build_tool_base_url,
+    workspace_hostname,
+)
+
+WS = "https://example.databricks.com"
+
+
+class TestWorkspaceHostname:
+    def test_extracts_hostname(self):
+        assert workspace_hostname(WS) == "example.databricks.com"
+
+    def test_handles_path(self):
+        assert (
+            workspace_hostname("https://foo.azuredatabricks.net/some/path")
+            == "foo.azuredatabricks.net"
+        )
+
+    def test_invalid_url_raises(self):
+        with pytest.raises((RuntimeError, ValueError)):
+            workspace_hostname("")
+
+
+class TestBuildDatabricksCliEnv:
+    def test_sets_databricks_host(self):
+        env = build_databricks_cli_env(WS)
+        assert env["DATABRICKS_HOST"] == WS
+
+    def test_scrubs_token_vars(self):
+        import coding_tool_gateway.databricks as db_mod
+
+        for var in db_mod.SCRUBBED_DATABRICKS_ENV_VARS:
+            env = build_databricks_cli_env(WS)
+            assert var not in env
+
+
+class TestBuildToolBaseUrl:
+    def test_codex(self):
+        url = build_tool_base_url("codex", WS)
+        assert url == f"{WS}/ai-gateway/codex/v1"
+
+    def test_claude(self):
+        url = build_tool_base_url("claude", WS)
+        assert url == f"{WS}/ai-gateway/anthropic"
+
+    def test_gemini(self):
+        url = build_tool_base_url("gemini", WS)
+        assert url == f"{WS}/ai-gateway/gemini"
+
+    def test_opencode_raises(self):
+        with pytest.raises(RuntimeError, match="multiple base URLs"):
+            build_tool_base_url("opencode", WS)
+
+    def test_unsupported_tool_raises(self):
+        with pytest.raises(RuntimeError, match="Unsupported"):
+            build_tool_base_url("unknown", WS)
+
+
+class TestBuildOpencodeBaseUrls:
+    def test_returns_anthropic_and_gemini(self):
+        urls = build_opencode_base_urls(WS)
+        assert urls["anthropic"] == f"{WS}/ai-gateway/anthropic/v1"
+        assert urls["gemini"] == f"{WS}/ai-gateway/gemini/v1beta"
+
+
+class TestBuildSharedBaseUrls:
+    def test_contains_all_tools(self):
+        urls = build_shared_base_urls(WS)
+        assert "codex" in urls
+        assert "claude" in urls
+        assert "gemini" in urls
+        assert "opencode" in urls
+
+    def test_opencode_is_dict(self):
+        urls = build_shared_base_urls(WS)
+        assert isinstance(urls["opencode"], dict)
+
+    def test_codex_url_format(self):
+        urls = build_shared_base_urls(WS)
+        assert urls["codex"] == f"{WS}/ai-gateway/codex/v1"
+
+
+class TestBuildAuthShellCommand:
+    def test_contains_workspace(self):
+        cmd = build_auth_shell_command(WS)
+        assert WS in cmd
+
+    def test_pipes_through_python(self):
+        cmd = build_auth_shell_command(WS)
+        assert "python3" in cmd
+        assert "access_token" in cmd
+
+    def test_unsets_scrubbed_vars(self):
+        cmd = build_auth_shell_command(WS)
+        assert "DATABRICKS_TOKEN" in cmd
+
+
+class TestEnsureAiGatewayV2:
+    """Test ensure_ai_gateway_v2 without real network calls."""
+
+    def test_raises_on_404(self):
+        from unittest.mock import MagicMock, patch
+        from urllib.error import HTTPError
+
+        exc = HTTPError(url="", code=404, msg="Not Found", hdrs=MagicMock(), fp=None)
+        with patch("coding_tool_gateway.databricks.urllib_request.urlopen", side_effect=exc):
+            from coding_tool_gateway.databricks import ensure_ai_gateway_v2
+
+            with pytest.raises(RuntimeError, match=AI_GATEWAY_V2_DOCS_URL):
+                ensure_ai_gateway_v2(WS, "fake-token")
+
+    def test_raises_on_url_error(self):
+        from unittest.mock import patch
+        from urllib.error import URLError
+
+        with patch(
+            "coding_tool_gateway.databricks.urllib_request.urlopen",
+            side_effect=URLError("connection refused"),
+        ):
+            from coding_tool_gateway.databricks import ensure_ai_gateway_v2
+
+            with pytest.raises(RuntimeError, match=AI_GATEWAY_V2_DOCS_URL):
+                ensure_ai_gateway_v2(WS, "fake-token")
+
+    def test_succeeds_on_non_404_http_error(self):
+        from unittest.mock import MagicMock, patch
+        from urllib.error import HTTPError
+
+        # 405 Method Not Allowed → still means v2 is there (method mismatch, not missing route)
+        exc = HTTPError(url="", code=405, msg="Method Not Allowed", hdrs=MagicMock(), fp=None)
+        with patch("coding_tool_gateway.databricks.urllib_request.urlopen", side_effect=exc):
+            from coding_tool_gateway.databricks import ensure_ai_gateway_v2
+
+            ensure_ai_gateway_v2(WS, "fake-token")  # should not raise
+
+    def test_succeeds_when_urlopen_returns(self):
+        from unittest.mock import MagicMock, patch
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        with patch("coding_tool_gateway.databricks.urllib_request.urlopen", return_value=mock_resp):
+            from coding_tool_gateway.databricks import ensure_ai_gateway_v2
+
+            ensure_ai_gateway_v2(WS, "fake-token")  # should not raise

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,370 @@
+"""End-to-end integration tests that require a live Databricks workspace.
+
+Run with:
+    CODING_GATEWAY_TEST_WORKSPACE=https://your-workspace.databricks.com uv run pytest tests/test_e2e.py -v
+
+All tests in this file are skipped automatically when the env var is not set.
+The agent-launch tests are also skipped per-agent/model when the binary is not
+installed or no models are available.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from coding_tool_gateway.databricks import (
+    build_shared_base_urls,
+    build_tool_base_url,
+    discover_sql_warehouse_http_path,
+    ensure_ai_gateway_v2,
+    fetch_ai_gateway_claude_models,
+    fetch_codex_models,
+    fetch_gemini_models,
+    has_valid_databricks_auth,
+    workspace_hostname,
+)
+from coding_tool_gateway.ui import normalize_workspace_url
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ws() -> str:
+    raw = os.environ.get("CODING_GATEWAY_TEST_WORKSPACE", "").strip().rstrip("/")
+    return normalize_workspace_url(raw) if raw else ""
+
+
+def _skip_if_no_workspace():
+    if not _ws():
+        pytest.skip("Set CODING_GATEWAY_TEST_WORKSPACE=https://... to run E2E tests")
+
+
+def _run_agent(
+    cmd: list[str], env: dict | None = None, timeout: int = 60
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Databricks auth / token
+# ---------------------------------------------------------------------------
+
+
+class TestDatabricksAuth:
+    def test_has_valid_auth(self, e2e_workspace):
+        assert has_valid_databricks_auth(e2e_workspace), (
+            "No valid Databricks auth found. Run `databricks auth login` first."
+        )
+
+    def test_get_token_returns_non_empty_string(self, e2e_token):
+        assert isinstance(e2e_token, str) and len(e2e_token) > 10
+
+
+# ---------------------------------------------------------------------------
+# AI Gateway v2 probe
+# ---------------------------------------------------------------------------
+
+
+class TestAiGatewayV2:
+    def test_ensure_ai_gateway_v2_does_not_raise(self, e2e_workspace, e2e_token):
+        ensure_ai_gateway_v2(e2e_workspace, e2e_token)
+
+    def test_workspace_hostname_resolves(self, e2e_workspace):
+        hostname = workspace_hostname(e2e_workspace)
+        assert "." in hostname
+
+
+# ---------------------------------------------------------------------------
+# Model discovery
+# ---------------------------------------------------------------------------
+
+
+class TestModelDiscovery:
+    def test_fetch_claude_models_returns_dict(self, e2e_workspace, e2e_token):
+        models = fetch_ai_gateway_claude_models(e2e_workspace, e2e_token)
+        assert isinstance(models, dict)
+        assert models, "No Claude models found — is the Anthropic route enabled on this workspace?"
+
+    def test_fetch_gemini_models_returns_list(self, e2e_workspace, e2e_token):
+        models = fetch_gemini_models(e2e_workspace, e2e_token)
+        assert isinstance(models, list)
+
+    def test_fetch_codex_models_returns_list(self, e2e_workspace, e2e_token):
+        models = fetch_codex_models(e2e_workspace, e2e_token)
+        assert isinstance(models, list)
+
+
+# ---------------------------------------------------------------------------
+# URL builders
+# ---------------------------------------------------------------------------
+
+
+class TestUrlBuilders:
+    def test_codex_url_contains_workspace(self, e2e_workspace):
+        assert e2e_workspace in build_tool_base_url("codex", e2e_workspace)
+
+    def test_claude_url_contains_workspace(self, e2e_workspace):
+        assert e2e_workspace in build_tool_base_url("claude", e2e_workspace)
+
+    def test_shared_base_urls_all_tools(self, e2e_workspace):
+        urls = build_shared_base_urls(e2e_workspace)
+        for tool in ("codex", "claude", "gemini", "opencode"):
+            assert tool in urls
+
+
+# ---------------------------------------------------------------------------
+# State round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestStateRoundTrip:
+    def test_configure_shared_state_and_reload(
+        self, tmp_path, monkeypatch, e2e_state, e2e_workspace
+    ):
+        import coding_tool_gateway.config_io as config_io_mod
+        import coding_tool_gateway.state as state_mod
+        from coding_tool_gateway.state import load_state, save_state
+
+        monkeypatch.setattr(state_mod, "STATE_PATH", tmp_path / "state.json")
+        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
+
+        save_state(e2e_state)
+        loaded = load_state()
+        assert loaded["workspace"] == e2e_workspace
+        assert loaded["claude_models"] == e2e_state["claude_models"]
+        assert loaded["base_urls"]["codex"] == f"{e2e_workspace}/ai-gateway/codex/v1"
+
+
+# ---------------------------------------------------------------------------
+# SQL warehouse discovery
+# ---------------------------------------------------------------------------
+
+
+class TestSqlWarehouseDiscovery:
+    def test_discovers_http_path(self, e2e_workspace, e2e_token):
+        try:
+            http_path = discover_sql_warehouse_http_path(e2e_workspace, e2e_token, quiet=True)
+        except RuntimeError as exc:
+            pytest.skip(f"No SQL warehouse available: {exc}")
+        assert http_path.startswith("/sql/1.0/warehouses/")
+
+
+# ---------------------------------------------------------------------------
+# Agent launch tests — one test per (agent, model)
+# ---------------------------------------------------------------------------
+#
+# Each test:
+#   1. Writes the agent config for the specific model
+#   2. Runs the binary with the validate_cmd prompt
+#   3. Asserts exit code 0 and non-empty stdout
+#
+# Tests are skipped when the binary is not installed or no models are available.
+# ---------------------------------------------------------------------------
+
+
+def _require_binary(binary: str):
+    if not shutil.which(binary):
+        pytest.skip(f"`{binary}` is not installed")
+
+
+class TestCodexLaunch:
+    """Run codex against every available codex model."""
+
+    def _codex_models(self, e2e_state: dict) -> list[str]:
+        models = e2e_state.get("codex_models") or []
+        if not models:
+            pytest.skip("No Codex models available on this workspace")
+        return models
+
+    def test_launch_codex_per_model(self, tmp_path, monkeypatch, e2e_state, e2e_workspace):
+        """Parametrized inline — iterates over all codex models and asserts each works."""
+        import coding_tool_gateway.config_io as config_io_mod
+        from coding_tool_gateway.agents import codex
+
+        _require_binary("codex")
+        models = self._codex_models(e2e_state)
+
+        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
+        config_dir = tmp_path / "codex_home" / ".codex"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "config.toml"
+        backup_path = tmp_path / "codex-config.backup.toml"
+        monkeypatch.setattr(codex, "CODEX_CONFIG_PATH", config_path)
+        monkeypatch.setattr(codex, "CODEX_BACKUP_PATH", backup_path)
+
+        failures = []
+        for model in models:
+            state = {**e2e_state, "workspace": e2e_workspace}
+            with pytest.MonkeyPatch().context() as mp:
+                mp.setattr("coding_tool_gateway.state.save_state", lambda s: None)
+                codex.write_tool_config(state)
+
+            cmd = codex.validate_cmd("codex")
+            result = _run_agent(cmd)
+            if result.returncode != 0 or not (result.stdout or result.stderr).strip():
+                failures.append(
+                    f"model={model} rc={result.returncode} "
+                    f"stdout={result.stdout[:200]!r} stderr={result.stderr[:200]!r}"
+                )
+
+        assert not failures, "Codex launch failures:\n" + "\n".join(failures)
+
+
+class TestClaudeLaunch:
+    """Run claude against every available claude model (sonnet, opus, haiku)."""
+
+    def test_launch_claude_per_model(
+        self, tmp_path, monkeypatch, e2e_state, e2e_workspace, e2e_token
+    ):
+        import coding_tool_gateway.config_io as config_io_mod
+        from coding_tool_gateway.agents import claude
+
+        _require_binary("claude")
+        claude_models: dict = e2e_state.get("claude_models") or {}
+        if not claude_models:
+            pytest.skip("No Claude models available on this workspace")
+
+        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
+        config_path = tmp_path / "claude-settings.json"
+        backup_path = tmp_path / "claude-settings.backup.json"
+        monkeypatch.setattr(claude, "CLAUDE_SETTINGS_PATH", config_path)
+        monkeypatch.setattr(claude, "CLAUDE_BACKUP_PATH", backup_path)
+
+        base_url = build_tool_base_url("claude", e2e_workspace)
+
+        failures = []
+        for family, model_id in claude_models.items():
+            with pytest.MonkeyPatch().context() as mp:
+                mp.setattr("coding_tool_gateway.state.save_state", lambda s: None)
+                claude.write_tool_config({**e2e_state, "workspace": e2e_workspace}, model_id)
+
+            env = {
+                **os.environ,
+                "ANTHROPIC_MODEL": model_id,
+                "ANTHROPIC_BASE_URL": base_url,
+                "ANTHROPIC_API_KEY": e2e_token,
+                "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+            }
+            cmd = claude.validate_cmd("claude")
+            result = _run_agent(cmd, env=env, timeout=90)
+            combined = (result.stdout + result.stderr).strip()
+            if result.returncode != 0 or not combined:
+                failures.append(
+                    f"family={family} model={model_id} rc={result.returncode} "
+                    f"stdout={result.stdout[:300]!r} stderr={result.stderr[:300]!r}"
+                )
+
+        assert not failures, "Claude launch failures:\n" + "\n".join(failures)
+
+
+class TestGeminiLaunch:
+    """Run gemini against every available gemini model."""
+
+    def test_launch_gemini_per_model(
+        self, tmp_path, monkeypatch, e2e_state, e2e_workspace, e2e_token
+    ):
+        import coding_tool_gateway.config_io as config_io_mod
+        from coding_tool_gateway.agents import gemini
+
+        _require_binary("gemini")
+        gemini_models: list = e2e_state.get("gemini_models") or []
+        if not gemini_models:
+            pytest.skip("No Gemini models available on this workspace")
+
+        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
+        env_path = tmp_path / ".env"
+        backup_path = tmp_path / "gemini-env.backup"
+        monkeypatch.setattr(gemini, "GEMINI_ENV_PATH", env_path)
+        monkeypatch.setattr(gemini, "GEMINI_BACKUP_PATH", backup_path)
+
+        failures = []
+        for model in gemini_models:
+            with pytest.MonkeyPatch().context() as mp:
+                mp.setattr("coding_tool_gateway.state.save_state", lambda s: None)
+                mp.setattr(
+                    "coding_tool_gateway.agents.gemini.get_databricks_token", lambda ws: e2e_token
+                )
+                gemini.write_tool_config(
+                    {**e2e_state, "workspace": e2e_workspace}, model, token=e2e_token
+                )
+
+            env = gemini.build_runtime_env(e2e_workspace, model, e2e_token)
+            cmd = gemini.validate_cmd("gemini")
+            result = _run_agent(cmd, env=env, timeout=90)
+            combined = (result.stdout + result.stderr).strip()
+            if result.returncode != 0 or not combined:
+                failures.append(
+                    f"model={model} rc={result.returncode} "
+                    f"stdout={result.stdout[:300]!r} stderr={result.stderr[:300]!r}"
+                )
+
+        assert not failures, "Gemini launch failures:\n" + "\n".join(failures)
+
+
+class TestOpencodeLaunch:
+    """Run opencode against every available opencode model (anthropic + gemini)."""
+
+    def _all_models(self, e2e_state: dict) -> list[tuple[str, str]]:
+        """Return [(provider, model_id), ...] for all opencode models."""
+        opencode_models: dict = e2e_state.get("opencode_models") or {}
+        out: list[tuple[str, str]] = []
+        for provider, models in opencode_models.items():
+            for model in models or []:
+                out.append((provider, model))
+        return out
+
+    def test_launch_opencode_per_model(
+        self, tmp_path, monkeypatch, e2e_state, e2e_workspace, e2e_token
+    ):
+        import coding_tool_gateway.config_io as config_io_mod
+        from coding_tool_gateway.agents import opencode
+
+        _require_binary("opencode")
+        models = self._all_models(e2e_state)
+        if not models:
+            pytest.skip("No OpenCode models available on this workspace")
+
+        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
+        config_path = tmp_path / "opencode.json"
+        backup_path = tmp_path / "opencode-config.backup.json"
+        monkeypatch.setattr(opencode, "OPENCODE_CONFIG_PATH", config_path)
+        monkeypatch.setattr(opencode, "OPENCODE_BACKUP_PATH", backup_path)
+
+        failures = []
+        for provider, model in models:
+            # Reset config file before each model so configs don't bleed together
+            if config_path.exists():
+                config_path.unlink()
+
+            with pytest.MonkeyPatch().context() as mp:
+                mp.setattr("coding_tool_gateway.state.save_state", lambda s: None)
+                mp.setattr(
+                    "coding_tool_gateway.agents.opencode.get_databricks_token", lambda ws: e2e_token
+                )
+                opencode.write_tool_config(
+                    {**e2e_state, "workspace": e2e_workspace},
+                    model,
+                    token=e2e_token,
+                )
+
+            cmd = opencode.validate_cmd("opencode")
+            result = _run_agent(cmd, timeout=90)
+            combined = (result.stdout + result.stderr).strip()
+            if result.returncode != 0 or not combined:
+                failures.append(
+                    f"provider={provider} model={model} rc={result.returncode} "
+                    f"stdout={result.stdout[:300]!r} stderr={result.stderr[:300]!r}"
+                )
+
+        assert not failures, "OpenCode launch failures:\n" + "\n".join(failures)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -1,0 +1,46 @@
+"""Lint and type-checking tests.
+
+These run ruff and ty against the source tree so that CI catches violations
+even without a pre-commit hook installed.
+
+Fix commands:
+  ruff check:   uv run ruff check --fix src/ tests/
+  ruff format:  uv run ruff format src/ tests/
+  ty:           uv run ty check src/
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, cwd=ROOT)
+
+
+def test_ruff_check():
+    result = _run([sys.executable, "-m", "ruff", "check", "src/", "tests/"])
+    assert result.returncode == 0, (
+        "ruff check found violations. Fix with:\n"
+        "  uv run ruff check --fix src/ tests/\n\n" + result.stdout
+    )
+
+
+def test_ruff_format():
+    result = _run([sys.executable, "-m", "ruff", "format", "--check", "src/", "tests/"])
+    assert result.returncode == 0, (
+        "ruff format found unformatted files. Fix with:\n"
+        "  uv run ruff format src/ tests/\n\n" + result.stdout
+    )
+
+
+def test_ty():
+    result = _run([sys.executable, "-m", "ty", "check", "src/"])
+    assert result.returncode == 0, (
+        "ty found type errors. Fix with:\n"
+        "  uv run ty check src/\n\n" + result.stdout + result.stderr
+    )

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,194 @@
+"""Tests for state.py — load/save/hydrate/clear/mark_tool_managed."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+import coding_tool_gateway.state as state_mod
+from coding_tool_gateway.state import (
+    STATE_VERSION,
+    clear_state,
+    hydrate_state,
+    load_full_state,
+    load_state,
+    mark_tool_managed,
+    save_state,
+)
+
+FAKE_WS = "https://example.databricks.com"
+FAKE_URLS = {
+    "codex": f"{FAKE_WS}/ai-gateway/codex/v1",
+    "claude": f"{FAKE_WS}/ai-gateway/anthropic",
+    "gemini": f"{FAKE_WS}/ai-gateway/gemini",
+    "opencode": {
+        "anthropic": f"{FAKE_WS}/ai-gateway/anthropic/v1",
+        "gemini": f"{FAKE_WS}/ai-gateway/gemini/v1beta",
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def patch_state_path(tmp_path, monkeypatch):
+    """Redirect STATE_PATH and APP_DIR to a temp directory for every test."""
+    fake_state_path = tmp_path / "state.json"
+    monkeypatch.setattr(state_mod, "STATE_PATH", fake_state_path)
+
+    import coding_tool_gateway.config_io as config_io_mod
+
+    monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def patch_build_urls():
+    """Avoid real network calls from hydrate_state."""
+    with patch("coding_tool_gateway.state.build_shared_base_urls", return_value=FAKE_URLS):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# load_full_state
+# ---------------------------------------------------------------------------
+
+
+class TestLoadFullState:
+    def test_returns_empty_structure_when_missing(self):
+        result = load_full_state()
+        assert result["state_version"] == STATE_VERSION
+        assert result["current_workspace"] is None
+        assert result["workspaces"] == {}
+
+    def test_returns_empty_when_wrong_version(self, tmp_path):
+        state_mod.STATE_PATH.write_text(
+            json.dumps({"state_version": 0, "current_workspace": None, "workspaces": {}}),
+            encoding="utf-8",
+        )
+        result = load_full_state()
+        assert result["workspaces"] == {}
+
+    def test_returns_empty_on_corrupt_json(self, tmp_path):
+        state_mod.STATE_PATH.write_text("not json", encoding="utf-8")
+        result = load_full_state()
+        assert result["current_workspace"] is None
+
+    def test_loads_valid_state(self, tmp_path):
+        data = {
+            "state_version": STATE_VERSION,
+            "current_workspace": FAKE_WS,
+            "workspaces": {FAKE_WS: {"claude_models": {"sonnet": "s4"}}},
+        }
+        state_mod.STATE_PATH.write_text(json.dumps(data), encoding="utf-8")
+        result = load_full_state()
+        assert result["current_workspace"] == FAKE_WS
+
+
+# ---------------------------------------------------------------------------
+# save_state / load_state round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSaveLoadRoundTrip:
+    def test_round_trip(self):
+        state = {
+            "workspace": FAKE_WS,
+            "claude_models": {"sonnet": "databricks-claude-sonnet-4"},
+        }
+        save_state(state)
+        loaded = load_state()
+        assert loaded["workspace"] == FAKE_WS
+        assert loaded["claude_models"]["sonnet"] == "databricks-claude-sonnet-4"
+
+    def test_save_respects_dry_run(self):
+        import coding_tool_gateway.config_io as config_io_mod
+
+        config_io_mod.set_dry_run(True)
+        try:
+            save_state({"workspace": FAKE_WS})
+            assert not state_mod.STATE_PATH.exists()
+        finally:
+            config_io_mod.set_dry_run(False)
+
+    def test_load_state_returns_empty_when_no_workspace(self):
+        result = load_state()
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# clear_state
+# ---------------------------------------------------------------------------
+
+
+class TestClearState:
+    def test_clears_current_workspace(self):
+        save_state({"workspace": FAKE_WS, "claude_models": {}})
+        clear_state()
+        full = load_full_state()
+        assert full["current_workspace"] is None
+        assert FAKE_WS not in full.get("workspaces", {})
+
+    def test_clear_when_no_state_is_noop(self):
+        clear_state()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# hydrate_state
+# ---------------------------------------------------------------------------
+
+
+class TestHydrateState:
+    def test_empty_input_returns_empty(self):
+        result = hydrate_state({})
+        assert result == {"managed_configs": {}, "base_urls": {}}
+
+    def test_non_dict_returns_empty(self):
+        assert hydrate_state(None) == {}  # type: ignore[arg-type]
+        assert hydrate_state("string") == {}  # type: ignore[arg-type]
+
+    def test_populates_base_urls_when_workspace_present(self):
+        result = hydrate_state({"workspace": FAKE_WS})
+        assert result["base_urls"] == FAKE_URLS
+
+    def test_no_base_urls_when_no_workspace(self):
+        result = hydrate_state({"claude_models": {}})
+        assert result["base_urls"] == {}
+
+    def test_normalizes_managed_configs_dict_entry(self):
+        state = {"managed_configs": {"claude": {"keys": [["env", "X"]]}}}
+        result = hydrate_state(state)
+        assert result["managed_configs"]["claude"] == {"keys": [["env", "X"]]}
+
+    def test_normalizes_managed_configs_truthy_entry(self):
+        state = {"managed_configs": {"codex": True}}
+        result = hydrate_state(state)
+        assert result["managed_configs"]["codex"] == {"keys": []}
+
+    def test_drops_falsy_managed_configs(self):
+        state = {"managed_configs": {"codex": False, "claude": None}}
+        result = hydrate_state(state)
+        assert "codex" not in result["managed_configs"]
+        assert "claude" not in result["managed_configs"]
+
+
+# ---------------------------------------------------------------------------
+# mark_tool_managed
+# ---------------------------------------------------------------------------
+
+
+class TestMarkToolManaged:
+    def test_sets_managed_keys(self):
+        state: dict = {}
+        result = mark_tool_managed(state, "claude", [["env", "X"], ["apiKeyHelper"]])
+        assert result["managed_configs"]["claude"] == {"keys": [["env", "X"], ["apiKeyHelper"]]}
+
+    def test_sets_last_tool(self):
+        state: dict = {}
+        result = mark_tool_managed(state, "codex", [])
+        assert result["last_tool"] == "codex"
+
+    def test_preserves_existing_managed_configs(self):
+        state = {"managed_configs": {"gemini": {"keys": [["GEMINI_MODEL"]]}}}
+        result = mark_tool_managed(state, "codex", [["profile"]])
+        assert "gemini" in result["managed_configs"]
+        assert "codex" in result["managed_configs"]

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,146 @@
+"""Tests for ui.py — pure helpers that don't touch I/O or prompts."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from coding_tool_gateway.ui import (
+    format_duration,
+    format_token_count,
+    normalize_workspace_url,
+    render_box_table,
+    status_badge,
+)
+
+
+class TestNormalizeWorkspaceUrl:
+    def test_adds_https_when_missing(self):
+        assert normalize_workspace_url("example.databricks.com") == "https://example.databricks.com"
+
+    def test_strips_trailing_slash(self):
+        assert (
+            normalize_workspace_url("https://example.databricks.com/")
+            == "https://example.databricks.com"
+        )
+
+    def test_strips_multiple_trailing_slashes(self):
+        assert (
+            normalize_workspace_url("https://example.databricks.com///")
+            == "https://example.databricks.com"
+        )
+
+    def test_preserves_https(self):
+        assert (
+            normalize_workspace_url("https://foo.azuredatabricks.net")
+            == "https://foo.azuredatabricks.net"
+        )
+
+    def test_preserves_http(self):
+        assert normalize_workspace_url("http://localhost:8080") == "http://localhost:8080"
+
+    def test_strips_whitespace(self):
+        assert (
+            normalize_workspace_url("  https://example.databricks.com  ")
+            == "https://example.databricks.com"
+        )
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            normalize_workspace_url("")
+
+    def test_whitespace_only_raises(self):
+        with pytest.raises(ValueError, match="empty"):
+            normalize_workspace_url("   ")
+
+
+class TestFormatTokenCount:
+    def test_small(self):
+        assert format_token_count(0) == "0"
+        assert format_token_count(999) == "999"
+
+    def test_thousands(self):
+        assert format_token_count(1000) == "1.0K"
+        assert format_token_count(1500) == "1.5K"
+        assert format_token_count(999_999) == "1000.0K"
+
+    def test_millions(self):
+        assert format_token_count(1_000_000) == "1.0M"
+        assert format_token_count(2_500_000) == "2.5M"
+
+    def test_billions(self):
+        assert format_token_count(1_000_000_000) == "1.0B"
+        assert format_token_count(2_200_000_000) == "2.2B"
+
+
+class TestFormatDuration:
+    def test_none_returns_dash(self):
+        assert format_duration(None) == "-"
+
+    def test_zero_returns_dash(self):
+        assert format_duration(timedelta(seconds=0)) == "-"
+
+    def test_negative_returns_dash(self):
+        assert format_duration(timedelta(seconds=-5)) == "-"
+
+    def test_minutes(self):
+        assert format_duration(timedelta(minutes=5)) == "5m"
+        assert format_duration(timedelta(minutes=59)) == "59m"
+
+    def test_hours_fractional(self):
+        result = format_duration(timedelta(hours=1, minutes=30))
+        assert result == "1.5h"
+
+    def test_hours_rounded(self):
+        result = format_duration(timedelta(hours=10))
+        assert result == "10h"
+
+    def test_days(self):
+        result = format_duration(timedelta(hours=48))
+        assert result == "2.0d"
+
+
+class TestStatusBadge:
+    def test_ok_is_green(self):
+        assert "green" in status_badge("OK", "ok")
+
+    def test_warn_is_yellow(self):
+        assert "yellow" in status_badge("Warning", "warn")
+
+    def test_error_is_red(self):
+        assert "red" in status_badge("Error", "error")
+
+    def test_unknown_kind_uses_bold(self):
+        result = status_badge("X", "unknown")
+        assert "bold" in result
+        assert "X" in result
+
+    def test_text_is_included(self):
+        assert "MyText" in status_badge("MyText", "ok")
+
+
+class TestRenderBoxTable:
+    def test_produces_box_chars(self):
+        result = render_box_table(["A", "B"], [["x", "y"]])
+        assert "┏" in result
+        assert "┗" not in result  # bottom uses └
+        assert "└" in result
+        assert "A" in result
+        assert "x" in result
+
+    def test_empty_rows(self):
+        result = render_box_table(["H1", "H2"], [])
+        assert "H1" in result
+        assert "H2" in result
+
+    def test_cell_wraps_when_max_width_set(self):
+        long_text = "a" * 30
+        result = render_box_table(["Col"], [[long_text]], max_widths=[10])
+        # wrapped lines mean the original 30-char string is broken up
+        lines = result.splitlines()
+        assert any(len(line.strip()) <= 14 for line in lines)
+
+    def test_dash_for_empty_cell(self):
+        result = render_box_table(["A"], [[""]])
+        assert "-" in result

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,215 @@
+"""Tests for usage.py — query builders, parsing/formatting, rendering."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+from coding_tool_gateway.usage import (
+    USAGE_BREAKDOWN_DAYS,
+    USAGE_SUMMARY_DAYS,
+    build_current_user_query,
+    build_usage_report_query,
+    coerce_date,
+    coerce_datetime,
+    empty_tool_day,
+    extract_model_names,
+    parse_usage_rows,
+    render_usage_summary,
+    simplify_model_name,
+    summarize_models,
+)
+
+
+class TestBuildUsageReportQuery:
+    def test_contains_system_table(self):
+        q = build_usage_report_query()
+        assert "system.ai_gateway.usage" in q
+
+    def test_contains_interval(self):
+        q = build_usage_report_query()
+        assert str(USAGE_SUMMARY_DAYS) in q
+
+    def test_filters_known_tools(self):
+        q = build_usage_report_query()
+        for tool in ("codex", "claude", "gemini", "opencode"):
+            assert tool in q
+
+
+class TestBuildCurrentUserQuery:
+    def test_uses_current_user(self):
+        q = build_current_user_query()
+        assert "current_user()" in q
+
+
+class TestParseUsageRows:
+    def test_zips_columns_and_rows(self):
+        columns = ["a", "b", "c"]
+        rows = [(1, 2, 3), (4, 5, 6)]
+        result = parse_usage_rows(columns, rows)
+        assert result == [{"a": 1, "b": 2, "c": 3}, {"a": 4, "b": 5, "c": 6}]
+
+    def test_empty_rows(self):
+        assert parse_usage_rows(["a"], []) == []
+
+
+class TestCoerceDate:
+    def test_date_passthrough(self):
+        d = date(2024, 6, 1)
+        assert coerce_date(d) == d
+
+    def test_datetime_to_date(self):
+        dt = datetime(2024, 6, 1, 12, 0, 0)
+        assert coerce_date(dt) == date(2024, 6, 1)
+
+    def test_iso_string(self):
+        assert coerce_date("2024-06-01") == date(2024, 6, 1)
+
+    def test_invalid_string_returns_none(self):
+        assert coerce_date("not-a-date") is None
+
+    def test_none_returns_none(self):
+        assert coerce_date(None) is None
+
+
+class TestCoerceDatetime:
+    def test_datetime_passthrough(self):
+        dt = datetime(2024, 6, 1, 0, 0, 0)
+        assert coerce_datetime(dt) == dt
+
+    def test_iso_string(self):
+        result = coerce_datetime("2024-06-01T12:00:00")
+        assert isinstance(result, datetime)
+        assert result.date() == date(2024, 6, 1)
+
+    def test_z_suffix(self):
+        result = coerce_datetime("2024-06-01T12:00:00Z")
+        assert isinstance(result, datetime)
+
+    def test_invalid_string_returns_none(self):
+        assert coerce_datetime("bad") is None
+
+    def test_none_returns_none(self):
+        assert coerce_datetime(None) is None
+
+
+class TestSimplifyModelName:
+    def test_strips_databricks_and_tool_prefix(self):
+        # databricks- stripped first, then claude- stripped → "sonnet-4"
+        assert simplify_model_name("claude", "databricks-claude-sonnet-4") == "sonnet-4"
+
+    def test_gemini_prefix(self):
+        result = simplify_model_name("gemini", "databricks-gemini-2.0-flash")
+        assert result == "2.0-flash"
+
+    def test_codex_strips_gpt_prefix(self):
+        result = simplify_model_name("codex", "databricks-gpt-4o")
+        assert result == "4o"
+
+    def test_empty_returns_dash(self):
+        assert simplify_model_name("claude", "") == "-"
+
+    def test_no_known_prefix_returns_as_is(self):
+        result = simplify_model_name("claude", "some-other-model")
+        assert result == "some-other-model"
+
+    def test_only_databricks_prefix_stripped_for_unknown_tool(self):
+        result = simplify_model_name("opencode", "databricks-claude-sonnet-4")
+        assert result == "claude-sonnet-4"
+
+
+class TestExtractModelNames:
+    def test_single_model(self):
+        result = extract_model_names("claude", "databricks-claude-sonnet-4")
+        assert result == ["sonnet-4"]
+
+    def test_multiple_models(self):
+        result = extract_model_names(
+            "claude", "databricks-claude-sonnet-4, databricks-claude-opus-4"
+        )
+        assert "sonnet-4" in result
+        assert "opus-4" in result
+
+    def test_deduplicates(self):
+        result = extract_model_names(
+            "claude", "databricks-claude-sonnet-4, databricks-claude-sonnet-4"
+        )
+        assert result.count("sonnet-4") == 1
+
+    def test_empty_returns_empty_list(self):
+        assert extract_model_names("claude", "") == []
+
+    def test_non_string_returns_empty_list(self):
+        assert extract_model_names("claude", None) == []
+
+
+class TestSummarizeModels:
+    def test_single_model(self):
+        result = summarize_models("claude", "databricks-claude-sonnet-4")
+        assert result == "sonnet-4"
+
+    def test_multiple_models_joined(self):
+        result = summarize_models("claude", "databricks-claude-sonnet-4, databricks-claude-opus-4")
+        assert "sonnet-4" in result
+        assert "," in result
+
+    def test_empty_returns_dash(self):
+        assert summarize_models("claude", "") == "-"
+
+    def test_none_returns_dash(self):
+        assert summarize_models("claude", None) == "-"
+
+
+class TestEmptyToolDay:
+    def test_structure(self):
+        d = date(2024, 6, 1)
+        row = empty_tool_day("claude", d)
+        assert row["tool"] == "claude"
+        assert row["usage_day"] == d
+        assert row["total_tokens_used"] == 0
+        assert row["sessions"] == 0
+        assert row["models"] == "-"
+
+
+class TestRenderUsageSummary:
+    def _make_record(self, days_ago: int, tool: str, tokens: int, model: str = "") -> dict:
+        d = date.today() - timedelta(days=days_ago)
+        return {
+            "tool": tool,
+            "usage_day": d,
+            "total_tokens_used": tokens,
+            "models": model,
+        }
+
+    def test_contains_requester_name(self):
+        records = [self._make_record(0, "claude", 1000)]
+        result = render_usage_summary(records, "alice@example.com", {"claude": "Claude Code"})
+        assert "alice@example.com" in result
+
+    def test_today_total(self):
+        records = [self._make_record(0, "claude", 5000)]
+        result = render_usage_summary(records, "user", {"claude": "Claude Code"})
+        assert "5.0K" in result
+
+    def test_weekly_total_includes_past_week(self):
+        records = [
+            self._make_record(0, "claude", 1000),
+            self._make_record(3, "claude", 2000),
+            self._make_record(USAGE_BREAKDOWN_DAYS, "claude", 9999),  # outside window
+        ]
+        result = render_usage_summary(records, "user", {"claude": "Claude Code"})
+        # only 3K from the last 7 days; 9999 from day 7 (boundary) may vary
+        assert "3.0K" in result or "3" in result
+
+    def test_active_tools_listed(self):
+        records = [self._make_record(0, "claude", 1000)]
+        result = render_usage_summary(records, "user", {"claude": "Claude Code"})
+        assert "Claude Code" in result
+
+    def test_top_models_listed(self):
+        records = [self._make_record(0, "claude", 5000, "databricks-claude-sonnet-4")]
+        result = render_usage_summary(records, "user", {"claude": "Claude Code"})
+        assert "sonnet-4" in result
+
+    def test_empty_records(self):
+        result = render_usage_summary([], "user", {"claude": "Claude Code"})
+        assert "user" in result

--- a/uv.lock
+++ b/uv.lock
@@ -121,12 +121,26 @@ dependencies = [
     { name = "typer" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "databricks-sql-connector", specifier = ">=3.6.0" },
     { name = "questionary", specifier = ">=2.0.0" },
     { name = "tomlkit", specifier = ">=0.13.0" },
     { name = "typer", specifier = ">=0.12.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "ruff", specifier = ">=0.15.12" },
+    { name = "ty" },
 ]
 
 [[package]]
@@ -175,6 +189,15 @@ source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -321,6 +344,15 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
@@ -368,6 +400,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
@@ -404,6 +445,22 @@ source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -468,6 +525,31 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
@@ -501,6 +583,30 @@ source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.33"
+source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/44/9478c50c266826c1bf30d1692e589755bffa8f1c0a3eb7af8a346c255991/ty-0.0.33.tar.gz", hash = "sha256:46d63bda07403322cb6c28ccfdd5536be916e13df725c29f7ccd0a21f06bd9e8", size = 5559373, upload-time = "2026-04-28T10:45:13.18Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/24/e287388c63a19191be26b32ff4dbd06029834068150ebe2532939bc4c851/ty-0.0.33-py3-none-linux_armv6l.whl", hash = "sha256:94d0a9d2234261a8911396d59e506b5923fe0971dbda43b9dcea287936887fcc", size = 11021308, upload-time = "2026-04-28T10:45:43.34Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ca/ba1eed819895bd239fba8ee35dfcd5fcb266c203b0914a17a59579096bb5/ty-0.0.33-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e4a2b5ba078f90de342f56b5f7979bb77c9b9b1d8625a041352ffc6ee93c4073", size = 10777272, upload-time = "2026-04-28T10:45:32.905Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a8/c3131d37b44b3fea1d6654a1c929a0cd0873822f77a90482b8ec28f6fbbd/ty-0.0.33-py3-none-macosx_11_0_arm64.whl", hash = "sha256:84ff5707825e9af9668d2bcf66975f93e520a63b524ab494e3a8265735be2563", size = 10201078, upload-time = "2026-04-28T10:45:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/db/d8e37ff0045810cc65e1ff36aa0da0a2253c05659787ac987df8a16c7897/ty-0.0.33-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e375285736f57886868e7af0b11c7b0ec5b6543fa15e7ad2a714fed9f077d4e0", size = 10732347, upload-time = "2026-04-28T10:45:21.444Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/1a/20e83a412506a918e4684fc67b567cf7cc13b105470b3428cb23c3d5aa13/ty-0.0.33-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5680f6350c3b4e46b8bff6d7bb132366ea239463d6cad4892725d06046e65464", size = 10808238, upload-time = "2026-04-28T10:45:38.565Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/4b/d0a39f4464dc6cb4cc2c159473ce216bd1846bfb684c0323a3cb36dce5c6/ty-0.0.33-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5535538bad8d0f7e62bcdff02197cdb30e41451d80b35d27e17d128f2e1dc5d", size = 11288348, upload-time = "2026-04-28T10:45:08.419Z" },
+    { url = "https://files.pythonhosted.org/packages/35/7e/f1745e0f9583363d7a83d9a4990fc244f76ecc30840ddad83dc16a33c52d/ty-0.0.33-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:da196c42bbbc069e1e21e3e52107c061aa9660352dae57a41930690b56e2c02d", size = 11789907, upload-time = "2026-04-28T10:45:19.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/71/25f39f46a12d662859d45bc648555d0661044eb43db6b5648c9947487da9/ty-0.0.33-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9281672921ef6d4460e03146b5e6c18cb1a3e3a3b8a1a88f6f33226d05a469b7", size = 11500774, upload-time = "2026-04-28T10:45:48.012Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ec/136959ecbb7c71cb90537f5aea441c73f4ab24612868a6ecdc9d7444d32d/ty-0.0.33-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82c1b8f303f82da64e878108e764be3ecbcd7c9903ac0a7f7031614ed00b97ab", size = 11360314, upload-time = "2026-04-28T10:45:05.402Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/95/32809575c222f00beed498cb728e9290a0f5009f930025381bb7253b2206/ty-0.0.33-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:efe3af412c9ff67bce5fa37d0a2b0d8555c24072b145a5bac6c79637f1c83abe", size = 10707785, upload-time = "2026-04-28T10:45:10.836Z" },
+    { url = "https://files.pythonhosted.org/packages/13/89/c8e9531f7aa4a093359e15fa32c8e1277fbbe90d16894d7c6032d29f4b34/ty-0.0.33-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:aeec29c91ea768601747da546c3efc20b72c2fb1bd52bcc786a5c6eeff51d27b", size = 10834987, upload-time = "2026-04-28T10:45:40.738Z" },
+    { url = "https://files.pythonhosted.org/packages/31/16/9835fbcf5338af1a1917bd28fdb8a7193c210b83f243aa286fa9f79cb3ad/ty-0.0.33-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a535977c52bbb5f7e96b8b70a6ad375ad077f4a9ff2492508ea3816a2b403819", size = 10968968, upload-time = "2026-04-28T10:45:30.26Z" },
+    { url = "https://files.pythonhosted.org/packages/36/69/64c76aabc1bc70c7f24b686cd93c3407f8ea430905e395f59bf9603ef571/ty-0.0.33-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1d732facf39fcb221ba279d469c5040d37883e964f123b1563888efd34818180", size = 11458077, upload-time = "2026-04-28T10:45:45.971Z" },
+    { url = "https://files.pythonhosted.org/packages/91/84/fae27b0c4718776a298690d31ca4cc1995f2e3e1c63a7b59e84c41498e9a/ty-0.0.33-py3-none-win32.whl", hash = "sha256:d90960b574428dc252f85e8598ec5fcb7f619794196b2fc95a90da075ed4681c", size = 10345364, upload-time = "2026-04-28T10:45:16.836Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a0/a2938b23ae3e1a09a2d7c189e2ac5f7113676bae4e0e23948b568e18e5f8/ty-0.0.33-py3-none-win_amd64.whl", hash = "sha256:c1c3aec62c44de610c6e95f0a4e97ac3dbc07934bfdbf1fd90d758c9ff72f48e", size = 11342470, upload-time = "2026-04-28T10:45:26.455Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/62/7fb948aace38d2f6329261bb33c035a8484549c74f1db28649c7a4c6fed9/ty-0.0.33-py3-none-win_arm64.whl", hash = "sha256:0d44f99ba1b441e55e2aa301b2ac0a21112784931b46a5f66f4ea9efe5620d97", size = 10742673, upload-time = "2026-04-28T10:45:35.555Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Split the 2200-line cli.py into ui, config_io, state, databricks, usage, mcp, and per-agent modules (agents/codex, claude, gemini, opencode). Drops AI Gateway v1 fallback — v2 is now a hard requirement. Adds pytest suite (unit tests for all modules + E2E tests gated on env var) and ruff/ty enforcement via test_lint.py.