### PR TITLE
 Make configure tolerate agent install failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Agent Instructions
+
+## Project
+
+`coding-gateway` is a Python CLI that configures and launches coding agents through Databricks AI Gateway.
+
+The package code lives in `src/coding_tool_gateway/`.
+Tests live in `tests/`.
+
+## Commands
+
+- Run the full test suite with `uv run pytest`.
+- Run focused tests with `uv run pytest tests/<file>.py`.
+- Run e2e tests with `CODING_GATEWAY_TEST_WORKSPACE=<db_workspace_url> uv run pytest tests/test_e2e.py -v`.
+- Run lint with `uv run ruff check .`.
+- Run the CLI from the current checkout with `uv run coding-gateway ...`.
+- Reinstall the local checkout as the `coding-gateway` tool with `uv tool install --reinstall .`.
+
+## Development
+
+- Use Python 3.12+.
+- Keep changes scoped to the requested behavior.
+- Follow the existing module boundaries: CLI orchestration in `cli.py`, agent-specific behavior in `agents/<name>.py`, shared agent dispatch in `agents/__init__.py`, Databricks calls in `databricks.py`, and presentation helpers in `ui.py`.
+- Prefer existing helpers for config file writes, state persistence, UI messages, and Databricks authentication.
+- Add or update focused tests for behavior changes.
+- Do not modify generated or lock files unless the dependency graph intentionally changes.
+
+## Style
+
+- Keep user-facing CLI errors actionable.
+- Use warnings for recoverable setup problems and errors for launch/runtime blockers.
+- Preserve existing Rich UI conventions, including `print_warning`, `print_err`, `print_success`, `print_section`, and `spinner`.
+- Avoid broad refactors while fixing a narrow bug.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+@AGENTS.md
+
+# Claude Code Notes
+
+Use `AGENTS.md` as the shared source of repository instructions.
+
+Put Claude-specific workflow notes here only when they are not useful to other agents.

--- a/src/coding_tool_gateway/agents/__init__.py
+++ b/src/coding_tool_gateway/agents/__init__.py
@@ -64,33 +64,57 @@ def normalize_tool(tool: str) -> str:
     return normalized
 
 
-def install_tool_binary(tool: str) -> None:
+def install_tool_binary(tool: str, *, strict: bool = True) -> bool:
     spec = TOOL_SPECS[tool]
     binary = spec["binary"]
     package = spec["package"]
 
     if shutil.which(binary):
-        return
+        return True
 
     if not shutil.which("npm"):
-        raise RuntimeError(f"`{binary}` is not installed and npm is not available to install it.")
+        message = f"`{binary}` is not installed and npm is not available to install it."
+        if strict:
+            raise RuntimeError(message)
+        print_warning(message)
+        return False
 
     print_section("Bootstrap")
     print_warning(f"`{binary}` was not found. Installing {spec['display']}...")
     try:
         subprocess.run(["npm", "install", "-g", package], check=True, timeout=300)
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
-        raise RuntimeError(f"Failed to install {spec['display']} automatically.") from exc
+        message = f"Failed to install {spec['display']} automatically."
+        if strict:
+            raise RuntimeError(message) from exc
+        print_warning(f"{message} Continuing without it.")
+        return False
 
     if not shutil.which(binary):
-        raise RuntimeError(
-            f"{spec['display']} install completed, but `{binary}` is still not on PATH."
-        )
+        message = f"{spec['display']} install completed, but `{binary}` is still not on PATH."
+        if strict:
+            raise RuntimeError(message)
+        print_warning(f"{message} Continuing without it.")
+        return False
+
+    return True
+
+
+def ensure_tool_binary_available(tool: str) -> None:
+    spec = TOOL_SPECS[tool]
+    binary = spec["binary"]
+    if shutil.which(binary):
+        return
+    raise RuntimeError(
+        f"{spec['display']} is not installed (`{binary}` was not found on PATH). "
+        f"Install it with `npm install -g {spec['package']}` or run "
+        f"`coding-gateway configure` to try automatic installation."
+    )
 
 
 def ensure_bootstrap_dependencies(tool: str) -> None:
     install_databricks_cli()
-    install_tool_binary(tool)
+    ensure_tool_binary_available(tool)
 
 
 def default_model_for_tool(tool: str, state: dict) -> str | None:

--- a/src/coding_tool_gateway/cli.py
+++ b/src/coding_tool_gateway/cli.py
@@ -247,7 +247,7 @@ def configure(
     try:
         install_databricks_cli()
         for t in TOOL_SPECS:
-            install_tool_binary(t)
+            install_tool_binary(t, strict=False)
         configure_workspace_command()
     except RuntimeError as exc:
         print_err(str(exc))

--- a/tests/test_agents_init.py
+++ b/tests/test_agents_init.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
+
 import pytest
 
 from coding_tool_gateway.agents import (
@@ -9,6 +11,8 @@ from coding_tool_gateway.agents import (
     TOOL_SPECS,
     check_gateway_endpoint,
     default_model_for_tool,
+    ensure_tool_binary_available,
+    install_tool_binary,
     normalize_tool,
     resolve_launch_model,
 )
@@ -121,3 +125,30 @@ class TestResolveLaunchModel:
     def test_raises_when_no_models_available(self):
         with pytest.raises(RuntimeError, match="No models available"):
             resolve_launch_model("claude", {}, None)
+
+
+class TestInstallToolBinary:
+    def test_non_strict_returns_false_when_npm_missing(self, monkeypatch):
+        monkeypatch.setattr("coding_tool_gateway.agents.shutil.which", lambda _: None)
+
+        assert install_tool_binary("opencode", strict=False) is False
+
+    def test_non_strict_returns_false_when_install_fails(self, monkeypatch):
+        def fake_which(binary: str) -> str | None:
+            if binary == "npm":
+                return "/usr/bin/npm"
+            return None
+
+        def fake_run(*args, **kwargs):
+            raise subprocess.CalledProcessError(1, args[0])
+
+        monkeypatch.setattr("coding_tool_gateway.agents.shutil.which", fake_which)
+        monkeypatch.setattr("coding_tool_gateway.agents.subprocess.run", fake_run)
+
+        assert install_tool_binary("opencode", strict=False) is False
+
+    def test_ensure_tool_binary_available_raises_when_missing(self, monkeypatch):
+        monkeypatch.setattr("coding_tool_gateway.agents.shutil.which", lambda _: None)
+
+        with pytest.raises(RuntimeError, match="OpenCode is not installed"):
+            ensure_tool_binary_available("opencode")


### PR DESCRIPTION
  ## What changed

  - Made agent CLI installation best-effort during `coding-gateway configure`.
  - If a missing agent cannot be installed automatically, configure now prints a warning and continues instead of failing the whole setup.
  - Changed launch-time behavior so `coding-gateway --agent <agent>` checks that the selected agent binary exists and returns an actionable error if it is
  missing.
  - Added `AGENTS.md` with shared repository instructions for coding agents and contributors, including test, lint, CLI, reinstall, and e2e commands.
  - Added `CLAUDE.md` that imports `AGENTS.md` and leaves room for Claude-specific notes.

  ## Validation

  - `uv run pytest tests/test_agents_init.py`