### PR TITLE
Fix gemini E2E test timeout by closing stdin

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -53,6 +53,7 @@ def _run_agent(
         text=True,
         timeout=timeout,
         env=env,
+        stdin=subprocess.DEVNULL,
     )
 
 


### PR DESCRIPTION
gemini CLI responds to -p but then waits for interactive input on stdin. Pass stdin=DEVNULL so the process exits after producing its response.