### PR TITLE
Prefix model selector with provider ID to fix OpenCode parsing error

### DIFF
--- a/src/ucode/agents/opencode.py
+++ b/src/ucode/agents/opencode.py
@@ -42,6 +42,22 @@ PROVIDER_KEYS: list[list[str]] = [
 ]
 
 
+def _resolve_model_selector(model: str, opencode_models: dict[str, list[str]]) -> str:
+    """Return an OpenCode model selector in provider/model form when possible."""
+    if model.startswith("databricks-anthropic/") or model.startswith("databricks-google/"):
+        return model
+
+    anthropic_models = opencode_models.get("anthropic") or []
+    if model in anthropic_models:
+        return f"databricks-anthropic/{model}"
+
+    gemini_models = opencode_models.get("gemini") or []
+    if model in gemini_models:
+        return f"databricks-google/{model}"
+
+    return model
+
+
 def render_overlay(
     model: str,
     token: str,
@@ -79,7 +95,7 @@ def render_overlay(
         }
         keys.append(["provider", "databricks-google"])
 
-    overlay: dict = {"model": model}
+    overlay: dict = {"model": _resolve_model_selector(model, opencode_models)}
     if providers:
         overlay["provider"] = providers
     return overlay, keys

--- a/tests/test_agent_opencode.py
+++ b/tests/test_agent_opencode.py
@@ -97,6 +97,16 @@ class TestRenderOverlay:
         assert "claude-sonnet" in provider_models
         assert "claude-haiku" in provider_models
 
+    def test_prefixes_anthropic_model_with_provider_id(self):
+        models = {"anthropic": ["claude-sonnet"], "gemini": []}
+        overlay, _ = opencode.render_overlay("claude-sonnet", "tok", _base_urls(), models)
+        assert overlay["model"] == "databricks-anthropic/claude-sonnet"
+
+    def test_prefixes_gemini_model_with_provider_id(self):
+        models = {"anthropic": [], "gemini": ["gemini-2"]}
+        overlay, _ = opencode.render_overlay("gemini-2", "tok", _base_urls(), models)
+        assert overlay["model"] == "databricks-google/gemini-2"
+
 
 class TestMcpServerConfig:
     def test_builds_remote_server_entry_with_oauth_token_env_header(self):
@@ -266,4 +276,4 @@ class TestWriteToolConfigStaleProviderCleanup:
             oc_mod.write_tool_config(state, "claude-sonnet", token="tok")
 
         written = json.loads(config_file.read_text())
-        assert written["model"] == "claude-sonnet"
+        assert written["model"] == "databricks-anthropic/claude-sonnet"


### PR DESCRIPTION
Adds `_resolve_model_selector` to map bare model names (e.g. `claude-sonnet`) to `provider/model` form (e.g. `databricks-anthropic/claude-sonnet`) before writing opencode.json, fixing the provider resolution error in OpenCode.

Co-authored-by: Isaac