### PR TITLE
Auto-upgrade Databricks CLI when version is too old

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -68,20 +68,32 @@ def workspace_hostname(workspace: str) -> str:
     return parsed.hostname
 
 
-def _databricks_upgrade_command() -> str:
-    if platform.system() == "Windows":
-        return f'powershell -Command "irm {WINDOWS_DATABRICKS_INSTALL_URL} | iex"'
-    if shutil.which("wget") and not shutil.which("curl"):
-        return f"wget -qO- {UNIX_DATABRICKS_INSTALL_URL} | sh"
-    return f"curl -fsSL {UNIX_DATABRICKS_INSTALL_URL} | sh"
-
-
 def _parse_databricks_cli_version(output: str) -> tuple[int, int, int] | None:
     # Example output: "Databricks CLI v0.299.2"
     match = re.search(r"v?(\d+)\.(\d+)\.(\d+)", output)
     if not match:
         return None
     return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def _run_databricks_cli_installer(brew_subcommand: str = "install") -> None:
+    system = platform.system()
+    try:
+        if system == "Windows":
+            run(
+                ["powershell", "-Command", f"irm {WINDOWS_DATABRICKS_INSTALL_URL} | iex"],
+                timeout=240,
+            )
+        elif system == "Darwin" and shutil.which("brew"):
+            run(["brew", brew_subcommand, "databricks"], timeout=240)
+        elif shutil.which("curl"):
+            run(["sh", "-c", f"curl -fsSL {UNIX_DATABRICKS_INSTALL_URL} | sudo sh"], timeout=240)
+        elif shutil.which("wget"):
+            run(["sh", "-c", f"wget -qO- {UNIX_DATABRICKS_INSTALL_URL} | sudo sh"], timeout=240)
+        else:
+            raise RuntimeError("Neither curl nor wget is available.")
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, RuntimeError) as exc:
+        raise RuntimeError("Failed to install/upgrade Databricks CLI automatically.") from exc
 
 
 def ensure_databricks_cli_version() -> None:
@@ -106,10 +118,11 @@ def ensure_databricks_cli_version() -> None:
     if version < MIN_DATABRICKS_CLI_VERSION:
         current = ".".join(str(n) for n in version)
         required = ".".join(str(n) for n in MIN_DATABRICKS_CLI_VERSION)
-        raise RuntimeError(
-            f"Databricks CLI v{current} is too old (need v{required} or newer). "
-            f"Upgrade with:\n    {_databricks_upgrade_command()}"
+        print_warning(
+            f"Databricks CLI v{current} is too old (need v{required} or newer). Upgrading..."
         )
+        _run_databricks_cli_installer(brew_subcommand="upgrade")
+        ensure_databricks_cli_version()
 
 
 def install_databricks_cli() -> None:
@@ -117,34 +130,9 @@ def install_databricks_cli() -> None:
         ensure_databricks_cli_version()
         return
 
-    system = platform.system()
     print_section("Bootstrap")
     print_warning("`databricks` was not found. Installing Databricks CLI...")
-
-    try:
-        if system == "Windows":
-            run(
-                [
-                    "powershell",
-                    "-Command",
-                    f"irm {WINDOWS_DATABRICKS_INSTALL_URL} | iex",
-                ],
-                timeout=240,
-            )
-        elif shutil.which("curl"):
-            run(
-                ["sh", "-c", f"curl -fsSL {UNIX_DATABRICKS_INSTALL_URL} | sh"],
-                timeout=240,
-            )
-        elif shutil.which("wget"):
-            run(
-                ["sh", "-c", f"wget -qO- {UNIX_DATABRICKS_INSTALL_URL} | sh"],
-                timeout=240,
-            )
-        else:
-            raise RuntimeError("Neither curl nor wget is available.")
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, RuntimeError) as exc:
-        raise RuntimeError("Failed to install Databricks CLI automatically.") from exc
+    _run_databricks_cli_installer(brew_subcommand="install")
 
     if not shutil.which("databricks"):
         raise RuntimeError(

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -289,21 +289,25 @@ class TestEnsureDatabricksCliVersion:
         monkeypatch.setattr("os.environ", env)
         ensure_databricks_cli_version()
 
-    def test_raises_when_version_too_old(self, tmp_path, monkeypatch):
+    def test_auto_upgrades_when_version_too_old(self, tmp_path, monkeypatch):
+        import ucode.databricks as db_mod
+
         env = self._fake_databricks(tmp_path, "Databricks CLI v0.297.0")
         monkeypatch.setattr("os.environ", env)
-        required = ".".join(str(n) for n in MIN_DATABRICKS_CLI_VERSION)
-        with pytest.raises(RuntimeError, match=f"v{required} or newer"):
-            ensure_databricks_cli_version()
+        upgraded = []
+        monkeypatch.setattr(db_mod, "_run_databricks_cli_installer", lambda brew_subcommand="install": upgraded.append(brew_subcommand))
+        # Stop the recursive re-check after upgrade
+        call_count = [0]
+        original = db_mod.ensure_databricks_cli_version
 
-    def test_error_includes_upgrade_command(self, tmp_path, monkeypatch):
-        env = self._fake_databricks(tmp_path, "Databricks CLI v0.100.0")
-        monkeypatch.setattr("os.environ", env)
-        with pytest.raises(RuntimeError) as excinfo:
-            ensure_databricks_cli_version()
-        # Either curl|sh, wget, or powershell — depending on host. All flow through
-        # the install script URL, so assert on that.
-        assert "setup-cli" in str(excinfo.value)
+        def once(*a, **kw):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                original()
+
+        monkeypatch.setattr(db_mod, "ensure_databricks_cli_version", once)
+        once()
+        assert upgraded == ["upgrade"]
 
     def test_raises_when_version_unparseable(self, tmp_path, monkeypatch):
         env = self._fake_databricks(tmp_path, "completely broken output")


### PR DESCRIPTION
Previously showed an error with a manual upgrade command. Now automatically runs the installer (brew upgrade on Mac, curl|sudo sh elsewhere) the same way auto-install works. Consolidates install/upgrade logic into a single _run_databricks_cli_installer helper.