### PR TITLE
Simplify auth helper and add Databricks CLI version check

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -45,7 +45,7 @@ def render_overlay(
         "ANTHROPIC_BASE_URL": base_url,
         "ANTHROPIC_CUSTOM_HEADERS": "x-databricks-use-coding-agent-mode: true",
         "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
-        "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "1800000",
+        "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "900000",
     }
     if claude_models:
         if claude_models.get("opus"):

--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -54,7 +54,7 @@ def render_overlay(workspace: str) -> dict:
                     "command": "sh",
                     "args": ["-c", auth_command],
                     "timeout_ms": 5000,
-                    "refresh_interval_ms": 1800000,
+                    "refresh_interval_ms": 900000,
                 },
             }
         },

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -83,7 +83,7 @@ def configure_shared_state(
     with spinner("Verifying AI Gateway V2..."):
         token = get_databricks_token(workspace)
         ensure_ai_gateway_v2(workspace, token)
-    print_success("AI Gateway V2 detected")
+    print_success("Unity AI Gateway detected")
 
     with spinner("Fetching available models..."):
         claude_models = (
@@ -297,8 +297,7 @@ def _launch_tool(tool_name: str, ctx: typer.Context) -> None:
         state = ensure_provider_state(tool)
         state, resolved_model = resolve_launch_model(tool, state, None)
         state = configure_tool(tool, state, resolved_model)
-        print_section("Launching")
-        print_kv("Tool", TOOL_SPECS[tool]["display"])
+        print_section(f"ucode with {TOOL_SPECS[tool]['display']}")
         if resolved_model:
             print_kv("Model", resolved_model)
         print_kv("Base URL", str(state["base_urls"][tool]))

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import platform
+import re
 import shutil
 import subprocess
 from typing import cast
@@ -31,15 +32,8 @@ WINDOWS_DATABRICKS_INSTALL_URL = (
     "https://raw.githubusercontent.com/databricks/setup-cli/main/install.ps1"
 )
 AI_GATEWAY_V2_DOCS_URL = "https://docs.databricks.com/aws/en/ai-gateway/overview-beta"
+MIN_DATABRICKS_CLI_VERSION = (0, 298, 0)
 TOKEN_REFRESH_INTERVAL_SECONDS = 1800
-SCRUBBED_DATABRICKS_ENV_VARS = (
-    "DATABRICKS_TOKEN",
-    "DATABRICKS_CLIENT_ID",
-    "DATABRICKS_CLIENT_SECRET",
-    "DATABRICKS_USERNAME",
-    "DATABRICKS_PASSWORD",
-    "DATABRICKS_AUTH_TYPE",
-)
 
 
 def run(
@@ -64,8 +58,6 @@ def run(
 def build_databricks_cli_env(workspace: str) -> dict[str, str]:
     env = os.environ.copy()
     env["DATABRICKS_HOST"] = workspace
-    for key in SCRUBBED_DATABRICKS_ENV_VARS:
-        env.pop(key, None)
     return env
 
 
@@ -76,8 +68,53 @@ def workspace_hostname(workspace: str) -> str:
     return parsed.hostname
 
 
+def _databricks_upgrade_command() -> str:
+    if platform.system() == "Windows":
+        return f'powershell -Command "irm {WINDOWS_DATABRICKS_INSTALL_URL} | iex"'
+    if shutil.which("wget") and not shutil.which("curl"):
+        return f"wget -qO- {UNIX_DATABRICKS_INSTALL_URL} | sh"
+    return f"curl -fsSL {UNIX_DATABRICKS_INSTALL_URL} | sh"
+
+
+def _parse_databricks_cli_version(output: str) -> tuple[int, int, int] | None:
+    # Example output: "Databricks CLI v0.299.2"
+    match = re.search(r"v?(\d+)\.(\d+)\.(\d+)", output)
+    if not match:
+        return None
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def ensure_databricks_cli_version() -> None:
+    try:
+        result = run(
+            ["databricks", "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise RuntimeError("Failed to read Databricks CLI version.") from exc
+
+    raw = result.stdout or result.stderr or ""
+    output = (raw if isinstance(raw, str) else raw.decode(errors="replace")).strip()
+    version = _parse_databricks_cli_version(output)
+    if version is None:
+        raise RuntimeError(
+            f"Could not parse Databricks CLI version from `databricks --version` output: {output!r}"
+        )
+    if version < MIN_DATABRICKS_CLI_VERSION:
+        current = ".".join(str(n) for n in version)
+        required = ".".join(str(n) for n in MIN_DATABRICKS_CLI_VERSION)
+        raise RuntimeError(
+            f"Databricks CLI v{current} is too old (need v{required} or newer). "
+            f"Upgrade with:\n    {_databricks_upgrade_command()}"
+        )
+
+
 def install_databricks_cli() -> None:
     if shutil.which("databricks"):
+        ensure_databricks_cli_version()
         return
 
     system = platform.system()
@@ -113,6 +150,7 @@ def install_databricks_cli() -> None:
         raise RuntimeError(
             "Databricks CLI install completed, but `databricks` is still not on PATH."
         )
+    ensure_databricks_cli_version()
 
 
 def has_valid_databricks_auth(workspace: str) -> bool:
@@ -299,20 +337,9 @@ def list_databricks_connections(workspace: str) -> list[dict]:
 
 
 def build_auth_shell_command(workspace: str) -> str:
-    unset_prefix = " ".join(f"-u {key}" for key in SCRUBBED_DATABRICKS_ENV_VARS)
-    # grep+sed are POSIX — no python3 or jq dependency required on the user's machine.
-    parse_token = 'grep -o \'"access_token": *"[^"]*"\' | sed \'s/.*": *"\\(.*\\)"/\\1/\''
-    get_token = (
-        f"env {unset_prefix} databricks auth token --host {workspace} --output json | {parse_token}"
-    )
-    # If the token comes back empty (expired session), re-authenticate and retry once.
     return (
-        f"token=$({get_token} 2>/dev/null); "
-        f'if [ -z "$token" ]; then '
-        f"env {unset_prefix} databricks auth login --host {workspace} --no-browser 2>/dev/null; "
-        f"token=$({get_token}); "
-        f"fi; "
-        f'echo "$token"'
+        f"databricks auth token --host {workspace} --force-refresh --output json "
+        f"| jq -r '.access_token'"
     )
 
 

--- a/src/ucode/ui.py
+++ b/src/ucode/ui.py
@@ -184,7 +184,7 @@ def prompt_for_workspace(
     them — `ui.py` stays Databricks-agnostic. Returns a normalized URL.
     """
     console.print()
-    console.print(Panel(description, title="ucode Setup", style="bold blue", expand=False))
+    console.print(Panel(description, title="ucode setup", style="bold blue", expand=False))
 
     if profiles:
         choices = [questionary.Choice(title=host, value=host) for host, _ in profiles]

--- a/tests/test_agent_codex.py
+++ b/tests/test_agent_codex.py
@@ -53,7 +53,7 @@ class TestRenderOverlay:
     def test_auth_refresh_interval(self):
         overlay = codex.render_overlay(WS)
         auth = overlay["model_providers"]["Databricks"]["auth"]
-        assert auth["refresh_interval_ms"] == 1_800_000
+        assert auth["refresh_interval_ms"] == 900_000
 
 
 class TestCodexDefaultModel:

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -11,11 +11,14 @@ import pytest
 import ucode.databricks as db_mod
 from ucode.databricks import (
     AI_GATEWAY_V2_DOCS_URL,
+    MIN_DATABRICKS_CLI_VERSION,
+    _parse_databricks_cli_version,
     build_auth_shell_command,
     build_databricks_cli_env,
     build_opencode_base_urls,
     build_shared_base_urls,
     build_tool_base_url,
+    ensure_databricks_cli_version,
     get_databricks_token,
     list_databricks_connections,
     workspace_hostname,
@@ -43,13 +46,6 @@ class TestBuildDatabricksCliEnv:
     def test_sets_databricks_host(self):
         env = build_databricks_cli_env(WS)
         assert env["DATABRICKS_HOST"] == WS
-
-    def test_scrubs_token_vars(self):
-        import ucode.databricks as db_mod
-
-        for var in db_mod.SCRUBBED_DATABRICKS_ENV_VARS:
-            env = build_databricks_cli_env(WS)
-            assert var not in env
 
 
 class TestBuildToolBaseUrl:
@@ -105,13 +101,9 @@ class TestBuildAuthShellCommand:
 
     def test_parses_access_token(self):
         cmd = build_auth_shell_command(WS)
-        assert "access_token" in cmd
-        assert "grep" in cmd
-        assert "sed" in cmd
-
-    def test_unsets_scrubbed_vars(self):
-        cmd = build_auth_shell_command(WS)
-        assert "DATABRICKS_TOKEN" in cmd
+        assert "jq" in cmd
+        assert ".access_token" in cmd
+        assert "--force-refresh" in cmd
 
     def test_returns_token_when_auth_succeeds(self, tmp_path):
         # Fake databricks binary that always returns a valid token JSON.
@@ -128,38 +120,6 @@ class TestBuildAuthShellCommand:
             env={**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"},
         )
         assert result.stdout.strip() == "good-token"
-
-    def test_reauths_and_retries_when_token_empty(self, tmp_path):
-        # Fake databricks binary: returns empty token on `auth token`, succeeds on retry
-        # after `auth login` is called. Uses a call-count file to track invocations.
-        call_count = tmp_path / "calls"
-        call_count.write_text("0")
-        fake = tmp_path / "databricks"
-        fake.write_text(
-            "#!/bin/sh\n"
-            f"count=$(cat {call_count})\n"
-            f"echo $((count + 1)) > {call_count}\n"
-            "# auth login is a no-op\n"
-            'case "$*" in\n'
-            '  *"auth login"*) exit 0 ;;\n'
-            "esac\n"
-            "# first auth token call returns empty; second returns a real token\n"
-            'if [ "$count" -eq 0 ]; then\n'
-            '  echo \'{"access_token": "", "token_type": "Bearer"}\'\n'
-            "else\n"
-            '  echo \'{"access_token": "refreshed-token", "token_type": "Bearer"}\'\n'
-            "fi\n"
-        )
-        fake.chmod(0o755)
-        cmd = build_auth_shell_command(WS)
-        result = subprocess.run(
-            ["sh", "-c", cmd],
-            capture_output=True,
-            text=True,
-            env={**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"},
-        )
-        assert result.stdout.strip() == "refreshed-token"
-        assert int(call_count.read_text()) >= 3  # auth token, auth login, auth token
 
 
 class TestGetDatabricksToken:
@@ -299,3 +259,54 @@ class TestEnsureAiGatewayV2:
             from ucode.databricks import ensure_ai_gateway_v2
 
             ensure_ai_gateway_v2(WS, "fake-token")  # should not raise
+
+
+class TestParseDatabricksCliVersion:
+    def test_parses_standard_format(self):
+        assert _parse_databricks_cli_version("Databricks CLI v0.299.2") == (0, 299, 2)
+
+    def test_parses_without_v_prefix(self):
+        assert _parse_databricks_cli_version("Databricks CLI 0.298.0") == (0, 298, 0)
+
+    def test_returns_none_on_garbage(self):
+        assert _parse_databricks_cli_version("not a version") is None
+
+
+class TestEnsureDatabricksCliVersion:
+    def _fake_databricks(self, tmp_path, version_output: str) -> dict:
+        fake = tmp_path / "databricks"
+        fake.write_text(f"#!/bin/sh\necho '{version_output}'\n")
+        fake.chmod(0o755)
+        return {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"}
+
+    def test_passes_when_version_meets_minimum(self, tmp_path, monkeypatch):
+        env = self._fake_databricks(tmp_path, "Databricks CLI v0.298.0")
+        monkeypatch.setattr("os.environ", env)
+        ensure_databricks_cli_version()  # should not raise
+
+    def test_passes_when_version_exceeds_minimum(self, tmp_path, monkeypatch):
+        env = self._fake_databricks(tmp_path, "Databricks CLI v0.299.2")
+        monkeypatch.setattr("os.environ", env)
+        ensure_databricks_cli_version()
+
+    def test_raises_when_version_too_old(self, tmp_path, monkeypatch):
+        env = self._fake_databricks(tmp_path, "Databricks CLI v0.297.0")
+        monkeypatch.setattr("os.environ", env)
+        required = ".".join(str(n) for n in MIN_DATABRICKS_CLI_VERSION)
+        with pytest.raises(RuntimeError, match=f"v{required} or newer"):
+            ensure_databricks_cli_version()
+
+    def test_error_includes_upgrade_command(self, tmp_path, monkeypatch):
+        env = self._fake_databricks(tmp_path, "Databricks CLI v0.100.0")
+        monkeypatch.setattr("os.environ", env)
+        with pytest.raises(RuntimeError) as excinfo:
+            ensure_databricks_cli_version()
+        # Either curl|sh, wget, or powershell — depending on host. All flow through
+        # the install script URL, so assert on that.
+        assert "setup-cli" in str(excinfo.value)
+
+    def test_raises_when_version_unparseable(self, tmp_path, monkeypatch):
+        env = self._fake_databricks(tmp_path, "completely broken output")
+        monkeypatch.setattr("os.environ", env)
+        with pytest.raises(RuntimeError, match="Could not parse"):
+            ensure_databricks_cli_version()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -519,66 +519,6 @@ def _make_reauth_fake_databricks(tmp_path, real_token: str) -> str:
     return str(tmp_path)
 
 
-class TestClaudeAuthRecovery:
-    """Claude Code uses apiKeyHelper — verify it reauths and recovers when the
-    first token fetch returns empty (simulating an expired Databricks session).
-
-    Uses CLAUDE_CONFIG_DIR to point the claude subprocess at an isolated temp
-    directory, so ~/.claude/settings.json is never touched.
-    """
-
-    def test_recovers_when_initial_token_empty(self, tmp_path, e2e_state, e2e_workspace, e2e_token):
-        import json
-
-        from ucode.agents import claude
-
-        _require_binary("claude")
-        claude_models: dict = e2e_state.get("claude_models") or {}
-        if not claude_models:
-            pytest.skip("No Claude models available on this workspace")
-
-        fake_db_dir = _make_reauth_fake_databricks(tmp_path / "fake_db", e2e_token)
-        model_id = next(iter(claude_models.values()))
-        base_url = build_tool_base_url("claude", e2e_workspace)
-
-        # Write an isolated settings.json under a temp config dir.
-        # CLAUDE_CONFIG_DIR makes the claude subprocess use this instead of ~/.claude.
-        config_dir = tmp_path / "claude_config"
-        config_dir.mkdir()
-        fake_helper = (
-            f"{fake_db_dir}/databricks auth token "
-            f"--host {e2e_workspace} --output json "
-            f'| grep -o \'"access_token": *"[^"]*"\' '
-            f'| sed \'s/.*": *"\\(.*\\)"/\\1/\''
-        )
-        settings = {
-            "apiKeyHelper": fake_helper,
-            "env": {
-                "ANTHROPIC_MODEL": model_id,
-                "ANTHROPIC_BASE_URL": base_url,
-                "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
-                # TTL=1ms so every API call triggers a helper refresh.
-                "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "1",
-            },
-        }
-        (config_dir / "settings.json").write_text(json.dumps(settings, indent=2))
-
-        env = {
-            **os.environ,
-            "CLAUDE_CONFIG_DIR": str(config_dir),
-            "PATH": f"{fake_db_dir}:{os.environ['PATH']}",
-        }
-        env.pop("ANTHROPIC_API_KEY", None)
-
-        cmd = claude.validate_cmd("claude")
-        result = _run_agent(cmd, env=env, timeout=90)
-        combined = (result.stdout + result.stderr).strip()
-        assert result.returncode == 0 and combined, (
-            f"Claude failed to recover from empty token: rc={result.returncode} "
-            f"stdout={result.stdout[:300]!r} stderr={result.stderr[:300]!r}"
-        )
-
-
 class TestGeminiAuthRecovery:
     """Gemini uses get_databricks_token() at launch — verify it reauths and
     recovers when the first token fetch returns empty."""


### PR DESCRIPTION
- Claude apiKeyHelper and Codex auth.command are now a single line: `databricks auth token --force-refresh --output json | jq -r '.access_token'`. Removed the env-var scrub and re-login fallback (verified unnecessary for `databricks auth token`).
- Lowered token refresh interval to 15 min for both Claude and Codex.
- Added ensure_databricks_cli_version() that enforces >= v0.298.0 and prints the platform-appropriate upgrade command on mismatch. Runs on configure and on first launch via install_databricks_cli.
- "AI Gateway V2 detected" -> "Unity AI Gateway detected".
- "ucode Setup" panel title -> "ucode setup".
- Launch panel title now reads "ucode with <Tool>" instead of generic "Launching" with a redundant Tool row underneath.