### PR TITLE
Inject env vars for Gemini validation subprocess

### DIFF
--- a/src/ucode/agents/gemini.py
+++ b/src/ucode/agents/gemini.py
@@ -139,3 +139,19 @@ def launch(state: dict, tool_args: list[str]) -> None:
 
 def validate_cmd(binary: str) -> list[str]:
     return [binary, "-p", "say hi in 5 words or less"]
+
+
+def validate_env(state: dict) -> dict[str, str]:
+    """Inject env vars for the validation subprocess.
+
+    The Gemini CLI's .env auto-loading skips ~/.gemini/.env when run from an
+    untrusted folder, so we cannot rely on it during validation.
+    """
+    workspace = state.get("workspace")
+    if not workspace:
+        raise RuntimeError("No workspace configured.")
+    model = default_model(state)
+    if not model:
+        raise RuntimeError("No Gemini model is configured.")
+    token = get_databricks_token(workspace)
+    return build_runtime_env(workspace, model, token)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -279,7 +279,7 @@ class TestGeminiLaunch:
         self, tmp_path, monkeypatch, e2e_state, e2e_workspace, e2e_token
     ):
         import ucode.config_io as config_io_mod
-        from ucode.agents import gemini
+        from ucode.agents import gemini, validate_tool
 
         _require_binary("gemini")
         gemini_models: list = e2e_state.get("gemini_models") or []
@@ -296,19 +296,15 @@ class TestGeminiLaunch:
             with pytest.MonkeyPatch().context() as mp:
                 mp.setattr("ucode.state.save_state", lambda s: None)
                 mp.setattr("ucode.agents.gemini.get_databricks_token", lambda ws: e2e_token)
-                gemini.write_tool_config(
-                    {**e2e_state, "workspace": e2e_workspace}, model, token=e2e_token
-                )
-
-            env = gemini.build_runtime_env(e2e_workspace, model, e2e_token)
-            cmd = gemini.validate_cmd("gemini")
-            result = _run_agent(cmd, env=env, timeout=90)
-            combined = (result.stdout + result.stderr).strip()
-            if result.returncode != 0 or not combined:
-                failures.append(
-                    f"model={model} rc={result.returncode} "
-                    f"stdout={result.stdout[:300]!r} stderr={result.stderr[:300]!r}"
-                )
+                state = {**e2e_state, "workspace": e2e_workspace}
+                gemini.write_tool_config(state, model, token=e2e_token)
+                # Exercise the real production validate flow — same code path
+                # that `ucode configure` invokes after writing the config.
+                captured_state = state
+                mp.setattr("ucode.agents.load_state", lambda s=captured_state: s)
+                ok, err = validate_tool("gemini")
+            if not ok:
+                failures.append(f"model={model} err={err}")
 
         assert not failures, "Gemini launch failures:\n" + "\n".join(failures)
 


### PR DESCRIPTION
The Gemini CLI's findEnvFile() skips ~/.gemini/.env when run from an untrusted folder, so `gemini -p` during validation could not find GEMINI_API_KEY and failed with "Update your environment and try again".

Add a validate_env hook (mirroring the Copilot pattern) so validate_tool passes env vars directly to the subprocess instead of relying on the CLI's .env discovery. Update the e2e test to invoke validate_tool() — the real production code path — so a regression like this would be caught automatically.