### PR TITLE
Add --skip-git-repo-check to Codex validation command

### DIFF
--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -85,4 +85,4 @@ def launch(state: dict, tool_args: list[str]) -> None:
 
 
 def validate_cmd(binary: str) -> list[str]:
-    return [binary, "exec", "say hi in 5 words or less"]
+    return [binary, "exec", "--skip-git-repo-check", "say hi in 5 words or less"]

--- a/tests/test_agent_codex.py
+++ b/tests/test_agent_codex.py
@@ -75,6 +75,12 @@ class TestCodexValidateCmd:
         cmd = codex.validate_cmd("codex")
         assert len(cmd) > 2
 
+    def test_skips_git_repo_check(self):
+        # Validation runs in arbitrary cwd (e.g., ~/Documents); without this
+        # flag Codex refuses to run outside a trusted/git directory.
+        cmd = codex.validate_cmd("codex")
+        assert "--skip-git-repo-check" in cmd
+
 
 class TestCodexLaunch:
     def test_sets_oauth_token_before_exec(self, monkeypatch):


### PR DESCRIPTION
Codex refuses to `exec` outside a trusted/git directory, so running `ucode codex` from a non-repo path (e.g. ~/Documents) failed post-configure validation and reverted the config. The flag only affects the smoke test; user-initiated runs still respect Codex's policy.