### PR TITLE
Default Claude Code to opus and remove model row from status

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -76,7 +76,7 @@ def write_tool_config(state: dict, model: str) -> dict:
 
 def default_model(state: dict) -> str | None:
     claude_models = state.get("claude_models") or {}
-    return claude_models.get("sonnet") or claude_models.get("opus") or claude_models.get("haiku")
+    return claude_models.get("opus") or claude_models.get("sonnet") or claude_models.get("haiku")
 
 
 def launch(state: dict, tool_args: list[str]) -> None:

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -13,7 +13,6 @@ from ucode.agents import (
     configure_all_tools,
     configure_single_tool,
     configure_tool,
-    default_model_for_tool,
     ensure_bootstrap_dependencies,
     ensure_provider_state,
     install_tool_binary,
@@ -199,8 +198,6 @@ def status() -> int:
         managed = bool(managed_configs.get(tool))
         config_path = spec["config_path"]
         print_kv("Coding Agent", spec["display"])
-        if tool != "codex":
-            print_kv("Model", default_model_for_tool(tool, state) or "not available")
         print_kv("Base URL", base_url)
         print_kv("Managed by Databricks", "yes" if managed else "no")
         print_kv("Config file", str(config_path) if config_path.exists() else "missing")

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -73,13 +73,13 @@ class TestRenderOverlay:
 
 
 class TestClaudeDefaultModel:
-    def test_prefers_sonnet(self):
+    def test_prefers_opus(self):
         state = {"claude_models": {"sonnet": "s4", "opus": "o4", "haiku": "h4"}}
-        assert claude.default_model(state) == "s4"
-
-    def test_falls_back_to_opus(self):
-        state = {"claude_models": {"opus": "o4", "haiku": "h4"}}
         assert claude.default_model(state) == "o4"
+
+    def test_falls_back_to_sonnet(self):
+        state = {"claude_models": {"sonnet": "s4", "haiku": "h4"}}
+        assert claude.default_model(state) == "s4"
 
     def test_falls_back_to_haiku(self):
         state = {"claude_models": {"haiku": "h4"}}

--- a/tests/test_agents_init.py
+++ b/tests/test_agents_init.py
@@ -91,13 +91,13 @@ class TestDefaultModelForTool:
     def test_codex_always_none(self):
         assert default_model_for_tool("codex", {}) is None
 
-    def test_claude_prefers_sonnet(self):
+    def test_claude_prefers_opus(self):
         state = {"claude_models": {"sonnet": "s4", "opus": "o4", "haiku": "h4"}}
-        assert default_model_for_tool("claude", state) == "s4"
-
-    def test_claude_falls_back_to_opus(self):
-        state = {"claude_models": {"opus": "o4"}}
         assert default_model_for_tool("claude", state) == "o4"
+
+    def test_claude_falls_back_to_sonnet(self):
+        state = {"claude_models": {"sonnet": "s4"}}
+        assert default_model_for_tool("claude", state) == "s4"
 
     def test_claude_falls_back_to_haiku(self):
         state = {"claude_models": {"haiku": "h4"}}

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -11,7 +11,6 @@ import pytest
 import ucode.databricks as db_mod
 from ucode.databricks import (
     AI_GATEWAY_V2_DOCS_URL,
-    MIN_DATABRICKS_CLI_VERSION,
     _parse_databricks_cli_version,
     build_auth_shell_command,
     build_databricks_cli_env,
@@ -295,7 +294,11 @@ class TestEnsureDatabricksCliVersion:
         env = self._fake_databricks(tmp_path, "Databricks CLI v0.297.0")
         monkeypatch.setattr("os.environ", env)
         upgraded = []
-        monkeypatch.setattr(db_mod, "_run_databricks_cli_installer", lambda brew_subcommand="install": upgraded.append(brew_subcommand))
+        monkeypatch.setattr(
+            db_mod,
+            "_run_databricks_cli_installer",
+            lambda brew_subcommand="install": upgraded.append(brew_subcommand),
+        )
         # Stop the recursive re-check after upgrade
         call_count = [0]
         original = db_mod.ensure_databricks_cli_version


### PR DESCRIPTION
- Claude agent now prefers opus over sonnet as the default model
- Remove "Model" row from `ucode status` — agents can have multiple models