### PR TITLE
Stop highlighting full row in tool picker

### DIFF
--- a/src/ucode/ui.py
+++ b/src/ucode/ui.py
@@ -219,8 +219,13 @@ def prompt_for_tools(available: list[tuple[str, str]]) -> list[str]:
     """
     style = questionary.Style(
         [
-            ("highlighted", "fg:cyan bold"),
+            # questionary applies `selected` to *checked* rows and
+            # `highlighted` to the cursor row — overriding both to plain
+            # white means only the indicator and the `›` pointer carry
+            # signal, instead of the entire row inverting.
             ("pointer", "fg:cyan bold"),
+            ("highlighted", "fg:white noinherit"),
+            ("selected", "fg:white noinherit"),
             ("answer", "fg:cyan"),
         ]
     )


### PR DESCRIPTION
questionary's checkbox applies `class:selected` to every checked row's title, which made the multi-select look like every row was always highlighted (every row is checked by default). Override `selected` and `highlighted` to plain white so only the `›` pointer and the `●`/`○` indicator carry signal.