### PR TITLE
Configure MCP servers across coding tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,17 @@ This writes managed config files for all three tools (`~/.codex/config.toml`, `~
 coding-gateway configure mcp
 ```
 
-Add Databricks MCP servers to Claude Code. Supported server types:
+Add Databricks MCP servers to installed MCP-capable tools: Codex, Claude Code, Gemini CLI, and OpenCode.
+Options are shown in this order:
 
-- **External** — e.g. confluence-mcp, jira-mcp
-- **UC Functions** — Unity Catalog AI functions
-- **Genie** — AI/BI dashboards
-- **Custom** — any MCP server URL
+- Discovered external MCP connections
+- Databricks SQL
+- Built-in AI tools
+- Other Databricks MCP products
+- Custom MCP server URL
 
-You will be prompted for OAuth credentials (client ID and secret) that are reused for all servers added in the session.
+Discovered external MCP connections are listed directly. MCP auth uses a Databricks token that
+`coding-gateway` sets when launching each tool.
 
 ### 3. Launch an agent
 

--- a/src/coding_tool_gateway/agents/claude.py
+++ b/src/coding_tool_gateway/agents/claude.py
@@ -16,6 +16,7 @@ from coding_tool_gateway.config_io import (
 from coding_tool_gateway.databricks import (
     build_auth_shell_command,
     build_tool_base_url,
+    get_databricks_token,
 )
 from coding_tool_gateway.state import mark_tool_managed, save_state
 
@@ -80,6 +81,9 @@ def default_model(state: dict) -> str | None:
 
 def launch(state: dict, tool_args: list[str]) -> None:
     binary = SPEC["binary"]
+    workspace = state.get("workspace")
+    if workspace:
+        os.environ["OAUTH_TOKEN"] = get_databricks_token(workspace)
     os.execvp(binary, [binary, *tool_args])
 
 

--- a/src/coding_tool_gateway/agents/codex.py
+++ b/src/coding_tool_gateway/agents/codex.py
@@ -16,6 +16,7 @@ from coding_tool_gateway.config_io import (
 from coding_tool_gateway.databricks import (
     build_auth_shell_command,
     build_tool_base_url,
+    get_databricks_token,
 )
 from coding_tool_gateway.state import mark_tool_managed, save_state
 
@@ -77,6 +78,9 @@ def default_model(state: dict) -> str | None:
 
 def launch(state: dict, tool_args: list[str]) -> None:
     binary = SPEC["binary"]
+    workspace = state.get("workspace")
+    if workspace:
+        os.environ["OAUTH_TOKEN"] = get_databricks_token(workspace)
     os.execvp(binary, [binary, *tool_args])
 
 

--- a/src/coding_tool_gateway/agents/gemini.py
+++ b/src/coding_tool_gateway/agents/gemini.py
@@ -39,6 +39,7 @@ MANAGED_KEYS: list[str] = [
     "GOOGLE_GEMINI_BASE_URL",
     "GEMINI_API_KEY_AUTH_MECHANISM",
     "GEMINI_API_KEY",
+    "OAUTH_TOKEN",
 ]
 
 
@@ -48,6 +49,7 @@ def render_env_overlay(workspace: str, model: str, token: str) -> dict[str, str]
         "GOOGLE_GEMINI_BASE_URL": build_tool_base_url("gemini", workspace),
         "GEMINI_API_KEY_AUTH_MECHANISM": "bearer",
         "GEMINI_API_KEY": token,
+        "OAUTH_TOKEN": token,
     }
 
 
@@ -57,6 +59,7 @@ def build_runtime_env(workspace: str, model: str, token: str) -> dict[str, str]:
     env["GOOGLE_GEMINI_BASE_URL"] = build_tool_base_url("gemini", workspace)
     env["GEMINI_API_KEY_AUTH_MECHANISM"] = "bearer"
     env["GEMINI_API_KEY"] = token
+    env["OAUTH_TOKEN"] = token
     return env
 
 

--- a/src/coding_tool_gateway/agents/opencode.py
+++ b/src/coding_tool_gateway/agents/opencode.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import signal
 import subprocess
 import threading
@@ -25,6 +26,7 @@ from coding_tool_gateway.state import mark_tool_managed, save_state
 OPENCODE_CONFIG_DIR = Path.home() / ".config" / "opencode"
 OPENCODE_CONFIG_PATH = OPENCODE_CONFIG_DIR / "opencode.json"
 OPENCODE_BACKUP_PATH = APP_DIR / "opencode-config.backup.json"
+OPENCODE_MCP_AUTH_HEADER_VALUE = "Bearer {env:OAUTH_TOKEN}"
 
 SPEC: ToolSpec = {
     "binary": "opencode",
@@ -112,6 +114,30 @@ def write_tool_config(
     return state, token
 
 
+def build_mcp_server_entry(url: str) -> dict:
+    return {
+        "type": "remote",
+        "url": url,
+        "enabled": True,
+        "headers": {
+            "Authorization": OPENCODE_MCP_AUTH_HEADER_VALUE,
+        },
+    }
+
+
+def write_mcp_server_config(name: str, url: str) -> bool:
+    backup_existing_file(OPENCODE_CONFIG_PATH, OPENCODE_BACKUP_PATH)
+    existing = read_json_safe(OPENCODE_CONFIG_PATH)
+    mcp_servers = existing.get("mcp")
+    if not isinstance(mcp_servers, dict):
+        mcp_servers = {}
+    removed = name in mcp_servers
+    mcp_servers[name] = build_mcp_server_entry(url)
+    existing["mcp"] = mcp_servers
+    write_json_file(OPENCODE_CONFIG_PATH, existing)
+    return removed
+
+
 def default_model(state: dict) -> str | None:
     opencode_models = state.get("opencode_models") or {}
     anthropic = opencode_models.get("anthropic") or []
@@ -137,9 +163,16 @@ def _refresh_forever(state: dict, stop_event: threading.Event) -> None:
             continue
 
 
+def build_runtime_env(token: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env["OAUTH_TOKEN"] = token
+    return env
+
+
 def launch(state: dict, tool_args: list[str]) -> None:
     """Launch opencode with background token refresh (same pattern as Gemini)."""
-    _refresh_token_once(state)
+    token = _refresh_token_once(state)
+    env = build_runtime_env(token)
 
     stop_event = threading.Event()
     refresher = threading.Thread(
@@ -149,7 +182,7 @@ def launch(state: dict, tool_args: list[str]) -> None:
     )
     refresher.start()
 
-    proc = subprocess.Popen([SPEC["binary"], *tool_args])
+    proc = subprocess.Popen([SPEC["binary"], *tool_args], env=env)
     try:
         returncode = proc.wait()
     except KeyboardInterrupt:

--- a/src/coding_tool_gateway/cli.py
+++ b/src/coding_tool_gateway/cli.py
@@ -150,14 +150,14 @@ def status() -> int:
         print_kv("Config file", str(config_path) if config_path.exists() else "missing")
         console.print()
 
-    print_heading("MCP Servers (Claude Code)")
-    print_note("Run `claude mcp list` to see configured MCP servers.")
+    print_heading("MCP Servers")
+    print_note("Run each tool's MCP list command to see configured MCP servers.")
     print_note("Run `coding-gateway configure mcp` to add Databricks MCP servers.")
 
     print_heading("State")
     print_kv("State file", str(STATE_PATH) if STATE_PATH.exists() else "missing")
     print_note("Use `coding-gateway configure` to update workspace settings or tool models.")
-    print_note("Use `coding-gateway configure mcp` to add Databricks MCP servers to Claude Code.")
+    print_note("Use `coding-gateway configure mcp` to add Databricks MCP servers to coding tools.")
     print_note("Use `coding-gateway revert` to clear managed configs and restore prior files.")
     return 0
 
@@ -259,7 +259,7 @@ def configure(
 
 @configure_app.command("mcp")
 def configure_mcp() -> None:
-    """Add Databricks MCP servers to Claude Code."""
+    """Add Databricks MCP servers to installed coding tools."""
     try:
         configure_mcp_command()
     except RuntimeError as exc:

--- a/src/coding_tool_gateway/databricks.py
+++ b/src/coding_tool_gateway/databricks.py
@@ -215,6 +215,70 @@ def get_databricks_token(workspace: str) -> str:
         raise RuntimeError("Failed to retrieve Databricks access token.") from exc
 
 
+def _extract_connection_page(payload: object) -> tuple[list[dict], str | None]:
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)], None
+    if not isinstance(payload, dict):
+        raise RuntimeError("Databricks connections listing returned invalid JSON.")
+
+    payload_dict = cast(dict[str, object], payload)
+    raw_connections = payload_dict.get("connections") or []
+    if not isinstance(raw_connections, list):
+        raise RuntimeError("Databricks connections listing returned invalid JSON.")
+
+    next_page_token = payload_dict.get("next_page_token")
+    if next_page_token is not None and not isinstance(next_page_token, str):
+        raise RuntimeError("Databricks connections listing returned invalid JSON.")
+
+    return [item for item in raw_connections if isinstance(item, dict)], next_page_token
+
+
+def list_databricks_connections(workspace: str) -> list[dict]:
+    env = build_databricks_cli_env(workspace)
+    connections: list[dict] = []
+    page_token: str | None = None
+    seen_page_tokens: set[str] = set()
+
+    try:
+        while True:
+            cmd = [
+                "databricks",
+                "connections",
+                "list",
+                "--max-results",
+                "0",
+                "--output",
+                "json",
+            ]
+            if page_token:
+                cmd.extend(["--page-token", page_token])
+
+            result = run(
+                cmd,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=30,
+            )
+            payload = json.loads(result.stdout or "{}")
+            page_connections, page_token = _extract_connection_page(payload)
+            connections.extend(page_connections)
+
+            if not page_token:
+                return connections
+            if page_token in seen_page_tokens:
+                raise RuntimeError("Databricks connections listing returned a repeated page token.")
+            seen_page_tokens.add(page_token)
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            "Failed to list Databricks connections via `databricks connections list`."
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("Timed out while listing Databricks connections.") from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError("Databricks connections listing returned invalid JSON.") from exc
+
+
 def build_auth_shell_command(workspace: str) -> str:
     python_expr = "import json,sys; print(json.load(sys.stdin).get('access_token', ''))"
     unset_prefix = " ".join(f"-u {key}" for key in SCRUBBED_DATABRICKS_ENV_VARS)

--- a/src/coding_tool_gateway/mcp.py
+++ b/src/coding_tool_gateway/mcp.py
@@ -1,13 +1,13 @@
-"""MCP (Model Context Protocol) server registration for Claude Code."""
+"""MCP (Model Context Protocol) server registration for coding tools."""
 
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import subprocess
 
-from coding_tool_gateway.databricks import ensure_databricks_auth
+from coding_tool_gateway.agents import opencode
+from coding_tool_gateway.databricks import ensure_databricks_auth, list_databricks_connections
 from coding_tool_gateway.state import load_state, save_state
 from coding_tool_gateway.ui import (
     console,
@@ -18,42 +18,315 @@ from coding_tool_gateway.ui import (
     print_note,
     print_section,
     print_success,
-    prompt_for_choice,
-    prompt_for_client_id,
-    prompt_for_client_secret,
+    print_warning,
+)
+
+MCP_AUTH_TOKEN_ENV_VAR = "OAUTH_TOKEN"
+MCP_USER_SCOPE = "user"
+MCP_CLEANUP_SCOPES = ("local", "project", MCP_USER_SCOPE)
+MCP_CLIENTS = {
+    "claude": {"binary": "claude", "display": "Claude Code"},
+    "codex": {"binary": "codex", "display": "Codex"},
+    "gemini": {"binary": "gemini", "display": "Gemini CLI"},
+    "opencode": {"binary": "opencode", "display": "OpenCode"},
+}
+MANUAL_EXTERNAL_MCP_VALUE = "external:manual"
+EXTERNAL_MCP_SELECTION_PREFIX = "external:"
+SQL_MCP_VALUE = "managed:sql"
+VECTOR_SEARCH_VALUE = "vector-search"
+GENIE_VALUE = "genie"
+UC_FUNCTIONS_VALUE = "uc-functions"
+CUSTOM_MCP_VALUE = "custom"
+MCP_CONNECTION_MARKERS = (
+    "is_mcp",
+    "is_mcp_connection",
+    "mcp",
+    "mcp_enabled",
+    "enable_mcp",
 )
 
 
-def build_mcp_http_entry(url: str, client_id: str, callback_port: int = 8080) -> dict:
+def build_mcp_http_entry(url: str) -> dict:
     return {
         "type": "http",
         "url": url,
-        "oauth": {
-            "clientId": client_id,
-            "callbackPort": callback_port,
+        "headers": {
+            "Authorization": f"Bearer ${{{MCP_AUTH_TOKEN_ENV_VAR}}}",
         },
     }
 
 
-def add_claude_mcp_server(name: str, entry: dict, client_secret: str) -> None:
-    env = os.environ.copy()
-    env["MCP_CLIENT_SECRET"] = client_secret
+def add_claude_mcp_server(name: str, entry: dict, scope: str = MCP_USER_SCOPE) -> None:
     try:
         subprocess.run(
-            [
-                "claude",
-                "mcp",
-                "add-json",
-                name,
-                json.dumps(entry),
-                "--client-secret",
-            ],
+            ["claude", "mcp", "add-json", name, json.dumps(entry), "-s", scope],
             check=True,
-            env=env,
+            capture_output=True,
+            text=True,
             timeout=30,
         )
     except subprocess.CalledProcessError as exc:
         raise RuntimeError(f"Failed to add MCP server '{name}' via claude CLI.") from exc
+
+
+def _is_missing_mcp_server_output(output: str) -> bool:
+    normalized = output.lower()
+    return (
+        "not found" in normalized
+        or "no mcp server" in normalized
+        or "no server named" in normalized
+        or ("mcp server found with name" in normalized and "no " in normalized)
+    )
+
+
+def remove_claude_mcp_server(name: str, scope: str) -> bool:
+    try:
+        subprocess.run(
+            ["claude", "mcp", "remove", name, "-s", scope],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return True
+    except subprocess.CalledProcessError as exc:
+        output = f"{exc.stderr or ''}\n{exc.stdout or ''}"
+        if _is_missing_mcp_server_output(output):
+            return False
+        raise RuntimeError(f"Failed to remove MCP server '{name}' via claude CLI.") from exc
+
+
+def add_codex_mcp_server(name: str, url: str) -> None:
+    try:
+        subprocess.run(
+            [
+                "codex",
+                "mcp",
+                "add",
+                name,
+                "--url",
+                url,
+                "--bearer-token-env-var",
+                MCP_AUTH_TOKEN_ENV_VAR,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"Failed to add MCP server '{name}' via codex CLI.") from exc
+
+
+def remove_codex_mcp_server(name: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["codex", "mcp", "remove", name],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"Timed out removing MCP server '{name}' via codex CLI.") from exc
+
+    output = f"{result.stderr or ''}\n{result.stdout or ''}"
+    if _is_missing_mcp_server_output(output):
+        return False
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to remove MCP server '{name}' via codex CLI.")
+    return True
+
+
+def add_gemini_mcp_server(name: str, url: str) -> None:
+    try:
+        subprocess.run(
+            [
+                "gemini",
+                "mcp",
+                "add",
+                name,
+                url,
+                "--type",
+                "http",
+                "--scope",
+                MCP_USER_SCOPE,
+                "--header",
+                f"Authorization: Bearer ${{{MCP_AUTH_TOKEN_ENV_VAR}}}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"Failed to add MCP server '{name}' via gemini CLI.") from exc
+
+
+def remove_gemini_mcp_server(name: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["gemini", "mcp", "remove", name, "--scope", MCP_USER_SCOPE],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"Timed out removing MCP server '{name}' via gemini CLI.") from exc
+
+    output = f"{result.stderr or ''}\n{result.stdout or ''}"
+    if _is_missing_mcp_server_output(output):
+        return False
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to remove MCP server '{name}' via gemini CLI.")
+    return True
+
+
+def available_mcp_clients() -> list[str]:
+    return [client for client, spec in MCP_CLIENTS.items() if shutil.which(str(spec["binary"]))]
+
+
+def configure_client_mcp_server(client: str, name: str, url: str, entry: dict) -> list[str]:
+    if client == "claude":
+        removed_scopes = [
+            scope for scope in MCP_CLEANUP_SCOPES if remove_claude_mcp_server(name, scope)
+        ]
+        add_claude_mcp_server(name, entry, MCP_USER_SCOPE)
+        return removed_scopes
+    if client == "codex":
+        removed = remove_codex_mcp_server(name)
+        add_codex_mcp_server(name, url)
+        return [MCP_USER_SCOPE] if removed else []
+    if client == "gemini":
+        removed = remove_gemini_mcp_server(name)
+        add_gemini_mcp_server(name, url)
+        return [MCP_USER_SCOPE] if removed else []
+    if client == "opencode":
+        removed = opencode.write_mcp_server_config(name, url)
+        return [MCP_USER_SCOPE] if removed else []
+    raise RuntimeError(f"Unsupported MCP client '{client}'.")
+
+
+def _coerce_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "y"}:
+            return True
+        if normalized in {"0", "false", "no", "n"}:
+            return False
+    return None
+
+
+def _mcp_marker_value(connection: dict) -> bool | None:
+    containers = [connection]
+    options = connection.get("options")
+    if isinstance(options, dict):
+        containers.append(options)
+
+    for container in containers:
+        for marker in MCP_CONNECTION_MARKERS:
+            if marker in container:
+                value = _coerce_bool(container.get(marker))
+                if value is not None:
+                    return value
+    return None
+
+
+def is_external_mcp_connection(connection: dict) -> bool:
+    connection_type = connection.get("connection_type")
+    if not isinstance(connection_type, str) or connection_type.upper() != "HTTP":
+        return False
+
+    marker_value = _mcp_marker_value(connection)
+    if marker_value is False:
+        return False
+    return True
+
+
+def external_mcp_connection_names(connections: list[dict]) -> list[str]:
+    names: set[str] = set()
+    for connection in connections:
+        if not is_external_mcp_connection(connection):
+            continue
+        name = connection.get("name")
+        if isinstance(name, str) and name.strip():
+            names.add(name.strip())
+    return sorted(names)
+
+
+def discover_external_mcp_connection_names(workspace: str) -> list[str]:
+    return external_mcp_connection_names(list_databricks_connections(workspace))
+
+
+def build_mcp_server_options(available_external_names: list[str]) -> list[tuple[str, str]]:
+    options = [
+        (f"{EXTERNAL_MCP_SELECTION_PREFIX}{name}", name) for name in available_external_names
+    ]
+    if not available_external_names:
+        options.append((MANUAL_EXTERNAL_MCP_VALUE, "External MCP connection"))
+    options.extend(
+        [
+            (SQL_MCP_VALUE, "Databricks SQL"),
+            (VECTOR_SEARCH_VALUE, "Vector Search"),
+            (GENIE_VALUE, "Genie Space"),
+            (UC_FUNCTIONS_VALUE, "Unity Catalog functions"),
+            (CUSTOM_MCP_VALUE, "Custom MCP URLs"),
+        ]
+    )
+    return options
+
+
+def prompt_for_manual_external_mcp_connection() -> str | None:
+    server_name = console.input(
+        f"  {label('MCP server name')} {muted('(e.g. confluence-mcp, jira-mcp)')} {muted('›')} "
+    ).strip()
+    if not server_name:
+        print_err("Server name cannot be empty.")
+        return None
+    return server_name
+
+
+def prompt_for_mcp_server_selection(available_external_names: list[str]) -> str:
+    options = build_mcp_server_options(available_external_names)
+    option_index = 1
+
+    console.print()
+    console.print("  [bold]External MCP Servers[/bold]")
+    for value, option_label in options:
+        if value == SQL_MCP_VALUE:
+            break
+        if value == MANUAL_EXTERNAL_MCP_VALUE or value.startswith(EXTERNAL_MCP_SELECTION_PREFIX):
+            console.print(f"    [bold]{option_index}.[/bold] [cyan]{option_label}[/cyan]")
+            option_index += 1
+
+    console.print("  [bold]Databricks SQL[/bold]")
+    console.print(f"    [bold]{option_index}.[/bold] [cyan]Databricks SQL[/cyan]")
+    option_index += 1
+
+    console.print("  [bold]Databricks Managed MCP Servers[/bold]")
+    console.print(f"    [bold]{option_index}.[/bold] [cyan]Vector Search[/cyan]")
+    option_index += 1
+    console.print(f"    [bold]{option_index}.[/bold] [cyan]Genie Space[/cyan]")
+    option_index += 1
+    console.print(f"    [bold]{option_index}.[/bold] [cyan]Unity Catalog functions[/cyan]")
+    option_index += 1
+
+    console.print("  [bold]Custom MCP URLs[/bold]")
+    console.print(f"    [bold]{option_index}.[/bold] [cyan]Custom MCP URLs[/cyan]")
+    console.print("  [dim]Press Enter when finished.[/dim]")
+
+    while True:
+        raw_value = console.input(f"{label('Select MCP server')} {muted('›')} ").strip()
+        if raw_value in {"", "0", "done"}:
+            return "done"
+        if raw_value.isdigit():
+            selected_index = int(raw_value)
+            if 1 <= selected_index <= len(options):
+                return options[selected_index - 1][0]
+        print_err("Please enter a valid option number.")
 
 
 def configure_mcp_command() -> int:
@@ -62,54 +335,67 @@ def configure_mcp_command() -> int:
     if not workspace:
         raise RuntimeError("Workspace is not configured. Run `coding-gateway configure` first.")
 
-    if not shutil.which("claude"):
+    clients = available_mcp_clients()
+    if not clients:
         raise RuntimeError(
-            "`claude` CLI is not installed. Install it with: npm install -g @anthropic-ai/claude-code"
+            "No supported MCP clients are installed. Install Claude, Codex, Gemini, or OpenCode."
         )
+    missing_clients = [client for client in MCP_CLIENTS if client not in clients]
 
     ensure_databricks_auth(workspace)
 
     print_section("MCP Server Configuration")
-    print_note("Configure Claude Code to connect to Databricks MCP servers.")
+    print_note("Configure installed coding tools to connect to Databricks MCP servers.")
     print_note(f"Workspace: {workspace}")
+    print_note(
+        "Databricks MCP servers are written to installed coding tool user MCP configs. "
+        f"Auth uses `{MCP_AUTH_TOKEN_ENV_VAR}`, which coding-gateway sets before launching tools."
+    )
+    configured_client_names = ", ".join(str(MCP_CLIENTS[client]["display"]) for client in clients)
+    print_note(f"Configuring MCP clients: {configured_client_names}")
+    for client in missing_clients:
+        print_warning(f"{MCP_CLIENTS[client]['display']} is not installed; skipping MCP config.")
 
-    print_heading("OAuth Credentials")
-    print_note("These will be used for all MCP servers added in this session.")
-    client_id = prompt_for_client_id()
-    client_secret = prompt_for_client_secret()
+    available_external_mcp_names: list[str] = []
+    try:
+        available_external_mcp_names = discover_external_mcp_connection_names(workspace)
+    except RuntimeError as exc:
+        print_warning(f"{exc} You can still enter an MCP connection name manually.")
 
-    state["mcp_oauth"] = {"client_id": client_id, "client_secret": client_secret}
+    if available_external_mcp_names:
+        print_success(
+            f"Found {len(available_external_mcp_names)} external MCP connection"
+            f"{'' if len(available_external_mcp_names) == 1 else 's'}."
+        )
+    else:
+        print_warning("No external MCP connections were discovered.")
+
     mcp_servers: list[dict] = list(state.get("mcp_servers") or [])
 
     added: list[str] = []
 
     print_section("Add MCP Server")
     while True:
-        selection = prompt_for_choice(
-            "Select server type",
-            [
-                ("external", "External MCP server (e.g. confluence-mcp, jira-mcp)"),
-                ("uc-functions", "UC Functions (Unity Catalog AI functions)"),
-                ("genie", "Genie (AI/BI dashboard)"),
-                ("custom", "Custom MCP server URL"),
-                ("done", "Done — exit"),
-            ],
-        )
+        selection = prompt_for_mcp_server_selection(available_external_mcp_names)
 
         if selection == "done":
             break
 
-        if selection == "external":
-            server_name = console.input(
-                f"  {label('MCP server name')} {muted('(e.g. confluence-mcp, jira-mcp)')} {muted('›')} "
-            ).strip()
+        if selection.startswith(EXTERNAL_MCP_SELECTION_PREFIX):
+            if selection == MANUAL_EXTERNAL_MCP_VALUE:
+                server_name = prompt_for_manual_external_mcp_connection()
+            else:
+                server_name = selection.removeprefix(EXTERNAL_MCP_SELECTION_PREFIX)
             if not server_name:
-                print_err("Server name cannot be empty.")
                 continue
             url = f"{workspace}/api/2.0/mcp/external/{server_name}"
             entry_name = server_name
 
-        elif selection == "uc-functions":
+        elif selection == SQL_MCP_VALUE:
+            url = f"{workspace}/api/2.0/mcp/sql"
+            entry_name = "databricks-sql"
+
+        elif selection == UC_FUNCTIONS_VALUE:
             catalog = console.input(f"  {label('Catalog name')} {muted('›')} ").strip()
             schema = console.input(f"  {label('Schema name')} {muted('›')} ").strip()
             if not catalog or not schema:
@@ -118,7 +404,17 @@ def configure_mcp_command() -> int:
             url = f"{workspace}/api/2.0/mcp/functions/{catalog}/{schema}"
             entry_name = f"databricks-uc-{catalog}-{schema}"
 
-        elif selection == "genie":
+        elif selection == VECTOR_SEARCH_VALUE:
+            catalog = console.input(f"  {label('Catalog name')} {muted('›')} ").strip()
+            schema = console.input(f"  {label('Schema name')} {muted('›')} ").strip()
+            index_name = console.input(f"  {label('Index name')} {muted('›')} ").strip()
+            if not catalog or not schema or not index_name:
+                print_err("Catalog, schema, and index name cannot be empty.")
+                continue
+            url = f"{workspace}/api/2.0/mcp/vector-search/{catalog}/{schema}/{index_name}"
+            entry_name = f"databricks-vector-search-{catalog}-{schema}-{index_name}"
+
+        elif selection == GENIE_VALUE:
             space_id = console.input(f"  {label('Genie space ID')} {muted('›')} ").strip()
             if not space_id:
                 print_err("Space ID cannot be empty.")
@@ -126,7 +422,7 @@ def configure_mcp_command() -> int:
             url = f"{workspace}/api/2.0/mcp/genie/{space_id}"
             entry_name = f"databricks-genie-{space_id}"
 
-        elif selection == "custom":
+        elif selection == CUSTOM_MCP_VALUE:
             url = console.input(f"  {label('Full MCP server URL')} {muted('›')} ").strip()
             if not url:
                 print_err("URL cannot be empty.")
@@ -139,15 +435,23 @@ def configure_mcp_command() -> int:
         else:
             continue
 
-        entry = build_mcp_http_entry(url, client_id)
-        add_claude_mcp_server(entry_name, entry, client_secret)
+        entry = build_mcp_http_entry(url)
+        for client in clients:
+            removed_scopes = configure_client_mcp_server(client, entry_name, url, entry)
+            if removed_scopes:
+                scope_text = ", ".join(removed_scopes)
+                print_warning(
+                    f"Found existing {MCP_CLIENTS[client]['display']} MCP entry "
+                    f"`{entry_name}` in: {scope_text}. Updating it."
+                )
         added.append(entry_name)
+        mcp_servers = [server for server in mcp_servers if server.get("name") != entry_name]
         mcp_servers.append(
             {
                 "name": entry_name,
                 "url": url,
-                "client_id": client_id,
-                "client_secret": client_secret,
+                "auth": f"env:{MCP_AUTH_TOKEN_ENV_VAR}",
+                "clients": clients,
             }
         )
         state["mcp_servers"] = mcp_servers
@@ -161,6 +465,5 @@ def configure_mcp_command() -> int:
     print_heading("MCP Configured")
     for name in added:
         console.print(f"  [bold green]●[/bold green] [cyan]{name}[/cyan]")
-    print_success("MCP servers registered via `claude mcp add-json`")
-    print_note("Run `claude mcp list` to see all configured servers.")
+    print_success("MCP servers registered in installed coding tool user MCP configs")
     return 0

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 from coding_tool_gateway.agents import claude
 
 WS = "https://example.databricks.com"
@@ -102,3 +104,24 @@ class TestClaudeValidateCmd:
         assert "--max-turns" in cmd
         idx = cmd.index("--max-turns")
         assert cmd[idx + 1] == "1"
+
+
+class TestClaudeLaunch:
+    def test_sets_oauth_token_before_exec(self, monkeypatch):
+        exec_calls: list[tuple[str, list[str]]] = []
+
+        def fake_execvp(binary: str, args: list[str]) -> None:
+            exec_calls.append((binary, args))
+            raise RuntimeError("stop")
+
+        monkeypatch.delenv("OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr(claude, "get_databricks_token", lambda workspace: "fresh-token")
+        monkeypatch.setattr(os, "execvp", fake_execvp)
+
+        try:
+            claude.launch({"workspace": WS}, ["--debug"])
+        except RuntimeError as exc:
+            assert str(exc) == "stop"
+
+        assert os.environ["OAUTH_TOKEN"] == "fresh-token"
+        assert exec_calls == [("claude", ["claude", "--debug"])]

--- a/tests/test_agent_codex.py
+++ b/tests/test_agent_codex.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 from coding_tool_gateway.agents import codex
 
 WS = "https://example.databricks.com"
@@ -72,3 +74,24 @@ class TestCodexValidateCmd:
     def test_has_prompt(self):
         cmd = codex.validate_cmd("codex")
         assert len(cmd) > 2
+
+
+class TestCodexLaunch:
+    def test_sets_oauth_token_before_exec(self, monkeypatch):
+        exec_calls: list[tuple[str, list[str]]] = []
+
+        def fake_execvp(binary: str, args: list[str]) -> None:
+            exec_calls.append((binary, args))
+            raise RuntimeError("stop")
+
+        monkeypatch.delenv("OAUTH_TOKEN", raising=False)
+        monkeypatch.setattr(codex, "get_databricks_token", lambda workspace: "fresh-token")
+        monkeypatch.setattr(os, "execvp", fake_execvp)
+
+        try:
+            codex.launch({"workspace": WS}, ["--search"])
+        except RuntimeError as exc:
+            assert str(exc) == "stop"
+
+        assert os.environ["OAUTH_TOKEN"] == "fresh-token"
+        assert exec_calls == [("codex", ["codex", "--search"])]

--- a/tests/test_agent_gemini.py
+++ b/tests/test_agent_gemini.py
@@ -31,6 +31,10 @@ class TestRenderEnvOverlay:
         env = gemini.render_env_overlay(WS, "gemini-2.0-flash", "tok123")
         assert env["GEMINI_API_KEY"] == "tok123"
 
+    def test_sets_oauth_token_for_mcp(self):
+        env = gemini.render_env_overlay(WS, "gemini-2.0-flash", "tok123")
+        assert env["OAUTH_TOKEN"] == "tok123"
+
     def test_sets_bearer_auth_mechanism(self):
         env = gemini.render_env_overlay(WS, "gemini-2.0-flash", "tok123")
         assert env["GEMINI_API_KEY_AUTH_MECHANISM"] == "bearer"
@@ -50,6 +54,10 @@ class TestBuildRuntimeEnv:
     def test_sets_base_url(self):
         env = gemini.build_runtime_env(WS, "gemini-2", "tok")
         assert env["GOOGLE_GEMINI_BASE_URL"] == f"{WS}/ai-gateway/gemini"
+
+    def test_sets_oauth_token_for_mcp(self):
+        env = gemini.build_runtime_env(WS, "gemini-2", "tok")
+        assert env["OAUTH_TOKEN"] == "tok"
 
 
 class TestGeminiDefaultModel:
@@ -87,3 +95,6 @@ class TestGeminiManagedKeys:
 
     def test_managed_keys_includes_api_key(self):
         assert "GEMINI_API_KEY" in gemini.MANAGED_KEYS
+
+    def test_managed_keys_includes_oauth_token(self):
+        assert "OAUTH_TOKEN" in gemini.MANAGED_KEYS

--- a/tests/test_agent_opencode.py
+++ b/tests/test_agent_opencode.py
@@ -98,6 +98,82 @@ class TestRenderOverlay:
         assert "claude-haiku" in provider_models
 
 
+class TestMcpServerConfig:
+    def test_builds_remote_server_entry_with_oauth_token_env_header(self):
+        entry = opencode.build_mcp_server_entry(f"{WS}/api/2.0/mcp/external/github")
+
+        assert entry == {
+            "type": "remote",
+            "url": f"{WS}/api/2.0/mcp/external/github",
+            "enabled": True,
+            "headers": {"Authorization": "Bearer {env:OAUTH_TOKEN}"},
+        }
+
+    def test_writes_mcp_server_without_clobbering_existing_config(self, tmp_path, monkeypatch):
+        import coding_tool_gateway.agents.opencode as oc_mod
+        import coding_tool_gateway.config_io as config_io_mod
+
+        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
+        config_file = tmp_path / "opencode.json"
+        backup_file = tmp_path / "opencode-backup.json"
+        monkeypatch.setattr(oc_mod, "OPENCODE_CONFIG_PATH", config_file)
+        monkeypatch.setattr(oc_mod, "OPENCODE_BACKUP_PATH", backup_file)
+
+        config_file.write_text(
+            json.dumps(
+                {
+                    "model": "existing-model",
+                    "mcp": {"old-server": {"type": "local", "command": ["old"]}},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        removed = oc_mod.write_mcp_server_config(
+            "github",
+            f"{WS}/api/2.0/mcp/external/github",
+        )
+
+        written = json.loads(config_file.read_text())
+        assert removed is False
+        assert written["model"] == "existing-model"
+        assert written["mcp"]["old-server"] == {"type": "local", "command": ["old"]}
+        assert written["mcp"]["github"] == {
+            "type": "remote",
+            "url": f"{WS}/api/2.0/mcp/external/github",
+            "enabled": True,
+            "headers": {"Authorization": "Bearer {env:OAUTH_TOKEN}"},
+        }
+
+    def test_reports_replaced_mcp_server(self, tmp_path, monkeypatch):
+        import coding_tool_gateway.agents.opencode as oc_mod
+        import coding_tool_gateway.config_io as config_io_mod
+
+        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
+        config_file = tmp_path / "opencode.json"
+        backup_file = tmp_path / "opencode-backup.json"
+        monkeypatch.setattr(oc_mod, "OPENCODE_CONFIG_PATH", config_file)
+        monkeypatch.setattr(oc_mod, "OPENCODE_BACKUP_PATH", backup_file)
+
+        config_file.write_text(json.dumps({"mcp": {"github": {"old": True}}}), encoding="utf-8")
+
+        removed = oc_mod.write_mcp_server_config(
+            "github",
+            f"{WS}/api/2.0/mcp/external/github",
+        )
+
+        assert removed is True
+        written = json.loads(config_file.read_text())
+        assert written["mcp"]["github"]["url"] == f"{WS}/api/2.0/mcp/external/github"
+
+
+class TestBuildRuntimeEnv:
+    def test_sets_oauth_token_for_mcp(self):
+        env = opencode.build_runtime_env("tok")
+
+        assert env["OAUTH_TOKEN"] == "tok"
+
+
 class TestOpencodeDefaultModel:
     def test_prefers_anthropic(self):
         state = {"opencode_models": {"anthropic": ["claude-sonnet"], "gemini": ["gemini-2"]}}

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import json
+import subprocess
+
 import pytest
 
+import coding_tool_gateway.databricks as db_mod
 from coding_tool_gateway.databricks import (
     AI_GATEWAY_V2_DOCS_URL,
     build_auth_shell_command,
@@ -11,6 +15,7 @@ from coding_tool_gateway.databricks import (
     build_opencode_base_urls,
     build_shared_base_urls,
     build_tool_base_url,
+    list_databricks_connections,
     workspace_hostname,
 )
 
@@ -104,6 +109,49 @@ class TestBuildAuthShellCommand:
     def test_unsets_scrubbed_vars(self):
         cmd = build_auth_shell_command(WS)
         assert "DATABRICKS_TOKEN" in cmd
+
+
+class TestListDatabricksConnections:
+    def test_lists_paginated_connections_with_workspace_env(self, monkeypatch):
+        calls: list[dict] = []
+
+        def fake_run(args, **kwargs):
+            calls.append({"args": args, "kwargs": kwargs})
+            if "--page-token" in args:
+                payload = {"connections": [{"name": "jira-mcp", "connection_type": "HTTP"}]}
+            else:
+                payload = {
+                    "connections": [{"name": "confluence-mcp", "connection_type": "HTTP"}],
+                    "next_page_token": "next-page",
+                }
+            return subprocess.CompletedProcess(args, 0, stdout=json.dumps(payload))
+
+        monkeypatch.setattr(db_mod, "run", fake_run)
+
+        assert list_databricks_connections(WS) == [
+            {"name": "confluence-mcp", "connection_type": "HTTP"},
+            {"name": "jira-mcp", "connection_type": "HTTP"},
+        ]
+        assert calls[0]["args"] == [
+            "databricks",
+            "connections",
+            "list",
+            "--max-results",
+            "0",
+            "--output",
+            "json",
+        ]
+        assert calls[0]["kwargs"]["env"]["DATABRICKS_HOST"] == WS
+        assert calls[1]["args"][-2:] == ["--page-token", "next-page"]
+
+    def test_raises_on_invalid_json(self, monkeypatch):
+        def fake_run(args, **kwargs):
+            return subprocess.CompletedProcess(args, 0, stdout="not-json")
+
+        monkeypatch.setattr(db_mod, "run", fake_run)
+
+        with pytest.raises(RuntimeError, match="invalid JSON"):
+            list_databricks_connections(WS)
 
 
 class TestEnsureAiGatewayV2:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,553 @@
+"""Tests for MCP server registration."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import MagicMock
+
+from coding_tool_gateway import mcp
+
+WS = "https://example.databricks.com"
+
+
+class TestBuildMcpHttpEntry:
+    def test_uses_http_url(self):
+        entry = mcp.build_mcp_http_entry(f"{WS}/api/2.0/mcp/external/github")
+        assert entry["type"] == "http"
+        assert entry["url"] == f"{WS}/api/2.0/mcp/external/github"
+
+    def test_uses_oauth_token_header_reference(self):
+        entry = mcp.build_mcp_http_entry(f"{WS}/api/2.0/mcp/external/github")
+        assert entry["headers"]["Authorization"] == "Bearer ${OAUTH_TOKEN}"
+        assert "oauth" not in entry
+        assert "headersHelper" not in entry
+
+
+class TestAddClaudeMcpServer:
+    def test_adds_user_scoped_json(self, monkeypatch):
+        calls: list[dict] = []
+
+        def fake_run(args, **kwargs):
+            calls.append({"args": args, "kwargs": kwargs})
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+
+        entry = mcp.build_mcp_http_entry(f"{WS}/api/2.0/mcp/external/github")
+        mcp.add_claude_mcp_server("github", entry)
+
+        assert calls
+        args = calls[0]["args"]
+        assert args[:4] == ["claude", "mcp", "add-json", "github"]
+        assert json.loads(args[4]) == entry
+        assert args[5:] == ["-s", "user"]
+        assert "--client-secret" not in args
+        assert "env" not in calls[0]["kwargs"]
+
+
+class TestAddCodexMcpServer:
+    def test_adds_http_server_with_bearer_token_env(self, monkeypatch):
+        calls: list[dict] = []
+
+        def fake_run(args, **kwargs):
+            calls.append({"args": args, "kwargs": kwargs})
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+
+        mcp.add_codex_mcp_server("github", f"{WS}/api/2.0/mcp/external/github")
+
+        assert calls == [
+            {
+                "args": [
+                    "codex",
+                    "mcp",
+                    "add",
+                    "github",
+                    "--url",
+                    f"{WS}/api/2.0/mcp/external/github",
+                    "--bearer-token-env-var",
+                    "OAUTH_TOKEN",
+                ],
+                "kwargs": {
+                    "check": True,
+                    "capture_output": True,
+                    "text": True,
+                    "timeout": 30,
+                },
+            }
+        ]
+
+
+class TestAddGeminiMcpServer:
+    def test_adds_user_scoped_http_server_with_auth_header(self, monkeypatch):
+        calls: list[dict] = []
+
+        def fake_run(args, **kwargs):
+            calls.append({"args": args, "kwargs": kwargs})
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+
+        mcp.add_gemini_mcp_server("github", f"{WS}/api/2.0/mcp/external/github")
+
+        assert calls == [
+            {
+                "args": [
+                    "gemini",
+                    "mcp",
+                    "add",
+                    "github",
+                    f"{WS}/api/2.0/mcp/external/github",
+                    "--type",
+                    "http",
+                    "--scope",
+                    "user",
+                    "--header",
+                    "Authorization: Bearer ${OAUTH_TOKEN}",
+                ],
+                "kwargs": {
+                    "check": True,
+                    "capture_output": True,
+                    "text": True,
+                    "timeout": 30,
+                },
+            }
+        ]
+
+
+class TestRemoveClaudeMcpServer:
+    def test_returns_true_when_server_removed(self, monkeypatch):
+        calls: list[list[str]] = []
+
+        def fake_run(args, **kwargs):
+            calls.append(args)
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+
+        assert mcp.remove_claude_mcp_server("github", "user") is True
+        assert calls == [["claude", "mcp", "remove", "github", "-s", "user"]]
+
+    def test_returns_false_when_server_missing(self, monkeypatch):
+        def fake_run(args, **kwargs):
+            raise subprocess.CalledProcessError(1, args, stderr="No MCP server named github found")
+
+        monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+
+        assert mcp.remove_claude_mcp_server("github", "user") is False
+
+    def test_returns_false_when_project_local_server_missing(self, monkeypatch):
+        def fake_run(args, **kwargs):
+            raise subprocess.CalledProcessError(
+                1,
+                args,
+                stderr="No project-local MCP server found with name: github",
+            )
+
+        monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+
+        assert mcp.remove_claude_mcp_server("github", "project") is False
+
+    def test_returns_false_when_user_scoped_server_missing(self, monkeypatch):
+        def fake_run(args, **kwargs):
+            raise subprocess.CalledProcessError(
+                1,
+                args,
+                stderr="No user-scoped MCP server found with name: github",
+            )
+
+        monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+
+        assert mcp.remove_claude_mcp_server("github", "user") is False
+
+    def test_unexpected_failure_raises(self, monkeypatch):
+        def fake_run(args, **kwargs):
+            raise subprocess.CalledProcessError(1, args, stderr="permission denied")
+
+        monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+
+        try:
+            mcp.remove_claude_mcp_server("github", "user")
+        except RuntimeError as exc:
+            assert "Failed to remove MCP server 'github'" in str(exc)
+        else:
+            raise AssertionError("expected RuntimeError")
+
+
+class TestExternalMcpConnectionNames:
+    def test_returns_sorted_http_connection_names(self):
+        assert mcp.external_mcp_connection_names(
+            [
+                {"name": "jira-mcp", "connection_type": "HTTP"},
+                {"name": "not-http", "connection_type": "POSTGRESQL"},
+                {"name": "confluence-mcp", "connection_type": "http"},
+                {"name": "jira-mcp", "connection_type": "HTTP"},
+            ]
+        ) == ["confluence-mcp", "jira-mcp"]
+
+    def test_excludes_explicit_non_mcp_http_connections(self):
+        assert mcp.external_mcp_connection_names(
+            [
+                {
+                    "name": "analytics-api",
+                    "connection_type": "HTTP",
+                    "options": {"is_mcp": "false"},
+                },
+                {"name": "github-mcp", "connection_type": "HTTP", "options": {"is_mcp": "true"}},
+            ]
+        ) == ["github-mcp"]
+
+
+class TestBuildMcpServerOptions:
+    def test_includes_discovered_mcps_in_initial_options(self):
+        assert mcp.build_mcp_server_options(["confluence-mcp", "github-mcp"]) == [
+            ("external:confluence-mcp", "confluence-mcp"),
+            ("external:github-mcp", "github-mcp"),
+            ("managed:sql", "Databricks SQL"),
+            ("vector-search", "Vector Search"),
+            ("genie", "Genie Space"),
+            ("uc-functions", "Unity Catalog functions"),
+            ("custom", "Custom MCP URLs"),
+        ]
+
+    def test_keeps_manual_external_option_when_none_discovered(self):
+        assert mcp.build_mcp_server_options([])[0] == (
+            "external:manual",
+            "External MCP connection",
+        )
+
+    def test_prompt_renders_managed_servers_after_sql_and_before_custom(self, monkeypatch, capsys):
+        monkeypatch.setattr(mcp.console, "input", lambda *args, **kwargs: "")
+
+        assert mcp.prompt_for_mcp_server_selection(["github-mcp"]) == "done"
+
+        output = capsys.readouterr().out
+        assert output.index("External MCP Servers") < output.index("Databricks SQL")
+        assert output.index("Databricks SQL") < output.index("Databricks Managed MCP Servers")
+        assert output.index("Vector Search") < output.index("Custom MCP URLs")
+        assert output.index("Genie Space") < output.index("Custom MCP URLs")
+        assert output.index("Unity Catalog functions") < output.index("Custom MCP URLs")
+        assert "Built-in AI tools" not in output
+
+
+class TestConfigureMcpCommand:
+    def test_registers_external_server_without_oauth_state(self, monkeypatch):
+        saved_states: list[dict] = []
+        removed: list[tuple[str, str]] = []
+        added: list[tuple[str, dict, str]] = []
+        selections = iter(["external:manual", "done"])
+
+        monkeypatch.setattr(mcp, "load_state", lambda: {"workspace": WS})
+        monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+        monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace: None)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
+        monkeypatch.setattr(mcp, "discover_external_mcp_connection_names", lambda workspace: [])
+        monkeypatch.setattr(
+            mcp, "prompt_for_mcp_server_selection", lambda *args, **kwargs: next(selections)
+        )
+        monkeypatch.setattr(mcp.console, "input", lambda *args, **kwargs: "github")
+        monkeypatch.setattr(
+            mcp,
+            "remove_claude_mcp_server",
+            lambda name, scope: removed.append((name, scope)) or False,
+        )
+        monkeypatch.setattr(
+            mcp,
+            "add_claude_mcp_server",
+            lambda name, entry, scope: added.append((name, entry, scope)),
+        )
+        monkeypatch.setattr(mcp, "save_state", lambda state: saved_states.append(state.copy()))
+
+        assert mcp.configure_mcp_command() == 0
+
+        assert removed == [
+            ("github", "local"),
+            ("github", "project"),
+            ("github", "user"),
+        ]
+        assert added == [
+            (
+                "github",
+                {
+                    "type": "http",
+                    "url": f"{WS}/api/2.0/mcp/external/github",
+                    "headers": {"Authorization": "Bearer ${OAUTH_TOKEN}"},
+                },
+                "user",
+            )
+        ]
+        assert saved_states
+        assert "mcp_oauth" not in saved_states[-1]
+        assert saved_states[-1]["mcp_servers"] == [
+            {
+                "name": "github",
+                "url": f"{WS}/api/2.0/mcp/external/github",
+                "auth": "env:OAUTH_TOKEN",
+                "clients": ["claude"],
+            }
+        ]
+
+    def test_updates_existing_server_state_by_name(self, monkeypatch):
+        saved_states: list[dict] = []
+        selections = iter(["external:manual", "done"])
+
+        monkeypatch.setattr(
+            mcp,
+            "load_state",
+            lambda: {
+                "workspace": WS,
+                "mcp_servers": [
+                    {
+                        "name": "github",
+                        "url": f"{WS}/old",
+                        "client_id": "old-client-id",
+                        "client_secret": "old-client-secret",
+                    }
+                ],
+            },
+        )
+        monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+        monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace: None)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
+        monkeypatch.setattr(mcp, "discover_external_mcp_connection_names", lambda workspace: [])
+        monkeypatch.setattr(
+            mcp, "prompt_for_mcp_server_selection", lambda *args, **kwargs: next(selections)
+        )
+        monkeypatch.setattr(mcp.console, "input", lambda *args, **kwargs: "github")
+        monkeypatch.setattr(mcp, "remove_claude_mcp_server", lambda name, scope: False)
+        monkeypatch.setattr(mcp, "add_claude_mcp_server", lambda name, entry, scope: None)
+        monkeypatch.setattr(mcp, "save_state", lambda state: saved_states.append(state.copy()))
+
+        assert mcp.configure_mcp_command() == 0
+
+        assert saved_states[-1]["mcp_servers"] == [
+            {
+                "name": "github",
+                "url": f"{WS}/api/2.0/mcp/external/github",
+                "auth": "env:OAUTH_TOKEN",
+                "clients": ["claude"],
+            }
+        ]
+
+    def test_registers_discovered_external_server(self, monkeypatch):
+        saved_states: list[dict] = []
+        configured: list[tuple[str, str, str, dict]] = []
+        selections = iter(["external:github-mcp", "done"])
+        option_lists: list[list[tuple[str, str]]] = []
+
+        monkeypatch.setattr(mcp, "load_state", lambda: {"workspace": WS})
+        monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+        monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace: None)
+        monkeypatch.setattr(
+            mcp,
+            "available_mcp_clients",
+            lambda: ["claude", "codex", "gemini", "opencode"],
+        )
+        monkeypatch.setattr(
+            mcp,
+            "discover_external_mcp_connection_names",
+            lambda workspace: ["confluence-mcp", "github-mcp"],
+        )
+
+        def fake_prompt_for_mcp_server_selection(*args, **kwargs):
+            option_lists.append(mcp.build_mcp_server_options(["confluence-mcp", "github-mcp"]))
+            return next(selections)
+
+        monkeypatch.setattr(
+            mcp,
+            "prompt_for_mcp_server_selection",
+            fake_prompt_for_mcp_server_selection,
+        )
+
+        def fake_configure_client_mcp_server(client, name, url, entry):
+            configured.append((client, name, url, entry))
+            return []
+
+        monkeypatch.setattr(mcp, "configure_client_mcp_server", fake_configure_client_mcp_server)
+        monkeypatch.setattr(mcp, "save_state", lambda state: saved_states.append(state.copy()))
+
+        assert mcp.configure_mcp_command() == 0
+
+        assert option_lists[0][:2] == [
+            ("external:confluence-mcp", "confluence-mcp"),
+            ("external:github-mcp", "github-mcp"),
+        ]
+        expected_entry = {
+            "type": "http",
+            "url": f"{WS}/api/2.0/mcp/external/github-mcp",
+            "headers": {"Authorization": "Bearer ${OAUTH_TOKEN}"},
+        }
+        assert configured == [
+            (
+                "claude",
+                "github-mcp",
+                f"{WS}/api/2.0/mcp/external/github-mcp",
+                expected_entry,
+            ),
+            ("codex", "github-mcp", f"{WS}/api/2.0/mcp/external/github-mcp", expected_entry),
+            ("gemini", "github-mcp", f"{WS}/api/2.0/mcp/external/github-mcp", expected_entry),
+            ("opencode", "github-mcp", f"{WS}/api/2.0/mcp/external/github-mcp", expected_entry),
+        ]
+        assert saved_states[-1]["mcp_servers"] == [
+            {
+                "name": "github-mcp",
+                "url": f"{WS}/api/2.0/mcp/external/github-mcp",
+                "auth": "env:OAUTH_TOKEN",
+                "clients": ["claude", "codex", "gemini", "opencode"],
+            }
+        ]
+
+    def test_registers_databricks_sql_server(self, monkeypatch):
+        saved_states: list[dict] = []
+        configured: list[tuple[str, str, str, dict]] = []
+        selections = iter(["managed:sql", "done"])
+
+        monkeypatch.setattr(mcp, "load_state", lambda: {"workspace": WS})
+        monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+        monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace: None)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
+        monkeypatch.setattr(mcp, "discover_external_mcp_connection_names", lambda workspace: [])
+        monkeypatch.setattr(
+            mcp, "prompt_for_mcp_server_selection", lambda *args, **kwargs: next(selections)
+        )
+        monkeypatch.setattr(
+            mcp,
+            "configure_client_mcp_server",
+            lambda client, name, url, entry: configured.append((client, name, url, entry)) or [],
+        )
+        monkeypatch.setattr(mcp, "save_state", lambda state: saved_states.append(state.copy()))
+
+        assert mcp.configure_mcp_command() == 0
+
+        assert configured == [
+            (
+                "claude",
+                "databricks-sql",
+                f"{WS}/api/2.0/mcp/sql",
+                {
+                    "type": "http",
+                    "url": f"{WS}/api/2.0/mcp/sql",
+                    "headers": {"Authorization": "Bearer ${OAUTH_TOKEN}"},
+                },
+            )
+        ]
+        assert saved_states[-1]["mcp_servers"] == [
+            {
+                "name": "databricks-sql",
+                "url": f"{WS}/api/2.0/mcp/sql",
+                "auth": "env:OAUTH_TOKEN",
+                "clients": ["claude"],
+            }
+        ]
+
+    def test_registers_vector_search_server(self, monkeypatch):
+        saved_states: list[dict] = []
+        configured: list[tuple[str, str, str, dict]] = []
+        selections = iter(["vector-search", "done"])
+
+        monkeypatch.setattr(mcp, "load_state", lambda: {"workspace": WS})
+        monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+        monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace: None)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
+        monkeypatch.setattr(mcp, "discover_external_mcp_connection_names", lambda workspace: [])
+        monkeypatch.setattr(
+            mcp, "prompt_for_mcp_server_selection", lambda *args, **kwargs: next(selections)
+        )
+        inputs = iter(["main", "search", "docs-index"])
+        monkeypatch.setattr(mcp.console, "input", lambda *args, **kwargs: next(inputs))
+        monkeypatch.setattr(
+            mcp,
+            "configure_client_mcp_server",
+            lambda client, name, url, entry: configured.append((client, name, url, entry)) or [],
+        )
+        monkeypatch.setattr(mcp, "save_state", lambda state: saved_states.append(state.copy()))
+
+        assert mcp.configure_mcp_command() == 0
+
+        assert configured == [
+            (
+                "claude",
+                "databricks-vector-search-main-search-docs-index",
+                f"{WS}/api/2.0/mcp/vector-search/main/search/docs-index",
+                {
+                    "type": "http",
+                    "url": f"{WS}/api/2.0/mcp/vector-search/main/search/docs-index",
+                    "headers": {"Authorization": "Bearer ${OAUTH_TOKEN}"},
+                },
+            )
+        ]
+
+    def test_registers_genie_space_server(self, monkeypatch):
+        saved_states: list[dict] = []
+        configured: list[tuple[str, str, str, dict]] = []
+        selections = iter(["genie", "done"])
+
+        monkeypatch.setattr(mcp, "load_state", lambda: {"workspace": WS})
+        monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+        monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace: None)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
+        monkeypatch.setattr(mcp, "discover_external_mcp_connection_names", lambda workspace: [])
+        monkeypatch.setattr(
+            mcp, "prompt_for_mcp_server_selection", lambda *args, **kwargs: next(selections)
+        )
+        monkeypatch.setattr(mcp.console, "input", lambda *args, **kwargs: "space-123")
+        monkeypatch.setattr(
+            mcp,
+            "configure_client_mcp_server",
+            lambda client, name, url, entry: configured.append((client, name, url, entry)) or [],
+        )
+        monkeypatch.setattr(mcp, "save_state", lambda state: saved_states.append(state.copy()))
+
+        assert mcp.configure_mcp_command() == 0
+
+        assert configured == [
+            (
+                "claude",
+                "databricks-genie-space-123",
+                f"{WS}/api/2.0/mcp/genie/space-123",
+                {
+                    "type": "http",
+                    "url": f"{WS}/api/2.0/mcp/genie/space-123",
+                    "headers": {"Authorization": "Bearer ${OAUTH_TOKEN}"},
+                },
+            )
+        ]
+
+    def test_registers_uc_functions_server(self, monkeypatch):
+        saved_states: list[dict] = []
+        configured: list[tuple[str, str, str, dict]] = []
+        selections = iter(["uc-functions", "done"])
+        inputs = iter(["main", "tools"])
+
+        monkeypatch.setattr(mcp, "load_state", lambda: {"workspace": WS})
+        monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+        monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace: None)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
+        monkeypatch.setattr(mcp, "discover_external_mcp_connection_names", lambda workspace: [])
+        monkeypatch.setattr(
+            mcp, "prompt_for_mcp_server_selection", lambda *args, **kwargs: next(selections)
+        )
+        monkeypatch.setattr(mcp.console, "input", lambda *args, **kwargs: next(inputs))
+        monkeypatch.setattr(
+            mcp,
+            "configure_client_mcp_server",
+            lambda client, name, url, entry: configured.append((client, name, url, entry)) or [],
+        )
+        monkeypatch.setattr(mcp, "save_state", lambda state: saved_states.append(state.copy()))
+
+        assert mcp.configure_mcp_command() == 0
+
+        assert configured == [
+            (
+                "claude",
+                "databricks-uc-main-tools",
+                f"{WS}/api/2.0/mcp/functions/main/tools",
+                {
+                    "type": "http",
+                    "url": f"{WS}/api/2.0/mcp/functions/main/tools",
+                    "headers": {"Authorization": "Bearer ${OAUTH_TOKEN}"},
+                },
+            )
+        ]


### PR DESCRIPTION
  ## What did you change, and why?
  - Expanded `coding-gateway configure mcp` from Claude-only setup to installed MCP-capable tools: Claude Code, Codex, Gemini CLI, and OpenCode.
  - Switched MCP auth to a Databricks token passed through `OAUTH_TOKEN` when launching tools, removing stored MCP OAuth client credentials from state.
  - Added discovery of Databricks HTTP connections for external MCP entries, plus Databricks SQL, Vector Search, Genie, UC Functions, and custom MCP URL
  setup.
  - Updated README/status text and added focused tests for bootstrap, Databricks connection listing, MCP registration, and per-agent `OAUTH_TOKEN` runtime
  behavior.

  ## How do you know it works?

  - `uv run pytest` -> 291 passed, 16 skipped.
  - `uv run ruff check .` -> All checks passed.