### PR TITLE
Rename project from coding-gateway to ucode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,19 +2,19 @@
 
 ## Project
 
-`coding-gateway` is a Python CLI that configures and launches coding agents through Databricks AI Gateway.
+`ucode` is a Python CLI that configures and launches coding agents through Databricks AI Gateway.
 
-The package code lives in `src/coding_tool_gateway/`.
+The package code lives in `src/ucode/`.
 Tests live in `tests/`.
 
 ## Commands
 
 - Run the full test suite with `uv run pytest`.
 - Run focused tests with `uv run pytest tests/<file>.py`.
-- Run e2e tests with `CODING_GATEWAY_TEST_WORKSPACE=<db_workspace_url> uv run pytest tests/test_e2e.py -v`.
+- Run e2e tests with `UCODE_TEST_WORKSPACE=<db_workspace_url> uv run pytest tests/test_e2e.py -v`.
 - Run lint with `uv run ruff check .`.
-- Run the CLI from the current checkout with `uv run coding-gateway ...`.
-- Reinstall the local checkout as the `coding-gateway` tool with `uv tool install --reinstall .`.
+- Run the CLI from the current checkout with `uv run ucode ...`.
+- Reinstall the local checkout as the `ucode` tool with `uv tool install --reinstall .`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Databricks Coding Gateway
+# ucode
 
-`coding-gateway` is a lightweight launcher for running Codex, Claude Code, Gemini CLI, OpenCode, and GitHub Copilot CLI through Databricks.
+`ucode` is a lightweight launcher for running Codex, Claude Code, Gemini CLI, OpenCode, and GitHub Copilot CLI through Databricks.
 
 ## Requirements
 
@@ -10,7 +10,7 @@
 ## Installation
 
 ```bash
-uv tool install git+https://github.com/databricks/coding-gateway
+uv tool install git+https://github.com/databricks/ucode
 ```
 
 ---
@@ -20,20 +20,20 @@ uv tool install git+https://github.com/databricks/coding-gateway
 Just run the tool you want:
 
 ```bash
-coding-gateway codex      # OpenAI Codex
-coding-gateway claude     # Claude Code
-coding-gateway gemini     # Gemini CLI
-coding-gateway opencode   # OpenCode
-coding-gateway copilot    # GitHub Copilot CLI
+ucode codex      # OpenAI Codex
+ucode claude     # Claude Code
+ucode gemini     # Gemini CLI
+ucode opencode   # OpenCode
+ucode copilot    # GitHub Copilot CLI
 ```
 
-On first launch, `coding-gateway` will prompt for your Databricks workspace URL, authenticate, and configure that tool automatically. Subsequent launches go straight to the agent.
+On first launch, `ucode` will prompt for your Databricks workspace URL, authenticate, and configure that tool automatically. Subsequent launches go straight to the agent.
 
 Pass flags directly to the underlying tool:
 
 ```bash
-coding-gateway claude -r          # resume last session
-coding-gateway codex --full-auto
+ucode claude -r          # resume last session
+ucode codex --full-auto
 ```
 
 All agents route through Databricks AI Gateway using your workspace credentials — no API keys required.
@@ -41,13 +41,13 @@ All agents route through Databricks AI Gateway using your workspace credentials 
 To configure all tools at once:
 
 ```bash
-coding-gateway configure
+ucode configure
 ```
 
 ### MCP servers (optional)
 
 ```bash
-coding-gateway configure mcp
+ucode configure mcp
 ```
 
 Add Databricks MCP servers to installed MCP-capable tools: Codex, Claude Code, Gemini CLI, OpenCode, and GitHub Copilot CLI.
@@ -59,7 +59,7 @@ Options are shown in this order:
 - Custom MCP server URL
 
 Discovered external MCP connections are listed directly. MCP auth uses a Databricks token that
-`coding-gateway` sets when launching each tool.
+`ucode` sets when launching each tool.
 
 ---
 
@@ -67,14 +67,14 @@ Discovered external MCP connections are listed directly. MCP auth uses a Databri
 
 | Command | Description |
 |---------|-------------|
-| `coding-gateway status` | Show current workspace, base URLs, managed config files, and selected models |
-| `coding-gateway usage` | Show AI Gateway usage summary |
-| `coding-gateway revert` | Clear saved state and restore backed-up config files |
-| `coding-gateway configure --dry-run` | Preview config files without writing them |
+| `ucode status` | Show current workspace, base URLs, managed config files, and selected models |
+| `ucode usage` | Show AI Gateway usage summary |
+| `ucode revert` | Clear saved state and restore backed-up config files |
+| `ucode configure --dry-run` | Preview config files without writing them |
 
 ## Managed Local Files
 
-`coding-gateway` manages these files:
+`ucode` manages these files:
 
 | File | Tool |
 |------|------|
@@ -84,7 +84,7 @@ Discovered external MCP connections are listed directly. MCP auth uses a Databri
 | `~/.config/opencode/opencode.json` | OpenCode |
 | `~/.copilot/.env` | GitHub Copilot CLI |
 
-Existing files are backed up before being overwritten. `coding-gateway revert` restores backups.
+Existing files are backed up before being overwritten. `ucode revert` restores backups.
 
 
 ## Documentation
@@ -101,8 +101,8 @@ Contributions are welcome.
 ### Getting started
 
 ```bash
-git clone https://github.com/databricks/coding-gateway
-cd coding-gateway
+git clone https://github.com/databricks/ucode
+cd ucode
 uv sync
 ```
 
@@ -120,15 +120,15 @@ uv sync
 4. For end-to-end testing against a real workspace:
 
    ```bash
-   CODING_GATEWAY_TEST_WORKSPACE=<db_workspace_url> uv run pytest tests/test_e2e.py -v
+   UCODE_TEST_WORKSPACE=<db_workspace_url> uv run pytest tests/test_e2e.py -v
    ```
 
 5. Open a pull request against `main`.
 
 ### Adding a new agent
 
-- Add `src/coding_tool_gateway/agents/<name>.py` with at least `write_tool_config`, `launch`, `default_model`, and `validate_cmd`.
-- Register it in `src/coding_tool_gateway/agents/__init__.py`.
+- Add `src/ucode/agents/<name>.py` with at least `write_tool_config`, `launch`, `default_model`, and `validate_cmd`.
+- Register it in `src/ucode/agents/__init__.py`.
 - Add focused tests under `tests/`.
 
 ## Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["uv_build>=0.11.0"]
 build-backend = "uv_build"
 
 [project]
-name = "coding-gateway"
+name = "ucode"
 version = "0.1.0"
 description = "Bootstrap Codex against a Databricks workspace with minimal setup."
 readme = "README.md"
@@ -16,10 +16,10 @@ dependencies = [
 ]
 
 [project.scripts]
-coding-gateway = "coding_tool_gateway.cli:main"
+ucode = "ucode.cli:main"
 
 [tool.uv.build-backend]
-module-name = "coding_tool_gateway"
+module-name = "ucode"
 
 [dependency-groups]
 dev = [

--- a/src/coding_tool_gateway/__init__.py
+++ b/src/coding_tool_gateway/__init__.py
@@ -1,1 +1,0 @@
-"""coding-gateway package."""

--- a/src/ucode/__init__.py
+++ b/src/ucode/__init__.py
@@ -1,0 +1,1 @@
+"""ucode package."""

--- a/src/ucode/agents/__init__.py
+++ b/src/ucode/agents/__init__.py
@@ -16,13 +16,13 @@ import json
 import shutil
 import subprocess
 
-from coding_tool_gateway.config_io import ToolSpec
-from coding_tool_gateway.databricks import (
+from ucode.config_io import ToolSpec
+from ucode.databricks import (
     ensure_databricks_auth,
     install_databricks_cli,
 )
-from coding_tool_gateway.state import load_state, save_state
-from coding_tool_gateway.ui import (
+from ucode.state import load_state, save_state
+from ucode.ui import (
     console,
     print_err,
     print_section,
@@ -110,7 +110,7 @@ def ensure_tool_binary_available(tool: str) -> None:
     raise RuntimeError(
         f"{spec['display']} is not installed (`{binary}` was not found on PATH). "
         f"Install it with `npm install -g {spec['package']}` or run "
-        f"`coding-gateway configure` to try automatic installation."
+        f"`ucode configure` to try automatic installation."
     )
 
 
@@ -133,8 +133,7 @@ def resolve_launch_model(
     model = explicit_model or default_model_for_tool(tool, state)
     if not model:
         raise RuntimeError(
-            f"No models available for {tool}. "
-            f"Run `coding-gateway configure` to set up your workspace."
+            f"No models available for {tool}. Run `ucode configure` to set up your workspace."
         )
     return state, model
 
@@ -227,12 +226,12 @@ def ensure_provider_state(tool: str) -> dict:
     state = load_state()
     workspace = state.get("workspace")
     if not workspace:
-        raise RuntimeError("No workspace configured. Run `coding-gateway configure` first.")
+        raise RuntimeError("No workspace configured. Run `ucode configure` first.")
     available_tools = state.get("available_tools") or []
     if tool not in available_tools:
         raise RuntimeError(
             f"{TOOL_SPECS[tool]['display']} is not available on this workspace. "
-            f"Run `coding-gateway configure` to set up your agents."
+            f"Run `ucode configure` to set up your agents."
         )
     ensure_databricks_auth(workspace)
     return state
@@ -278,7 +277,7 @@ def validate_tool(tool: str) -> tuple[bool, str]:
 def validate_all_tools(state: dict) -> None:
     from rich.panel import Panel  # local to avoid bumping module-level deps
 
-    from coding_tool_gateway.config_io import restore_file
+    from ucode.config_io import restore_file
 
     console.print()
     console.print(
@@ -315,6 +314,6 @@ def validate_all_tools(state: dict) -> None:
             spec = TOOL_SPECS[tool]
             lines.append(
                 f"[green]✓[/green] [bold]{spec['display']}[/bold] — "
-                f"run with [cyan]coding-gateway --agent {tool}[/cyan]"
+                f"run with [cyan]ucode --agent {tool}[/cyan]"
             )
         console.print(Panel("\n".join(lines), title="Ready", style="green", expand=False))

--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from coding_tool_gateway.config_io import (
+from ucode.config_io import (
     APP_DIR,
     ToolSpec,
     backup_existing_file,
@@ -13,12 +13,12 @@ from coding_tool_gateway.config_io import (
     read_json_safe,
     write_json_file,
 )
-from coding_tool_gateway.databricks import (
+from ucode.databricks import (
     build_auth_shell_command,
     build_tool_base_url,
     get_databricks_token,
 )
-from coding_tool_gateway.state import mark_tool_managed, save_state
+from ucode.state import mark_tool_managed, save_state
 
 CLAUDE_CONFIG_DIR = Path.home() / ".claude"
 CLAUDE_SETTINGS_PATH = CLAUDE_CONFIG_DIR / "settings.json"

--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-from coding_tool_gateway.config_io import (
+from ucode.config_io import (
     APP_DIR,
     ToolSpec,
     backup_existing_file,
@@ -13,12 +13,12 @@ from coding_tool_gateway.config_io import (
     read_toml_safe,
     write_toml_file,
 )
-from coding_tool_gateway.databricks import (
+from ucode.databricks import (
     build_auth_shell_command,
     build_tool_base_url,
     get_databricks_token,
 )
-from coding_tool_gateway.state import mark_tool_managed, save_state
+from ucode.state import mark_tool_managed, save_state
 
 CODEX_CONFIG_DIR = Path.home() / ".codex"
 CODEX_CONFIG_PATH = CODEX_CONFIG_DIR / "config.toml"

--- a/src/ucode/agents/copilot.py
+++ b/src/ucode/agents/copilot.py
@@ -20,7 +20,7 @@ import subprocess
 import threading
 from pathlib import Path
 
-from coding_tool_gateway.config_io import (
+from ucode.config_io import (
     APP_DIR,
     ToolSpec,
     backup_existing_file,
@@ -29,12 +29,12 @@ from coding_tool_gateway.config_io import (
     write_dotenv,
     write_json_file,
 )
-from coding_tool_gateway.databricks import (
+from ucode.databricks import (
     TOKEN_REFRESH_INTERVAL_SECONDS,
     build_copilot_base_url,
     get_databricks_token,
 )
-from coding_tool_gateway.state import mark_tool_managed, save_state
+from ucode.state import mark_tool_managed, save_state
 
 COPILOT_CONFIG_DIR = Path.home() / ".copilot"
 COPILOT_ENV_PATH = COPILOT_CONFIG_DIR / ".env"

--- a/src/ucode/agents/gemini.py
+++ b/src/ucode/agents/gemini.py
@@ -8,7 +8,7 @@ import subprocess
 import threading
 from pathlib import Path
 
-from coding_tool_gateway.config_io import (
+from ucode.config_io import (
     APP_DIR,
     ToolSpec,
     backup_existing_file,
@@ -17,12 +17,12 @@ from coding_tool_gateway.config_io import (
     write_dotenv,
     write_json_file,
 )
-from coding_tool_gateway.databricks import (
+from ucode.databricks import (
     TOKEN_REFRESH_INTERVAL_SECONDS,
     build_tool_base_url,
     get_databricks_token,
 )
-from coding_tool_gateway.state import mark_tool_managed, save_state
+from ucode.state import mark_tool_managed, save_state
 
 GEMINI_CONFIG_DIR = Path.home() / ".gemini"
 GEMINI_ENV_PATH = GEMINI_CONFIG_DIR / ".env"

--- a/src/ucode/agents/opencode.py
+++ b/src/ucode/agents/opencode.py
@@ -8,7 +8,7 @@ import subprocess
 import threading
 from pathlib import Path
 
-from coding_tool_gateway.config_io import (
+from ucode.config_io import (
     APP_DIR,
     ToolSpec,
     backup_existing_file,
@@ -16,12 +16,12 @@ from coding_tool_gateway.config_io import (
     read_json_safe,
     write_json_file,
 )
-from coding_tool_gateway.databricks import (
+from ucode.databricks import (
     TOKEN_REFRESH_INTERVAL_SECONDS,
     build_opencode_base_urls,
     get_databricks_token,
 )
-from coding_tool_gateway.state import mark_tool_managed, save_state
+from ucode.state import mark_tool_managed, save_state
 
 OPENCODE_CONFIG_DIR = Path.home() / ".config" / "opencode"
 OPENCODE_CONFIG_PATH = OPENCODE_CONFIG_DIR / "opencode.json"

--- a/src/ucode/bootstrap.py
+++ b/src/ucode/bootstrap.py
@@ -1,9 +1,9 @@
-"""Best-effort runtime/bootstrap installer for coding-gateway dependencies."""
+"""Best-effort runtime/bootstrap installer for ucode dependencies."""
 
 from __future__ import annotations
 
-from coding_tool_gateway.agents import TOOL_SPECS, ensure_bootstrap_dependencies
-from coding_tool_gateway.ui import print_err
+from ucode.agents import TOOL_SPECS, ensure_bootstrap_dependencies
+from ucode.ui import print_err
 
 
 def main() -> int:
@@ -11,7 +11,7 @@ def main() -> int:
         for tool in TOOL_SPECS:
             ensure_bootstrap_dependencies(tool)
     except RuntimeError as exc:
-        print_err(f"coding-gateway bootstrap failed: {exc}")
+        print_err(f"ucode bootstrap failed: {exc}")
         return 1
     return 0
 

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""CLI entry point for coding-gateway."""
+"""CLI entry point for ucode."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 from rich.panel import Panel
 
-from coding_tool_gateway.agents import (
+from ucode.agents import (
     TOOL_SPECS,
     configure_all_tools,
     configure_single_tool,
@@ -22,11 +22,11 @@ from coding_tool_gateway.agents import (
     validate_all_tools,
     validate_tool,
 )
-from coding_tool_gateway.agents import (
+from ucode.agents import (
     launch as launch_agent,
 )
-from coding_tool_gateway.config_io import restore_file, set_dry_run
-from coding_tool_gateway.databricks import (
+from ucode.config_io import restore_file, set_dry_run
+from ucode.databricks import (
     build_shared_base_urls,
     ensure_ai_gateway_v2,
     ensure_databricks_auth,
@@ -39,9 +39,9 @@ from coding_tool_gateway.databricks import (
     normalize_workspace_url,
     run_databricks_login,
 )
-from coding_tool_gateway.mcp import configure_mcp_command
-from coding_tool_gateway.state import STATE_PATH, clear_state, load_state, save_state
-from coding_tool_gateway.ui import (
+from ucode.mcp import configure_mcp_command
+from ucode.state import STATE_PATH, clear_state, load_state, save_state
+from ucode.ui import (
     console,
     heading,
     print_err,
@@ -54,7 +54,7 @@ from coding_tool_gateway.ui import (
     spinner,
     status_badge,
 )
-from coding_tool_gateway.usage import usage as usage_report
+from ucode.usage import usage as usage_report
 
 
 def _prompt_for_configuration(tool: str | None = None) -> str:
@@ -124,7 +124,35 @@ def configure_shared_state(
     return state
 
 
-def configure_workspace_command() -> int:
+def configure_workspace_command(tool: str | None = None) -> int:
+    if tool is not None:
+        workspace = _prompt_for_configuration(tool)
+        state = configure_shared_state(workspace, tools=[tool], force_login=True)
+        state = configure_single_tool(tool, state)
+        spec = TOOL_SPECS[tool]
+        console.print(
+            Panel(
+                f"[bold]Workspace:[/bold] [cyan]{state['workspace']}[/cyan]\n"
+                f"[bold]{spec['display']}:[/bold] [green]configured[/green]",
+                title="Configuration Complete",
+                style="green",
+                expand=False,
+            )
+        )
+        with spinner(f"Validating {spec['display']}..."):
+            ok, err = validate_tool(tool)
+        if ok:
+            print_success(f"{spec['display']} is working")
+        else:
+            print_err(f"{spec['display']}: {err}")
+            managed = bool(state.get("managed_configs", {}).get(tool))
+            restore_file(spec["config_path"], spec["backup_path"], managed)
+            available_tools = [t for t in (state.get("available_tools") or []) if t != tool]
+            state["available_tools"] = available_tools
+            save_state(state)
+            raise RuntimeError(f"{spec['display']} validation failed — config reverted.")
+        return 0
+
     workspace = _prompt_for_configuration()
     state = configure_shared_state(workspace, force_login=True)
     state = configure_all_tools(state)
@@ -133,8 +161,8 @@ def configure_workspace_command() -> int:
     summary_lines = [
         f"[bold]Workspace:[/bold] [cyan]{state['workspace']}[/cyan]",
     ]
-    for tool, spec in TOOL_SPECS.items():
-        if tool in available_tools:
+    for tool_name, spec in TOOL_SPECS.items():
+        if tool_name in available_tools:
             summary_lines.append(f"[bold]{spec['display']}:[/bold] [green]configured[/green]")
         else:
             summary_lines.append(f"[bold]{spec['display']}:[/bold] [dim]not available[/dim]")
@@ -157,7 +185,7 @@ def status() -> int:
     workspace = state.get("workspace")
     managed_configs = state.get("managed_configs") or {}
 
-    console.print(heading("coding-gateway status"))
+    console.print(heading("ucode status"))
     console.print(
         f"  {status_badge('Configured', 'ok') if workspace else status_badge('Not Configured', 'warn')}"
     )
@@ -180,13 +208,13 @@ def status() -> int:
 
     print_heading("MCP Servers")
     print_note("Run each tool's MCP list command to see configured MCP servers.")
-    print_note("Run `coding-gateway configure mcp` to add Databricks MCP servers.")
+    print_note("Run `ucode configure mcp` to add Databricks MCP servers.")
 
     print_heading("State")
     print_kv("State file", str(STATE_PATH) if STATE_PATH.exists() else "missing")
-    print_note("Use `coding-gateway configure` to update workspace settings or tool models.")
-    print_note("Use `coding-gateway configure mcp` to add Databricks MCP servers to coding tools.")
-    print_note("Use `coding-gateway revert` to clear managed configs and restore prior files.")
+    print_note("Use `ucode configure` to update workspace settings or tool models.")
+    print_note("Use `ucode configure mcp` to add Databricks MCP servers to coding tools.")
+    print_note("Use `ucode revert` to clear managed configs and restore prior files.")
     return 0
 
 
@@ -206,7 +234,7 @@ def revert() -> int:
     print_kv("Workspace", state.get("workspace") or "none")
     for tool, spec in TOOL_SPECS.items():
         print_kv(f"{spec['display']} config", "restored" if results[tool] else "unchanged")
-    print_success("coding-gateway state cleared")
+    print_success("ucode state cleared")
     return 0
 
 
@@ -327,6 +355,13 @@ def configure(
     dry_run: Annotated[
         bool, typer.Option("--dry-run", help="Print config files without writing them.")
     ] = False,
+    agent: Annotated[
+        str | None,
+        typer.Option(
+            "--agent",
+            help="Configure only the named agent (e.g. claude, codex, gemini, opencode, copilot).",
+        ),
+    ] = None,
 ) -> None:
     """Configure workspace URL and AI Gateway."""
     if ctx.invoked_subcommand is not None:
@@ -334,9 +369,14 @@ def configure(
     set_dry_run(dry_run)
     try:
         install_databricks_cli()
-        for t in TOOL_SPECS:
-            install_tool_binary(t, strict=False)
-        configure_workspace_command()
+        if agent is not None:
+            tool = normalize_tool(agent)
+            install_tool_binary(tool, strict=True)
+            configure_workspace_command(tool)
+        else:
+            for t in TOOL_SPECS:
+                install_tool_binary(t, strict=False)
+            configure_workspace_command()
     except RuntimeError as exc:
         print_err(str(exc))
         raise typer.Exit(1) from None
@@ -370,7 +410,7 @@ def status_cmd() -> None:
 
 @app.command("revert")
 def revert_cmd() -> None:
-    """Clear coding-gateway state and restore backed-up agent config files."""
+    """Clear ucode state and restore backed-up agent config files."""
     try:
         revert()
     except RuntimeError as exc:
@@ -387,6 +427,28 @@ def usage_cmd() -> None:
     except RuntimeError as exc:
         print_err(str(exc))
         raise typer.Exit(1) from None
+
+
+@app.command("upgrade")
+def upgrade_cmd() -> None:
+    """Upgrade ucode to the latest version from GitHub."""
+    import subprocess
+
+    git_url = "git+https://github.com/databricks/ucode"
+    print_section("Upgrade")
+    print_kv("Source", git_url)
+    try:
+        subprocess.run(
+            ["uv", "tool", "install", "--reinstall", git_url],
+            check=True,
+        )
+    except FileNotFoundError:
+        print_err("`uv` was not found on PATH. Install uv to upgrade ucode.")
+        raise typer.Exit(1) from None
+    except subprocess.CalledProcessError as exc:
+        print_err(f"Upgrade failed (exit code {exc.returncode}).")
+        raise typer.Exit(1) from None
+    print_success("ucode upgraded")
 
 
 def main() -> None:

--- a/src/ucode/config_io.py
+++ b/src/ucode/config_io.py
@@ -9,7 +9,7 @@ from typing import TypedDict
 import tomlkit
 import tomlkit.exceptions
 
-from coding_tool_gateway.ui import console
+from ucode.ui import console
 
 
 class ToolSpec(TypedDict):
@@ -20,7 +20,7 @@ class ToolSpec(TypedDict):
     backup_path: Path
 
 
-APP_DIR = Path.home() / ".coding-gateway"
+APP_DIR = Path.home() / ".ucode"
 
 _dry_run = False
 

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -14,7 +14,7 @@ from urllib import error as urllib_error
 from urllib import request as urllib_request
 from urllib.parse import urlparse
 
-from coding_tool_gateway.ui import (
+from ucode.ui import (
     normalize_workspace_url,
     print_kv,
     print_note,

--- a/src/ucode/mcp.py
+++ b/src/ucode/mcp.py
@@ -6,10 +6,10 @@ import json
 import shutil
 import subprocess
 
-from coding_tool_gateway.agents import copilot, opencode
-from coding_tool_gateway.databricks import ensure_databricks_auth, list_databricks_connections
-from coding_tool_gateway.state import load_state, save_state
-from coding_tool_gateway.ui import (
+from ucode.agents import copilot, opencode
+from ucode.databricks import ensure_databricks_auth, list_databricks_connections
+from ucode.state import load_state, save_state
+from ucode.ui import (
     console,
     label,
     muted,
@@ -285,9 +285,7 @@ def build_mcp_server_options(available_external_names: list[str]) -> list[tuple[
 
 
 def prompt_for_manual_external_mcp_connection() -> str | None:
-    values = prompt_for_mcp_setup_fields(
-        [("MCP server name", "(e.g. confluence-mcp, jira-mcp)")]
-    )
+    values = prompt_for_mcp_setup_fields([("MCP server name", "(e.g. confluence-mcp, jira-mcp)")])
     if values is None:
         return None
     server_name = values[0]
@@ -356,7 +354,7 @@ def configure_mcp_command() -> int:
     state = load_state()
     workspace = state.get("workspace")
     if not workspace:
-        raise RuntimeError("Workspace is not configured. Run `coding-gateway configure` first.")
+        raise RuntimeError("Workspace is not configured. Run `ucode configure` first.")
 
     clients = available_mcp_clients()
     if not clients:
@@ -373,7 +371,7 @@ def configure_mcp_command() -> int:
     print_note(f"Workspace: {workspace}")
     print_note(
         "Databricks MCP servers are written to installed coding tool user MCP configs. "
-        f"Auth uses `{MCP_AUTH_TOKEN_ENV_VAR}`, which coding-gateway sets before launching tools."
+        f"Auth uses `{MCP_AUTH_TOKEN_ENV_VAR}`, which ucode sets before launching tools."
     )
     configured_client_names = ", ".join(str(MCP_CLIENTS[client]["display"]) for client in clients)
     print_note(f"Configuring MCP clients: {configured_client_names}")
@@ -420,9 +418,7 @@ def configure_mcp_command() -> int:
             entry_name = "databricks-sql"
 
         elif selection == UC_FUNCTIONS_VALUE:
-            values = prompt_for_mcp_setup_fields(
-                [("Catalog name", None), ("Schema name", None)]
-            )
+            values = prompt_for_mcp_setup_fields([("Catalog name", None), ("Schema name", None)])
             if values is None:
                 continue
             catalog, schema = values

--- a/src/ucode/state.py
+++ b/src/ucode/state.py
@@ -1,11 +1,11 @@
-"""Persistent state for coding-gateway (per-workspace, versioned)."""
+"""Persistent state for ucode (per-workspace, versioned)."""
 
 from __future__ import annotations
 
 import json
 
-from coding_tool_gateway.config_io import APP_DIR, is_dry_run
-from coding_tool_gateway.databricks import build_shared_base_urls
+from ucode.config_io import APP_DIR, is_dry_run
+from ucode.databricks import build_shared_base_urls
 
 STATE_PATH = APP_DIR / "state.json"
 STATE_VERSION = 3

--- a/src/ucode/ui.py
+++ b/src/ucode/ui.py
@@ -184,7 +184,7 @@ def prompt_for_workspace(
     them — `ui.py` stays Databricks-agnostic. Returns a normalized URL.
     """
     console.print()
-    console.print(Panel(description, title="coding-gateway Setup", style="bold blue", expand=False))
+    console.print(Panel(description, title="ucode Setup", style="bold blue", expand=False))
 
     if profiles:
         choices = [questionary.Choice(title=host, value=host) for host, _ in profiles]

--- a/src/ucode/usage.py
+++ b/src/ucode/usage.py
@@ -8,14 +8,14 @@ from __future__ import annotations
 from datetime import date, datetime, timedelta
 from typing import cast
 
-from coding_tool_gateway.databricks import (
+from ucode.databricks import (
     discover_sql_warehouse_http_path,
     ensure_databricks_auth,
     get_databricks_token,
     run_usage_query,
 )
-from coding_tool_gateway.state import load_state
-from coding_tool_gateway.ui import (
+from ucode.state import load_state
+from ucode.ui import (
     console,
     format_duration,
     format_token_count,
@@ -265,12 +265,12 @@ def render_usage_summary(
 
 def usage() -> int:
     # Late import to avoid circular import (agents → state, but usage uses TOOL_SPECS for displays).
-    from coding_tool_gateway.agents import TOOL_SPECS
+    from ucode.agents import TOOL_SPECS
 
     state = load_state()
     workspace = state.get("workspace")
     if not workspace:
-        raise RuntimeError("Workspace is not configured. Run `coding-gateway configure` first.")
+        raise RuntimeError("Workspace is not configured. Run `ucode configure` first.")
 
     ensure_databricks_auth(workspace)
     with spinner("Retrieving Databricks access token..."):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,18 +6,18 @@ import os
 
 import pytest
 
-from coding_tool_gateway.databricks import (
+from ucode.databricks import (
     build_shared_base_urls,
     fetch_ai_gateway_claude_models,
     fetch_codex_models,
     fetch_gemini_models,
     get_databricks_token,
 )
-from coding_tool_gateway.ui import normalize_workspace_url
+from ucode.ui import normalize_workspace_url
 
 
 def _workspace() -> str:
-    ws = os.environ.get("CODING_GATEWAY_TEST_WORKSPACE", "").strip().rstrip("/")
+    ws = os.environ.get("UCODE_TEST_WORKSPACE", "").strip().rstrip("/")
     return normalize_workspace_url(ws) if ws else ""
 
 
@@ -25,7 +25,7 @@ def _workspace() -> str:
 def e2e_workspace():
     ws = _workspace()
     if not ws:
-        pytest.skip("Set CODING_GATEWAY_TEST_WORKSPACE=https://... to run E2E tests")
+        pytest.skip("Set UCODE_TEST_WORKSPACE=https://... to run E2E tests")
     return ws
 
 

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 
-from coding_tool_gateway.agents import claude
+from ucode.agents import claude
 
 WS = "https://example.databricks.com"
 

--- a/tests/test_agent_codex.py
+++ b/tests/test_agent_codex.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 
-from coding_tool_gateway.agents import codex
+from ucode.agents import codex
 
 WS = "https://example.databricks.com"
 

--- a/tests/test_agent_copilot.py
+++ b/tests/test_agent_copilot.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from coding_tool_gateway.agents import copilot
+from ucode.agents import copilot
 
 WS = "https://example.databricks.com"
 
@@ -71,8 +71,8 @@ class TestMcpServerConfig:
         }
 
     def test_writes_mcp_server_without_clobbering_existing_config(self, tmp_path, monkeypatch):
-        import coding_tool_gateway.agents.copilot as cp_mod
-        import coding_tool_gateway.config_io as config_io_mod
+        import ucode.agents.copilot as cp_mod
+        import ucode.config_io as config_io_mod
 
         monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
         config_file = tmp_path / "mcp-config.json"
@@ -107,8 +107,8 @@ class TestMcpServerConfig:
         }
 
     def test_reports_replaced_mcp_server(self, tmp_path, monkeypatch):
-        import coding_tool_gateway.agents.copilot as cp_mod
-        import coding_tool_gateway.config_io as config_io_mod
+        import ucode.agents.copilot as cp_mod
+        import ucode.config_io as config_io_mod
 
         monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
         config_file = tmp_path / "mcp-config.json"

--- a/tests/test_agent_gemini.py
+++ b/tests/test_agent_gemini.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from coding_tool_gateway.agents import gemini
+from ucode.agents import gemini
 
 WS = "https://example.databricks.com"
 
@@ -104,17 +104,15 @@ class TestGeminiManagedKeys:
 
 class TestWriteToolConfigSetsAuthType:
     def test_writes_settings_json_with_gemini_api_key_auth(self, tmp_path, monkeypatch):
-        import coding_tool_gateway.config_io as config_io_mod
+        import ucode.config_io as config_io_mod
 
         settings_path = tmp_path / "settings.json"
         monkeypatch.setattr(gemini, "GEMINI_ENV_PATH", tmp_path / ".env")
         monkeypatch.setattr(gemini, "GEMINI_SETTINGS_PATH", settings_path)
         monkeypatch.setattr(gemini, "GEMINI_BACKUP_PATH", tmp_path / "backup")
         monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
-        monkeypatch.setattr("coding_tool_gateway.state.save_state", lambda s: None)
-        monkeypatch.setattr(
-            "coding_tool_gateway.agents.gemini.get_databricks_token", lambda ws: "fake-token"
-        )
+        monkeypatch.setattr("ucode.state.save_state", lambda s: None)
+        monkeypatch.setattr("ucode.agents.gemini.get_databricks_token", lambda ws: "fake-token")
 
         gemini.write_tool_config({"workspace": WS}, "some-model")
 
@@ -122,7 +120,7 @@ class TestWriteToolConfigSetsAuthType:
         assert settings["security"]["auth"]["selectedType"] == "gemini-api-key"
 
     def test_preserves_existing_settings_json_keys(self, tmp_path, monkeypatch):
-        import coding_tool_gateway.config_io as config_io_mod
+        import ucode.config_io as config_io_mod
 
         settings_path = tmp_path / "settings.json"
         settings_path.write_text(json.dumps({"theme": "dark", "otherKey": 123}))
@@ -130,10 +128,8 @@ class TestWriteToolConfigSetsAuthType:
         monkeypatch.setattr(gemini, "GEMINI_SETTINGS_PATH", settings_path)
         monkeypatch.setattr(gemini, "GEMINI_BACKUP_PATH", tmp_path / "backup")
         monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
-        monkeypatch.setattr("coding_tool_gateway.state.save_state", lambda s: None)
-        monkeypatch.setattr(
-            "coding_tool_gateway.agents.gemini.get_databricks_token", lambda ws: "fake-token"
-        )
+        monkeypatch.setattr("ucode.state.save_state", lambda s: None)
+        monkeypatch.setattr("ucode.agents.gemini.get_databricks_token", lambda ws: "fake-token")
 
         gemini.write_tool_config({"workspace": WS}, "some-model")
 

--- a/tests/test_agent_opencode.py
+++ b/tests/test_agent_opencode.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from unittest.mock import patch
 
-from coding_tool_gateway.agents import opencode
+from ucode.agents import opencode
 
 WS = "https://example.databricks.com"
 
@@ -110,8 +110,8 @@ class TestMcpServerConfig:
         }
 
     def test_writes_mcp_server_without_clobbering_existing_config(self, tmp_path, monkeypatch):
-        import coding_tool_gateway.agents.opencode as oc_mod
-        import coding_tool_gateway.config_io as config_io_mod
+        import ucode.agents.opencode as oc_mod
+        import ucode.config_io as config_io_mod
 
         monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
         config_file = tmp_path / "opencode.json"
@@ -146,8 +146,8 @@ class TestMcpServerConfig:
         }
 
     def test_reports_replaced_mcp_server(self, tmp_path, monkeypatch):
-        import coding_tool_gateway.agents.opencode as oc_mod
-        import coding_tool_gateway.config_io as config_io_mod
+        import ucode.agents.opencode as oc_mod
+        import ucode.config_io as config_io_mod
 
         monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
         config_file = tmp_path / "opencode.json"
@@ -204,8 +204,8 @@ class TestOpencodeValidateCmd:
 
 class TestWriteToolConfigStaleProviderCleanup:
     def test_stale_providers_removed_before_merge(self, tmp_path, monkeypatch):
-        import coding_tool_gateway.agents.opencode as oc_mod
-        import coding_tool_gateway.config_io as config_io_mod
+        import ucode.agents.opencode as oc_mod
+        import ucode.config_io as config_io_mod
 
         monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
         config_file = tmp_path / "opencode.json"
@@ -230,8 +230,8 @@ class TestWriteToolConfigStaleProviderCleanup:
         }
 
         with (
-            patch("coding_tool_gateway.agents.opencode.get_databricks_token", return_value="tok"),
-            patch("coding_tool_gateway.agents.opencode.save_state"),
+            patch("ucode.agents.opencode.get_databricks_token", return_value="tok"),
+            patch("ucode.agents.opencode.save_state"),
         ):
             oc_mod.write_tool_config(state, "claude-sonnet", token="tok")
 
@@ -243,8 +243,8 @@ class TestWriteToolConfigStaleProviderCleanup:
         assert providers.get("other-provider") == {"keep": True}
 
     def test_config_written_with_correct_model(self, tmp_path, monkeypatch):
-        import coding_tool_gateway.agents.opencode as oc_mod
-        import coding_tool_gateway.config_io as config_io_mod
+        import ucode.agents.opencode as oc_mod
+        import ucode.config_io as config_io_mod
 
         monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
         config_file = tmp_path / "opencode.json"
@@ -260,8 +260,8 @@ class TestWriteToolConfigStaleProviderCleanup:
         }
 
         with (
-            patch("coding_tool_gateway.agents.opencode.get_databricks_token", return_value="tok"),
-            patch("coding_tool_gateway.agents.opencode.save_state"),
+            patch("ucode.agents.opencode.get_databricks_token", return_value="tok"),
+            patch("ucode.agents.opencode.save_state"),
         ):
             oc_mod.write_tool_config(state, "claude-sonnet", token="tok")
 

--- a/tests/test_agents_init.py
+++ b/tests/test_agents_init.py
@@ -6,7 +6,7 @@ import subprocess
 
 import pytest
 
-from coding_tool_gateway.agents import (
+from ucode.agents import (
     DEFAULT_TOOL,
     TOOL_SPECS,
     check_gateway_endpoint,
@@ -143,7 +143,7 @@ class TestResolveLaunchModel:
 
 class TestInstallToolBinary:
     def test_non_strict_returns_false_when_npm_missing(self, monkeypatch):
-        monkeypatch.setattr("coding_tool_gateway.agents.shutil.which", lambda _: None)
+        monkeypatch.setattr("ucode.agents.shutil.which", lambda _: None)
 
         assert install_tool_binary("opencode", strict=False) is False
 
@@ -156,13 +156,13 @@ class TestInstallToolBinary:
         def fake_run(*args, **kwargs):
             raise subprocess.CalledProcessError(1, args[0])
 
-        monkeypatch.setattr("coding_tool_gateway.agents.shutil.which", fake_which)
-        monkeypatch.setattr("coding_tool_gateway.agents.subprocess.run", fake_run)
+        monkeypatch.setattr("ucode.agents.shutil.which", fake_which)
+        monkeypatch.setattr("ucode.agents.subprocess.run", fake_run)
 
         assert install_tool_binary("opencode", strict=False) is False
 
     def test_ensure_tool_binary_available_raises_when_missing(self, monkeypatch):
-        monkeypatch.setattr("coding_tool_gateway.agents.shutil.which", lambda _: None)
+        monkeypatch.setattr("ucode.agents.shutil.which", lambda _: None)
 
         with pytest.raises(RuntimeError, match="OpenCode is not installed"):
             ensure_tool_binary_available("opencode")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 from typer.testing import CliRunner
 
-from coding_tool_gateway.cli import app
+from ucode.cli import app
 
 runner = CliRunner()
 
@@ -18,13 +18,13 @@ TOOLS = ["codex", "claude", "gemini", "opencode"]
 def no_state_writes():
     """Prevent any test from writing to the real state file on disk."""
     with (
-        patch("coding_tool_gateway.state.save_state"),
-        patch("coding_tool_gateway.cli.save_state"),
-        patch("coding_tool_gateway.agents.__init__.save_state"),
-        patch("coding_tool_gateway.agents.codex.save_state"),
-        patch("coding_tool_gateway.agents.claude.save_state"),
-        patch("coding_tool_gateway.agents.gemini.save_state"),
-        patch("coding_tool_gateway.agents.opencode.save_state"),
+        patch("ucode.state.save_state"),
+        patch("ucode.cli.save_state"),
+        patch("ucode.agents.__init__.save_state"),
+        patch("ucode.agents.codex.save_state"),
+        patch("ucode.agents.claude.save_state"),
+        patch("ucode.agents.gemini.save_state"),
+        patch("ucode.agents.opencode.save_state"),
     ):
         yield
 
@@ -73,21 +73,21 @@ def _patch_launch(tool: str):
     the auto-configure path is skipped entirely.
     """
     return [
-        patch("coding_tool_gateway.cli.ensure_bootstrap_dependencies"),
-        patch("coding_tool_gateway.cli.load_state", return_value=MINIMAL_STATE),
+        patch("ucode.cli.ensure_bootstrap_dependencies"),
+        patch("ucode.cli.load_state", return_value=MINIMAL_STATE),
         patch(
-            "coding_tool_gateway.cli.ensure_provider_state",
+            "ucode.cli.ensure_provider_state",
             return_value=MINIMAL_STATE,
         ),
         patch(
-            "coding_tool_gateway.cli.resolve_launch_model",
+            "ucode.cli.resolve_launch_model",
             return_value=(MINIMAL_STATE, "databricks-claude-sonnet-4"),
         ),
         patch(
-            "coding_tool_gateway.cli.configure_tool",
+            "ucode.cli.configure_tool",
             return_value=MINIMAL_STATE,
         ),
-        patch("coding_tool_gateway.cli.launch_agent"),
+        patch("ucode.cli.launch_agent"),
     ]
 
 
@@ -121,19 +121,19 @@ class TestAutoConfigureOnFirstRun:
         empty_state = {}
         configured_state = {**MINIMAL_STATE}
         with (
-            patch("coding_tool_gateway.cli.ensure_bootstrap_dependencies"),
-            patch("coding_tool_gateway.cli.load_state", return_value=empty_state),
-            patch("coding_tool_gateway.cli._auto_configure_tool") as mock_auto,
+            patch("ucode.cli.ensure_bootstrap_dependencies"),
+            patch("ucode.cli.load_state", return_value=empty_state),
+            patch("ucode.cli._auto_configure_tool") as mock_auto,
             patch(
-                "coding_tool_gateway.cli.ensure_provider_state",
+                "ucode.cli.ensure_provider_state",
                 return_value=configured_state,
             ),
             patch(
-                "coding_tool_gateway.cli.resolve_launch_model",
+                "ucode.cli.resolve_launch_model",
                 return_value=(configured_state, "databricks-claude-sonnet-4"),
             ),
-            patch("coding_tool_gateway.cli.configure_tool", return_value=configured_state),
-            patch("coding_tool_gateway.cli.launch_agent"),
+            patch("ucode.cli.configure_tool", return_value=configured_state),
+            patch("ucode.cli.launch_agent"),
         ):
             result = runner.invoke(app, ["claude"])
         assert result.exit_code == 0, result.output
@@ -143,19 +143,19 @@ class TestAutoConfigureOnFirstRun:
         """Auto-configure runs when workspace exists but the tool wasn't configured."""
         state_without_tool = {**MINIMAL_STATE, "available_tools": ["codex"]}
         with (
-            patch("coding_tool_gateway.cli.ensure_bootstrap_dependencies"),
-            patch("coding_tool_gateway.cli.load_state", return_value=state_without_tool),
-            patch("coding_tool_gateway.cli._auto_configure_tool") as mock_auto,
+            patch("ucode.cli.ensure_bootstrap_dependencies"),
+            patch("ucode.cli.load_state", return_value=state_without_tool),
+            patch("ucode.cli._auto_configure_tool") as mock_auto,
             patch(
-                "coding_tool_gateway.cli.ensure_provider_state",
+                "ucode.cli.ensure_provider_state",
                 return_value=MINIMAL_STATE,
             ),
             patch(
-                "coding_tool_gateway.cli.resolve_launch_model",
+                "ucode.cli.resolve_launch_model",
                 return_value=(MINIMAL_STATE, "databricks-claude-sonnet-4"),
             ),
-            patch("coding_tool_gateway.cli.configure_tool", return_value=MINIMAL_STATE),
-            patch("coding_tool_gateway.cli.launch_agent"),
+            patch("ucode.cli.configure_tool", return_value=MINIMAL_STATE),
+            patch("ucode.cli.launch_agent"),
         ):
             result = runner.invoke(app, ["claude"])
         assert result.exit_code == 0, result.output
@@ -164,19 +164,19 @@ class TestAutoConfigureOnFirstRun:
     def test_skipped_when_already_configured(self):
         """Auto-configure is skipped when workspace and tool are already set up."""
         with (
-            patch("coding_tool_gateway.cli.ensure_bootstrap_dependencies"),
-            patch("coding_tool_gateway.cli.load_state", return_value=MINIMAL_STATE),
-            patch("coding_tool_gateway.cli._auto_configure_tool") as mock_auto,
+            patch("ucode.cli.ensure_bootstrap_dependencies"),
+            patch("ucode.cli.load_state", return_value=MINIMAL_STATE),
+            patch("ucode.cli._auto_configure_tool") as mock_auto,
             patch(
-                "coding_tool_gateway.cli.ensure_provider_state",
+                "ucode.cli.ensure_provider_state",
                 return_value=MINIMAL_STATE,
             ),
             patch(
-                "coding_tool_gateway.cli.resolve_launch_model",
+                "ucode.cli.resolve_launch_model",
                 return_value=(MINIMAL_STATE, "databricks-claude-sonnet-4"),
             ),
-            patch("coding_tool_gateway.cli.configure_tool", return_value=MINIMAL_STATE),
-            patch("coding_tool_gateway.cli.launch_agent"),
+            patch("ucode.cli.configure_tool", return_value=MINIMAL_STATE),
+            patch("ucode.cli.launch_agent"),
         ):
             runner.invoke(app, ["claude"])
         mock_auto.assert_not_called()
@@ -222,3 +222,61 @@ class TestPassthroughArgs:
             runner.invoke(app, ["claude"])
         forwarded = mock_launch.call_args[0][2]
         assert forwarded == []
+
+
+class TestConfigureAgentFlag:
+    def test_no_flag_calls_configure_all(self):
+        with (
+            patch("ucode.cli.install_databricks_cli"),
+            patch("ucode.cli.install_tool_binary"),
+            patch("ucode.cli.configure_workspace_command") as mock_cfg,
+        ):
+            result = runner.invoke(app, ["configure"])
+        assert result.exit_code == 0, result.output
+        mock_cfg.assert_called_once_with()
+
+    def test_agent_flag_calls_configure_with_tool(self):
+        with (
+            patch("ucode.cli.install_databricks_cli"),
+            patch("ucode.cli.install_tool_binary"),
+            patch("ucode.cli.configure_workspace_command") as mock_cfg,
+        ):
+            result = runner.invoke(app, ["configure", "--agent", "claude"])
+        assert result.exit_code == 0, result.output
+        mock_cfg.assert_called_once_with("claude")
+
+    def test_agent_flag_normalizes_alias(self):
+        with (
+            patch("ucode.cli.install_databricks_cli"),
+            patch("ucode.cli.install_tool_binary"),
+            patch("ucode.cli.configure_workspace_command") as mock_cfg,
+        ):
+            result = runner.invoke(app, ["configure", "--agent", "claude-code"])
+        assert result.exit_code == 0, result.output
+        mock_cfg.assert_called_once_with("claude")
+
+    def test_upgrade_runs_uv_tool_install(self):
+        with patch("subprocess.run") as mock_run:
+            result = runner.invoke(app, ["upgrade"])
+        assert result.exit_code == 0, result.output
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert cmd[:3] == ["uv", "tool", "install"]
+        assert "--reinstall" in cmd
+        assert any("github.com/databricks/ucode" in s for s in cmd)
+
+    def test_upgrade_handles_uv_missing(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = runner.invoke(app, ["upgrade"])
+        assert result.exit_code != 0
+        assert "uv" in result.output.lower()
+
+    def test_agent_flag_rejects_unknown(self):
+        with (
+            patch("ucode.cli.install_databricks_cli"),
+            patch("ucode.cli.install_tool_binary"),
+            patch("ucode.cli.configure_workspace_command") as mock_cfg,
+        ):
+            result = runner.invoke(app, ["configure", "--agent", "bogus"])
+        assert result.exit_code != 0
+        mock_cfg.assert_not_called()

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -7,8 +7,8 @@ import json
 import pytest
 import tomlkit
 
-import coding_tool_gateway.config_io as config_io
-from coding_tool_gateway.config_io import (
+import ucode.config_io as config_io
+from ucode.config_io import (
     backup_existing_file,
     deep_merge_dict,
     ensure_parent_dir,

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -8,8 +8,8 @@ import subprocess
 
 import pytest
 
-import coding_tool_gateway.databricks as db_mod
-from coding_tool_gateway.databricks import (
+import ucode.databricks as db_mod
+from ucode.databricks import (
     AI_GATEWAY_V2_DOCS_URL,
     build_auth_shell_command,
     build_databricks_cli_env,
@@ -45,7 +45,7 @@ class TestBuildDatabricksCliEnv:
         assert env["DATABRICKS_HOST"] == WS
 
     def test_scrubs_token_vars(self):
-        import coding_tool_gateway.databricks as db_mod
+        import ucode.databricks as db_mod
 
         for var in db_mod.SCRUBBED_DATABRICKS_ENV_VARS:
             env = build_databricks_cli_env(WS)
@@ -259,8 +259,8 @@ class TestEnsureAiGatewayV2:
         from urllib.error import HTTPError
 
         exc = HTTPError(url="", code=404, msg="Not Found", hdrs=MagicMock(), fp=None)
-        with patch("coding_tool_gateway.databricks.urllib_request.urlopen", side_effect=exc):
-            from coding_tool_gateway.databricks import ensure_ai_gateway_v2
+        with patch("ucode.databricks.urllib_request.urlopen", side_effect=exc):
+            from ucode.databricks import ensure_ai_gateway_v2
 
             with pytest.raises(RuntimeError, match=AI_GATEWAY_V2_DOCS_URL):
                 ensure_ai_gateway_v2(WS, "fake-token")
@@ -270,10 +270,10 @@ class TestEnsureAiGatewayV2:
         from urllib.error import URLError
 
         with patch(
-            "coding_tool_gateway.databricks.urllib_request.urlopen",
+            "ucode.databricks.urllib_request.urlopen",
             side_effect=URLError("connection refused"),
         ):
-            from coding_tool_gateway.databricks import ensure_ai_gateway_v2
+            from ucode.databricks import ensure_ai_gateway_v2
 
             with pytest.raises(RuntimeError, match=AI_GATEWAY_V2_DOCS_URL):
                 ensure_ai_gateway_v2(WS, "fake-token")
@@ -284,8 +284,8 @@ class TestEnsureAiGatewayV2:
 
         # 405 Method Not Allowed → still means v2 is there (method mismatch, not missing route)
         exc = HTTPError(url="", code=405, msg="Method Not Allowed", hdrs=MagicMock(), fp=None)
-        with patch("coding_tool_gateway.databricks.urllib_request.urlopen", side_effect=exc):
-            from coding_tool_gateway.databricks import ensure_ai_gateway_v2
+        with patch("ucode.databricks.urllib_request.urlopen", side_effect=exc):
+            from ucode.databricks import ensure_ai_gateway_v2
 
             ensure_ai_gateway_v2(WS, "fake-token")  # should not raise
 
@@ -295,7 +295,7 @@ class TestEnsureAiGatewayV2:
         mock_resp = MagicMock()
         mock_resp.__enter__ = lambda s: s
         mock_resp.__exit__ = MagicMock(return_value=False)
-        with patch("coding_tool_gateway.databricks.urllib_request.urlopen", return_value=mock_resp):
-            from coding_tool_gateway.databricks import ensure_ai_gateway_v2
+        with patch("ucode.databricks.urllib_request.urlopen", return_value=mock_resp):
+            from ucode.databricks import ensure_ai_gateway_v2
 
             ensure_ai_gateway_v2(WS, "fake-token")  # should not raise

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,7 +1,7 @@
 """End-to-end integration tests that require a live Databricks workspace.
 
 Run with:
-    CODING_GATEWAY_TEST_WORKSPACE=https://your-workspace.databricks.com uv run pytest tests/test_e2e.py -v
+    UCODE_TEST_WORKSPACE=https://your-workspace.databricks.com uv run pytest tests/test_e2e.py -v
 
 All tests in this file are skipped automatically when the env var is not set.
 The agent-launch tests are also skipped per-agent/model when the binary is not
@@ -16,7 +16,7 @@ import subprocess
 
 import pytest
 
-from coding_tool_gateway.databricks import (
+from ucode.databricks import (
     build_shared_base_urls,
     build_tool_base_url,
     discover_sql_warehouse_http_path,
@@ -27,7 +27,7 @@ from coding_tool_gateway.databricks import (
     has_valid_databricks_auth,
     workspace_hostname,
 )
-from coding_tool_gateway.ui import normalize_workspace_url
+from ucode.ui import normalize_workspace_url
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -35,13 +35,13 @@ from coding_tool_gateway.ui import normalize_workspace_url
 
 
 def _ws() -> str:
-    raw = os.environ.get("CODING_GATEWAY_TEST_WORKSPACE", "").strip().rstrip("/")
+    raw = os.environ.get("UCODE_TEST_WORKSPACE", "").strip().rstrip("/")
     return normalize_workspace_url(raw) if raw else ""
 
 
 def _skip_if_no_workspace():
     if not _ws():
-        pytest.skip("Set CODING_GATEWAY_TEST_WORKSPACE=https://... to run E2E tests")
+        pytest.skip("Set UCODE_TEST_WORKSPACE=https://... to run E2E tests")
 
 
 def _run_agent(
@@ -133,9 +133,9 @@ class TestStateRoundTrip:
     def test_configure_shared_state_and_reload(
         self, tmp_path, monkeypatch, e2e_state, e2e_workspace
     ):
-        import coding_tool_gateway.config_io as config_io_mod
-        import coding_tool_gateway.state as state_mod
-        from coding_tool_gateway.state import load_state, save_state
+        import ucode.config_io as config_io_mod
+        import ucode.state as state_mod
+        from ucode.state import load_state, save_state
 
         monkeypatch.setattr(state_mod, "STATE_PATH", tmp_path / "state.json")
         monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
@@ -190,8 +190,8 @@ class TestCodexLaunch:
 
     def test_launch_codex_per_model(self, tmp_path, monkeypatch, e2e_state, e2e_workspace):
         """Parametrized inline — iterates over all codex models and asserts each works."""
-        import coding_tool_gateway.config_io as config_io_mod
-        from coding_tool_gateway.agents import codex
+        import ucode.config_io as config_io_mod
+        from ucode.agents import codex
 
         _require_binary("codex")
         models = self._codex_models(e2e_state)
@@ -208,7 +208,7 @@ class TestCodexLaunch:
         for model in models:
             state = {**e2e_state, "workspace": e2e_workspace}
             with pytest.MonkeyPatch().context() as mp:
-                mp.setattr("coding_tool_gateway.state.save_state", lambda s: None)
+                mp.setattr("ucode.state.save_state", lambda s: None)
                 codex.write_tool_config(state)
 
             cmd = codex.validate_cmd("codex")
@@ -228,8 +228,8 @@ class TestClaudeLaunch:
     def test_launch_claude_per_model(
         self, tmp_path, monkeypatch, e2e_state, e2e_workspace, e2e_token
     ):
-        import coding_tool_gateway.config_io as config_io_mod
-        from coding_tool_gateway.agents import claude
+        import ucode.config_io as config_io_mod
+        from ucode.agents import claude
 
         _require_binary("claude")
         claude_models: dict = e2e_state.get("claude_models") or {}
@@ -249,7 +249,7 @@ class TestClaudeLaunch:
         failures = []
         for family, model_id in claude_models.items():
             with pytest.MonkeyPatch().context() as mp:
-                mp.setattr("coding_tool_gateway.state.save_state", lambda s: None)
+                mp.setattr("ucode.state.save_state", lambda s: None)
                 claude.write_tool_config({**e2e_state, "workspace": e2e_workspace}, model_id)
 
             env = {
@@ -278,8 +278,8 @@ class TestGeminiLaunch:
     def test_launch_gemini_per_model(
         self, tmp_path, monkeypatch, e2e_state, e2e_workspace, e2e_token
     ):
-        import coding_tool_gateway.config_io as config_io_mod
-        from coding_tool_gateway.agents import gemini
+        import ucode.config_io as config_io_mod
+        from ucode.agents import gemini
 
         _require_binary("gemini")
         gemini_models: list = e2e_state.get("gemini_models") or []
@@ -294,10 +294,8 @@ class TestGeminiLaunch:
         failures = []
         for model in gemini_models:
             with pytest.MonkeyPatch().context() as mp:
-                mp.setattr("coding_tool_gateway.state.save_state", lambda s: None)
-                mp.setattr(
-                    "coding_tool_gateway.agents.gemini.get_databricks_token", lambda ws: e2e_token
-                )
+                mp.setattr("ucode.state.save_state", lambda s: None)
+                mp.setattr("ucode.agents.gemini.get_databricks_token", lambda ws: e2e_token)
                 gemini.write_tool_config(
                     {**e2e_state, "workspace": e2e_workspace}, model, token=e2e_token
                 )
@@ -327,8 +325,8 @@ class TestGeminiSettingsJsonOnFreshInstall:
     ):
         import json
 
-        import coding_tool_gateway.config_io as config_io_mod
-        from coding_tool_gateway.agents import gemini
+        import ucode.config_io as config_io_mod
+        from ucode.agents import gemini
 
         settings_path = tmp_path / "settings.json"
         monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
@@ -340,7 +338,7 @@ class TestGeminiSettingsJsonOnFreshInstall:
         model = gemini_models[0] if gemini_models else "some-model"
 
         with pytest.MonkeyPatch().context() as mp:
-            mp.setattr("coding_tool_gateway.state.save_state", lambda s: None)
+            mp.setattr("ucode.state.save_state", lambda s: None)
             gemini.write_tool_config(
                 {**e2e_state, "workspace": e2e_workspace}, model, token=e2e_token
             )
@@ -367,8 +365,8 @@ class TestOpencodeLaunch:
     def test_launch_opencode_per_model(
         self, tmp_path, monkeypatch, e2e_state, e2e_workspace, e2e_token
     ):
-        import coding_tool_gateway.config_io as config_io_mod
-        from coding_tool_gateway.agents import opencode
+        import ucode.config_io as config_io_mod
+        from ucode.agents import opencode
 
         _require_binary("opencode")
         models = self._all_models(e2e_state)
@@ -388,10 +386,8 @@ class TestOpencodeLaunch:
                 config_path.unlink()
 
             with pytest.MonkeyPatch().context() as mp:
-                mp.setattr("coding_tool_gateway.state.save_state", lambda s: None)
-                mp.setattr(
-                    "coding_tool_gateway.agents.opencode.get_databricks_token", lambda ws: e2e_token
-                )
+                mp.setattr("ucode.state.save_state", lambda s: None)
+                mp.setattr("ucode.agents.opencode.get_databricks_token", lambda ws: e2e_token)
                 opencode.write_tool_config(
                     {**e2e_state, "workspace": e2e_workspace},
                     model,
@@ -445,8 +441,8 @@ class TestCopilotLaunch:
     def test_launch_copilot_per_model(
         self, tmp_path, monkeypatch, e2e_state, e2e_workspace, e2e_token
     ):
-        import coding_tool_gateway.config_io as config_io_mod
-        from coding_tool_gateway.agents import copilot
+        import ucode.config_io as config_io_mod
+        from ucode.agents import copilot
 
         _require_binary("copilot")
         models = self._all_models(e2e_state)
@@ -462,9 +458,9 @@ class TestCopilotLaunch:
         failures = []
         for family, model in models:
             with pytest.MonkeyPatch().context() as mp:
-                mp.setattr("coding_tool_gateway.state.save_state", lambda s: None)
+                mp.setattr("ucode.state.save_state", lambda s: None)
                 mp.setattr(
-                    "coding_tool_gateway.agents.copilot.get_databricks_token",
+                    "ucode.agents.copilot.get_databricks_token",
                     lambda ws: e2e_token,
                 )
                 copilot.write_tool_config(
@@ -534,7 +530,7 @@ class TestClaudeAuthRecovery:
     def test_recovers_when_initial_token_empty(self, tmp_path, e2e_state, e2e_workspace, e2e_token):
         import json
 
-        from coding_tool_gateway.agents import claude
+        from ucode.agents import claude
 
         _require_binary("claude")
         claude_models: dict = e2e_state.get("claude_models") or {}
@@ -590,8 +586,8 @@ class TestGeminiAuthRecovery:
     def test_recovers_when_initial_token_empty(
         self, tmp_path, monkeypatch, e2e_state, e2e_workspace, e2e_token
     ):
-        import coding_tool_gateway.config_io as config_io_mod
-        from coding_tool_gateway.agents import gemini
+        import ucode.config_io as config_io_mod
+        from ucode.agents import gemini
 
         _require_binary("gemini")
         gemini_models: list = e2e_state.get("gemini_models") or []
@@ -607,7 +603,7 @@ class TestGeminiAuthRecovery:
         fake_db_dir = _make_reauth_fake_databricks(tmp_path / "fake_db", e2e_token)
 
         with pytest.MonkeyPatch().context() as mp:
-            mp.setattr("coding_tool_gateway.state.save_state", lambda s: None)
+            mp.setattr("ucode.state.save_state", lambda s: None)
             mp.setenv("PATH", f"{fake_db_dir}:{os.environ['PATH']}")
             # get_databricks_token will fail first, reauth, then return e2e_token
             _, recovered_token = gemini.write_tool_config(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from coding_tool_gateway import mcp
+from ucode import mcp
 
 WS = "https://example.databricks.com"
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -7,8 +7,8 @@ from unittest.mock import patch
 
 import pytest
 
-import coding_tool_gateway.state as state_mod
-from coding_tool_gateway.state import (
+import ucode.state as state_mod
+from ucode.state import (
     STATE_VERSION,
     clear_state,
     hydrate_state,
@@ -36,7 +36,7 @@ def patch_state_path(tmp_path, monkeypatch):
     fake_state_path = tmp_path / "state.json"
     monkeypatch.setattr(state_mod, "STATE_PATH", fake_state_path)
 
-    import coding_tool_gateway.config_io as config_io_mod
+    import ucode.config_io as config_io_mod
 
     monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
 
@@ -44,7 +44,7 @@ def patch_state_path(tmp_path, monkeypatch):
 @pytest.fixture(autouse=True)
 def patch_build_urls():
     """Avoid real network calls from hydrate_state."""
-    with patch("coding_tool_gateway.state.build_shared_base_urls", return_value=FAKE_URLS):
+    with patch("ucode.state.build_shared_base_urls", return_value=FAKE_URLS):
         yield
 
 
@@ -101,7 +101,7 @@ class TestSaveLoadRoundTrip:
         assert loaded["claude_models"]["sonnet"] == "databricks-claude-sonnet-4"
 
     def test_save_respects_dry_run(self):
-        import coding_tool_gateway.config_io as config_io_mod
+        import ucode.config_io as config_io_mod
 
         config_io_mod.set_dry_run(True)
         try:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 
 import pytest
 
-from coding_tool_gateway.ui import (
+from ucode.ui import (
     format_duration,
     format_token_count,
     normalize_workspace_url,

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, timedelta
 
-from coding_tool_gateway.usage import (
+from ucode.usage import (
     USAGE_BREAKDOWN_DAYS,
     USAGE_SUMMARY_DAYS,
     build_current_user_query,

--- a/uv.lock
+++ b/uv.lock
@@ -111,39 +111,6 @@ wheels = [
 ]
 
 [[package]]
-name = "coding-gateway"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "databricks-sql-connector" },
-    { name = "questionary" },
-    { name = "tomlkit" },
-    { name = "typer" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest" },
-    { name = "ruff" },
-    { name = "ty" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "databricks-sql-connector", specifier = ">=3.6.0" },
-    { name = "questionary", specifier = ">=2.0.0" },
-    { name = "tomlkit", specifier = ">=0.13.0" },
-    { name = "typer", specifier = ">=0.12.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "ruff", specifier = ">=0.15.12" },
-    { name = "ty" },
-]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
@@ -631,6 +598,39 @@ source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+]
+
+[[package]]
+name = "ucode"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "databricks-sql-connector" },
+    { name = "questionary" },
+    { name = "tomlkit" },
+    { name = "typer" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+    { name = "ty" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "databricks-sql-connector", specifier = ">=3.6.0" },
+    { name = "questionary", specifier = ">=2.0.0" },
+    { name = "tomlkit", specifier = ">=0.13.0" },
+    { name = "typer", specifier = ">=0.12.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "ruff", specifier = ">=0.15.12" },
+    { name = "ty" },
 ]
 
 [[package]]


### PR DESCRIPTION
Renames the Python package, CLI command, distribution name, config directory, and e2e env var to ucode. Updates README, AGENTS.md, and GitHub install URL accordingly.

- src/coding_tool_gateway/ -> src/ucode/
- coding-gateway CLI -> ucode
- ~/.coding-gateway/ -> ~/.ucode/
- CODING_GATEWAY_TEST_WORKSPACE -> UCODE_TEST_WORKSPACE
- github.com/databricks/coding-gateway -> github.com/databricks/ucode