### PR TITLE
Add web_search MCP server backed by Databricks GPT Responses API

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 from pathlib import Path
 
 from ucode.config_io import (
@@ -33,12 +34,52 @@ SPEC: ToolSpec = {
 }
 
 
+def _resolve_web_search_model(state: dict) -> str | None:
+    """Pick the model the web_search MCP server should call. Prefers an
+    explicit override in state, otherwise the first endpoint discovered as
+    Responses-API-capable. Returns None if no GPT endpoint is available —
+    callers should skip the MCP wiring in that case."""
+    override = state.get("web_search_model")
+    if isinstance(override, str) and override.strip():
+        return override.strip()
+    codex_models = state.get("codex_models") or []
+    if isinstance(codex_models, list) and codex_models:
+        first = codex_models[0]
+        if isinstance(first, str) and first.strip():
+            return first.strip()
+    return None
+
+
+WEB_SEARCH_MCP_NAME = "web_search"
+
+
+def _web_search_mcp_entry(workspace: str, search_model: str) -> dict:
+    """Stdio MCP server entry pointing at `ucode mcp web-search`. Resolves
+    the absolute path to the `ucode` binary so launchers without the right
+    PATH (e.g. desktop GUI launchers) still find it."""
+    ucode_binary = shutil.which("ucode") or "ucode"
+    return {
+        "type": "stdio",
+        "command": ucode_binary,
+        "args": ["mcp", "web-search"],
+        "env": {
+            "DATABRICKS_HOST": workspace,
+            "UCODE_WEB_SEARCH_MODEL": search_model,
+        },
+    }
+
+
 def render_overlay(
     workspace: str,
     model: str,
     claude_models: dict[str, str] | None = None,
+    disable_web_search: bool = False,
 ) -> tuple[dict, list[list[str]]]:
-    """Return (overlay, managed_key_paths) for Claude settings.json."""
+    """Return (overlay, managed_key_paths) for Claude settings.json.
+
+    NOTE: MCP servers are NOT written here. Claude Code reads `mcpServers`
+    from `~/.claude.json`, not `~/.claude/settings.json` — registration goes
+    through `claude mcp add-json` (see `_register_web_search_mcp`)."""
     base_url = build_tool_base_url("claude", workspace)
     env: dict[str, str] = {
         "ANTHROPIC_MODEL": model,
@@ -54,21 +95,67 @@ def render_overlay(
             env["ANTHROPIC_DEFAULT_SONNET_MODEL"] = claude_models["sonnet"]
         if claude_models.get("haiku"):
             env["ANTHROPIC_DEFAULT_HAIKU_MODEL"] = claude_models["haiku"]
-    overlay = {"apiKeyHelper": build_auth_shell_command(workspace), "env": env}
+    overlay: dict = {"apiKeyHelper": build_auth_shell_command(workspace), "env": env}
     keys: list[list[str]] = [["apiKeyHelper"]] + [["env", k] for k in env]
+
+    # Disable Claude Code's built-in WebSearch (it routes through Anthropic's
+    # hosted infra and fails through the Databricks gateway). The replacement
+    # `web_search` MCP server is registered separately via the claude CLI.
+    if disable_web_search:
+        overlay["disabledTools"] = ["WebSearch"]
+        keys.append(["disabledTools"])
+
     return overlay, keys
+
+
+def _register_web_search_mcp(workspace: str, search_model: str) -> None:
+    """Register (or replace) the web_search MCP server in Claude Code's user
+    scope via `claude mcp add-json`. Removes any prior entry first so re-runs
+    pick up changes to the workspace, model, or ucode binary path."""
+    # Imported lazily to avoid a circular import via ucode.mcp -> ucode.agents.
+    from ucode.mcp import (
+        MCP_CLEANUP_SCOPES,
+        add_claude_mcp_server,
+        remove_claude_mcp_server,
+    )
+
+    for scope in MCP_CLEANUP_SCOPES:
+        try:
+            remove_claude_mcp_server(WEB_SEARCH_MCP_NAME, scope)
+        except RuntimeError:
+            # Best-effort cleanup of stale entries — keep going.
+            pass
+    entry = _web_search_mcp_entry(workspace, search_model)
+    add_claude_mcp_server(WEB_SEARCH_MCP_NAME, entry)
+
+
+def _unregister_web_search_mcp() -> None:
+    """Remove the web_search MCP server from all scopes. Used by revert."""
+    from ucode.mcp import MCP_CLEANUP_SCOPES, remove_claude_mcp_server
+
+    for scope in MCP_CLEANUP_SCOPES:
+        try:
+            remove_claude_mcp_server(WEB_SEARCH_MCP_NAME, scope)
+        except RuntimeError:
+            pass
 
 
 def write_tool_config(state: dict, model: str) -> dict:
     backup_existing_file(CLAUDE_SETTINGS_PATH, CLAUDE_BACKUP_PATH)
+    web_search_model = _resolve_web_search_model(state)
     overlay, managed_keys = render_overlay(
         state["workspace"],
         model,
         state.get("claude_models") or {},
+        disable_web_search=web_search_model is not None,
     )
     existing = read_json_safe(CLAUDE_SETTINGS_PATH)
     merged = deep_merge_dict(existing, overlay)
     write_json_file(CLAUDE_SETTINGS_PATH, merged)
+
+    if web_search_model:
+        _register_web_search_mcp(state["workspace"], web_search_model)
+
     state = mark_tool_managed(state, "claude", managed_keys)
     save_state(state)
     return state

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -268,6 +268,16 @@ app = typer.Typer(
 )
 configure_app = typer.Typer(add_completion=False, no_args_is_help=False)
 app.add_typer(configure_app, name="configure", help="Configure workspace and tool settings.")
+mcp_app = typer.Typer(add_completion=False, no_args_is_help=True)
+app.add_typer(mcp_app, name="mcp", help="MCP servers exposed by ucode.")
+
+
+@mcp_app.command("web-search")
+def mcp_web_search_cmd() -> None:
+    """Run the web_search MCP server over stdio. Invoked as a subprocess by Claude Code."""
+    from ucode.mcp_web_search import serve
+
+    serve()
 
 
 def _auto_configure_tool(tool: str) -> None:

--- a/src/ucode/mcp_web_search.py
+++ b/src/ucode/mcp_web_search.py
@@ -1,0 +1,208 @@
+"""Stdio MCP server exposing a `web_search` tool backed by a Databricks-hosted
+GPT model's native Responses API web search.
+
+Claude Code on Databricks doesn't have working web search (the built-in
+`WebSearch` tool talks to Anthropic's hosted infra, not the gateway). This
+server bridges the gap: it advertises a single MCP tool, and on call it
+forwards the query to the workspace's Responses API with
+`tools: [{"type": "web_search"}]`, returning the model's text output.
+
+Speaks MCP JSON-RPC 2.0 over stdio (newline-delimited JSON). Implemented by
+hand to avoid pulling in the `mcp` SDK — keeps `ucode`'s dep footprint lean.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+from ucode.databricks import get_databricks_token
+
+PROTOCOL_VERSION = "2024-11-05"
+SERVER_NAME = "ucode-web-search"
+SERVER_VERSION = "0.1.0"
+
+TOOL_NAME = "web_search"
+TOOL_DESCRIPTION = (
+    "Search the web for up-to-date public information, current events, "
+    "real-time facts, and recent data. Use this when the user's question "
+    "requires information beyond your training data."
+)
+TOOL_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": "The search query.",
+        },
+    },
+    "required": ["query"],
+}
+
+
+def _tool_descriptor() -> dict[str, Any]:
+    return {
+        "name": TOOL_NAME,
+        "description": TOOL_DESCRIPTION,
+        "inputSchema": TOOL_INPUT_SCHEMA,
+    }
+
+
+def _result(req_id: Any, result: Any) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _error(req_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+
+def _tool_error(text: str) -> dict[str, Any]:
+    """An MCP tool-call result with isError=true. Different from JSON-RPC errors:
+    tool-level failures should be returned as results so the model can see and
+    react to them, not as protocol errors that abort the call."""
+    return {"content": [{"type": "text", "text": text}], "isError": True}
+
+
+def _extract_response_text(payload: dict[str, Any]) -> str:
+    """Walk a Responses API payload and concatenate all `output_text` content
+    from `message`-type output items. Skips reasoning, tool-call, and other
+    item types — we only want the final user-facing answer."""
+    parts: list[str] = []
+    for item in payload.get("output", []) or []:
+        if not isinstance(item, dict) or item.get("type") != "message":
+            continue
+        for content in item.get("content", []) or []:
+            if isinstance(content, dict) and content.get("type") == "output_text":
+                text = content.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+    return "\n".join(parts).strip()
+
+
+def _call_responses_api(query: str) -> dict[str, Any]:
+    """POST to the Databricks Codex (Responses API) gateway and return the
+    parsed JSON payload. Raises RuntimeError on any failure with a message
+    suitable for surfacing as a tool error."""
+    workspace = os.environ.get("DATABRICKS_HOST", "").strip()
+    model = os.environ.get("UCODE_WEB_SEARCH_MODEL", "").strip()
+    if not workspace:
+        raise RuntimeError("DATABRICKS_HOST env var is not set.")
+    if not model:
+        raise RuntimeError("UCODE_WEB_SEARCH_MODEL env var is not set.")
+
+    try:
+        token = get_databricks_token(workspace)
+    except RuntimeError as exc:
+        raise RuntimeError(f"Failed to acquire Databricks token: {exc}") from exc
+
+    body = json.dumps(
+        {
+            "model": model,
+            "input": [{"role": "user", "content": query}],
+            "tools": [{"type": "web_search"}],
+            "store": False,
+        }
+    ).encode("utf-8")
+
+    request = urllib_request.Request(
+        f"{workspace.rstrip('/')}/ai-gateway/codex/v1/responses",
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib_request.urlopen(request, timeout=60) as response:
+            raw = response.read().decode("utf-8")
+    except urllib_error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read().decode("utf-8")[:500]
+        except Exception:
+            pass
+        raise RuntimeError(f"Responses API returned HTTP {exc.code}: {detail}") from exc
+    except urllib_error.URLError as exc:
+        raise RuntimeError(f"Responses API request failed: {exc.reason}") from exc
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Responses API returned non-JSON payload: {exc}") from exc
+
+
+def _handle_tools_call(arguments: dict[str, Any]) -> dict[str, Any]:
+    query = arguments.get("query")
+    if not isinstance(query, str) or not query.strip():
+        return _tool_error("`query` must be a non-empty string.")
+    try:
+        payload = _call_responses_api(query)
+    except RuntimeError as exc:
+        return _tool_error(str(exc))
+
+    text = _extract_response_text(payload)
+    if not text:
+        return _tool_error("Web search returned no text output.")
+    return {"content": [{"type": "text", "text": text}]}
+
+
+def _handle_request(req: dict[str, Any]) -> dict[str, Any] | None:
+    """Dispatch a single JSON-RPC request. Returns the response dict, or None
+    for notifications (which must not produce a response per JSON-RPC spec)."""
+    method = req.get("method")
+    req_id = req.get("id")
+    params = req.get("params") or {}
+    is_notification = "id" not in req
+
+    if method == "initialize":
+        return _result(
+            req_id,
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+            },
+        )
+    if method == "notifications/initialized":
+        return None
+    if method == "tools/list":
+        return _result(req_id, {"tools": [_tool_descriptor()]})
+    if method == "tools/call":
+        if params.get("name") != TOOL_NAME:
+            return _error(req_id, -32602, f"Unknown tool: {params.get('name')!r}")
+        return _result(req_id, _handle_tools_call(params.get("arguments") or {}))
+
+    if is_notification:
+        return None
+    return _error(req_id, -32601, f"Method not found: {method!r}")
+
+
+def serve(stdin=None, stdout=None) -> None:
+    """Read newline-delimited JSON-RPC requests from stdin, write responses to
+    stdout. Loops until EOF. Injectable streams for testing."""
+    in_stream = stdin if stdin is not None else sys.stdin
+    out_stream = stdout if stdout is not None else sys.stdout
+
+    for line in in_stream:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError:
+            response = _error(None, -32700, "Parse error")
+            out_stream.write(json.dumps(response) + "\n")
+            out_stream.flush()
+            continue
+
+        response = _handle_request(req)
+        if response is None:
+            continue
+        out_stream.write(json.dumps(response) + "\n")
+        out_stream.flush()

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -72,6 +72,56 @@ class TestRenderOverlay:
         assert len(env_keys) > 0
 
 
+class TestRenderOverlayWebSearchDisable:
+    def test_settings_overlay_never_includes_mcp_servers(self):
+        # MCP servers belong in ~/.claude.json, not settings.json.
+        overlay, _ = claude.render_overlay(WS, "s4", disable_web_search=True)
+        assert "mcpServers" not in overlay
+
+    def test_disables_builtin_websearch_when_requested(self):
+        overlay, _ = claude.render_overlay(WS, "s4", disable_web_search=True)
+        assert overlay["disabledTools"] == ["WebSearch"]
+
+    def test_no_disable_when_not_requested(self):
+        overlay, _ = claude.render_overlay(WS, "s4", disable_web_search=False)
+        assert "disabledTools" not in overlay
+
+    def test_managed_keys_include_disabled_tools_when_set(self):
+        _, keys = claude.render_overlay(WS, "s4", disable_web_search=True)
+        assert ["disabledTools"] in keys
+
+    def test_managed_keys_omit_disabled_tools_when_not_set(self):
+        _, keys = claude.render_overlay(WS, "s4", disable_web_search=False)
+        assert ["disabledTools"] not in keys
+
+
+class TestWebSearchMcpEntry:
+    def test_entry_shape(self):
+        entry = claude._web_search_mcp_entry(WS, "databricks-gpt-5")
+        assert entry["type"] == "stdio"
+        assert entry["args"] == ["mcp", "web-search"]
+        assert entry["env"]["DATABRICKS_HOST"] == WS
+        assert entry["env"]["UCODE_WEB_SEARCH_MODEL"] == "databricks-gpt-5"
+        assert isinstance(entry["command"], str) and entry["command"]
+
+
+class TestResolveWebSearchModel:
+    def test_uses_explicit_override(self):
+        assert claude._resolve_web_search_model({"web_search_model": "explicit"}) == "explicit"
+
+    def test_falls_back_to_first_codex_model(self):
+        state = {"codex_models": ["m1", "m2"]}
+        assert claude._resolve_web_search_model(state) == "m1"
+
+    def test_returns_none_when_no_codex_models(self):
+        assert claude._resolve_web_search_model({}) is None
+        assert claude._resolve_web_search_model({"codex_models": []}) is None
+
+    def test_override_wins_over_codex_models(self):
+        state = {"web_search_model": "winner", "codex_models": ["loser"]}
+        assert claude._resolve_web_search_model(state) == "winner"
+
+
 class TestClaudeDefaultModel:
     def test_prefers_opus(self):
         state = {"claude_models": {"sonnet": "s4", "opus": "o4", "haiku": "h4"}}
@@ -104,6 +154,82 @@ class TestClaudeValidateCmd:
         assert "--max-turns" in cmd
         idx = cmd.index("--max-turns")
         assert cmd[idx + 1] == "1"
+
+
+class TestWriteToolConfigMcpRegistration:
+    def _common_patches(self, monkeypatch, calls):
+        monkeypatch.setattr(claude, "backup_existing_file", lambda *a, **kw: True)
+        monkeypatch.setattr(claude, "read_json_safe", lambda path: {})
+        monkeypatch.setattr(claude, "write_json_file", lambda path, payload: None)
+        monkeypatch.setattr(claude, "save_state", lambda state: None)
+        monkeypatch.setattr(
+            claude,
+            "_register_web_search_mcp",
+            lambda ws, model: calls.append(("register", ws, model)),
+        )
+
+    def test_registers_mcp_when_codex_model_available(self, monkeypatch):
+        calls: list = []
+        self._common_patches(monkeypatch, calls)
+        state = {"workspace": WS, "codex_models": ["databricks-gpt-5"]}
+        claude.write_tool_config(state, "databricks-claude-sonnet-4")
+        assert calls == [("register", WS, "databricks-gpt-5")]
+
+    def test_skips_registration_without_codex_model(self, monkeypatch):
+        calls: list = []
+        self._common_patches(monkeypatch, calls)
+        state = {"workspace": WS, "codex_models": []}
+        claude.write_tool_config(state, "databricks-claude-sonnet-4")
+        assert calls == []
+
+    def test_explicit_override_used_over_codex_models(self, monkeypatch):
+        calls: list = []
+        self._common_patches(monkeypatch, calls)
+        state = {
+            "workspace": WS,
+            "web_search_model": "explicit-model",
+            "codex_models": ["other-model"],
+        }
+        claude.write_tool_config(state, "databricks-claude-sonnet-4")
+        assert calls == [("register", WS, "explicit-model")]
+
+
+class TestRegisterWebSearchMcp:
+    def test_clears_existing_then_adds(self, monkeypatch):
+        import ucode.mcp as mcp_mod
+
+        removed: list[str] = []
+        added: list = []
+        monkeypatch.setattr(
+            mcp_mod, "remove_claude_mcp_server", lambda name, scope: removed.append(scope) or True
+        )
+        monkeypatch.setattr(
+            mcp_mod,
+            "add_claude_mcp_server",
+            lambda name, entry, scope=mcp_mod.MCP_USER_SCOPE: added.append((name, entry, scope)),
+        )
+        claude._register_web_search_mcp(WS, "databricks-gpt-5")
+        assert removed == list(mcp_mod.MCP_CLEANUP_SCOPES)
+        assert len(added) == 1
+        name, entry, _ = added[0]
+        assert name == "web_search"
+        assert entry["env"]["UCODE_WEB_SEARCH_MODEL"] == "databricks-gpt-5"
+
+    def test_remove_failures_are_swallowed(self, monkeypatch):
+        import ucode.mcp as mcp_mod
+
+        def boom(name, scope):
+            raise RuntimeError("nope")
+
+        added: list = []
+        monkeypatch.setattr(mcp_mod, "remove_claude_mcp_server", boom)
+        monkeypatch.setattr(
+            mcp_mod,
+            "add_claude_mcp_server",
+            lambda name, entry, scope=mcp_mod.MCP_USER_SCOPE: added.append(name),
+        )
+        claude._register_web_search_mcp(WS, "m")
+        assert added == ["web_search"]
 
 
 class TestClaudeLaunch:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -121,6 +121,18 @@ class TestSubcommandRouting:
         assert result.exit_code != 0
 
 
+class TestMcpSubcommands:
+    def test_web_search_subcommand_help(self):
+        result = runner.invoke(app, ["mcp", "web-search", "--help"])
+        assert result.exit_code == 0
+        assert "Usage:" in result.output
+
+    def test_mcp_group_lists_web_search(self):
+        result = runner.invoke(app, ["mcp", "--help"])
+        assert result.exit_code == 0
+        assert "web-search" in result.output
+
+
 class TestAutoConfigureOnFirstRun:
     def test_triggers_when_no_workspace(self):
         """Auto-configure runs when state has no workspace."""

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -690,6 +690,103 @@ class TestPiLaunch:
 
 
 # ---------------------------------------------------------------------------
+# Web search MCP — Databricks-backed Responses API
+# ---------------------------------------------------------------------------
+#
+# Verifies the web_search MCP path against a real workspace:
+#   1. The Responses API call with tools=[{type: web_search}] returns text.
+#   2. The MCP server subprocess answers initialize/tools/list and tools/call
+#      correctly when DATABRICKS_HOST and UCODE_WEB_SEARCH_MODEL are set.
+#
+# Skipped when the workspace has no Responses-API endpoint (codex_models
+# empty), since web_search is unavailable in that case by design.
+# ---------------------------------------------------------------------------
+
+
+def _first_codex_model(e2e_state: dict) -> str:
+    models = e2e_state.get("codex_models") or []
+    if not models:
+        pytest.skip("No Responses-API (codex) models available on this workspace")
+    return models[0]
+
+
+class TestWebSearchResponsesApi:
+    """Hit the real Databricks Codex (Responses API) endpoint with native
+    web_search and assert the model returns non-empty text."""
+
+    def test_call_responses_api_returns_text(self, monkeypatch, e2e_state, e2e_workspace):
+        from ucode import mcp_web_search
+
+        model = _first_codex_model(e2e_state)
+        monkeypatch.setenv("DATABRICKS_HOST", e2e_workspace)
+        monkeypatch.setenv("UCODE_WEB_SEARCH_MODEL", model)
+
+        payload = mcp_web_search._call_responses_api(
+            "What is today's date? Use web search to confirm."
+        )
+        assert isinstance(payload, dict)
+        text = mcp_web_search._extract_response_text(payload)
+        assert text, (
+            f"Responses API returned no text output. Full payload (truncated): {str(payload)[:500]}"
+        )
+
+
+class TestWebSearchMcpSubprocess:
+    """Drive the `ucode mcp web-search` subprocess over stdio and assert the
+    full MCP protocol works end-to-end with a real workspace."""
+
+    def test_subprocess_initialize_list_and_call(self, e2e_state, e2e_workspace):
+        if not shutil.which("ucode"):
+            pytest.skip("`ucode` binary is not on PATH")
+        model = _first_codex_model(e2e_state)
+
+        env = {
+            **os.environ,
+            "DATABRICKS_HOST": e2e_workspace,
+            "UCODE_WEB_SEARCH_MODEL": model,
+        }
+        # Three MCP requests, one per line.
+        requests = [
+            '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}',
+            '{"jsonrpc":"2.0","id":2,"method":"tools/list"}',
+            (
+                '{"jsonrpc":"2.0","id":3,"method":"tools/call",'
+                '"params":{"name":"web_search","arguments":'
+                '{"query":"latest anthropic announcement"}}}'
+            ),
+        ]
+        proc = subprocess.run(
+            ["ucode", "mcp", "web-search"],
+            input="\n".join(requests) + "\n",
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=120,
+        )
+        assert proc.returncode == 0, (
+            f"ucode mcp web-search exited {proc.returncode}; stderr={proc.stderr[:500]!r}"
+        )
+
+        import json as _json
+
+        responses = [_json.loads(line) for line in proc.stdout.strip().splitlines()]
+        assert len(responses) == 3, f"Expected 3 responses, got {len(responses)}: {responses}"
+
+        init = responses[0]["result"]
+        assert init["serverInfo"]["name"] == "ucode-web-search"
+
+        tools = responses[1]["result"]["tools"]
+        assert any(t["name"] == "web_search" for t in tools)
+
+        call_result = responses[2]["result"]
+        assert "isError" not in call_result, (
+            f"web_search tool call returned an error: {call_result['content'][0]['text'][:300]}"
+        )
+        text = call_result["content"][0]["text"]
+        assert isinstance(text, str) and text.strip(), "tool call returned empty text"
+
+
+# ---------------------------------------------------------------------------
 # Auth recovery tests
 # ---------------------------------------------------------------------------
 #

--- a/tests/test_mcp_web_search.py
+++ b/tests/test_mcp_web_search.py
@@ -1,0 +1,242 @@
+"""Tests for the web_search stdio MCP server."""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+
+import pytest
+
+from ucode import mcp_web_search
+
+WS = "https://example.databricks.com"
+
+
+def _drive(requests: list[dict]) -> list[dict]:
+    """Run `serve()` over a synthetic stdin and return parsed responses."""
+    stdin = io.StringIO("\n".join(json.dumps(r) for r in requests) + "\n")
+    stdout = io.StringIO()
+    mcp_web_search.serve(stdin=stdin, stdout=stdout)
+    out = stdout.getvalue().strip().splitlines()
+    return [json.loads(line) for line in out]
+
+
+class TestInitialize:
+    def test_returns_protocol_and_server_info(self):
+        responses = _drive([{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}])
+        assert len(responses) == 1
+        result = responses[0]["result"]
+        assert result["protocolVersion"] == mcp_web_search.PROTOCOL_VERSION
+        assert result["serverInfo"]["name"] == mcp_web_search.SERVER_NAME
+        assert "tools" in result["capabilities"]
+
+
+class TestNotifications:
+    def test_initialized_notification_produces_no_response(self):
+        responses = _drive([{"jsonrpc": "2.0", "method": "notifications/initialized"}])
+        assert responses == []
+
+
+class TestToolsList:
+    def test_lists_web_search_tool(self):
+        responses = _drive([{"jsonrpc": "2.0", "id": 2, "method": "tools/list"}])
+        tools = responses[0]["result"]["tools"]
+        assert len(tools) == 1
+        assert tools[0]["name"] == "web_search"
+        assert "web" in tools[0]["description"].lower()
+        assert tools[0]["inputSchema"]["required"] == ["query"]
+
+
+class TestToolsCallSuccess:
+    def test_unwraps_responses_api_text(self, monkeypatch):
+        captured: dict[str, Any] = {}
+
+        def fake_call(query: str) -> dict:
+            captured["query"] = query
+            return {
+                "output": [
+                    {
+                        "type": "reasoning",
+                        "content": [{"type": "output_text", "text": "ignored"}],
+                    },
+                    {
+                        "type": "message",
+                        "content": [
+                            {"type": "output_text", "text": "Hello,"},
+                            {"type": "output_text", "text": " world."},
+                        ],
+                    },
+                ]
+            }
+
+        monkeypatch.setattr(mcp_web_search, "_call_responses_api", fake_call)
+        responses = _drive(
+            [
+                {
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": {"name": "web_search", "arguments": {"query": "anthropic news"}},
+                }
+            ]
+        )
+        result = responses[0]["result"]
+        assert "isError" not in result
+        assert result["content"] == [{"type": "text", "text": "Hello,\n world."}]
+        assert captured["query"] == "anthropic news"
+
+
+class TestToolsCallErrors:
+    def test_missing_query_returns_tool_error(self, monkeypatch):
+        responses = _drive(
+            [
+                {
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "method": "tools/call",
+                    "params": {"name": "web_search", "arguments": {}},
+                }
+            ]
+        )
+        result = responses[0]["result"]
+        assert result["isError"] is True
+        assert "query" in result["content"][0]["text"].lower()
+
+    def test_http_failure_surfaces_as_tool_error(self, monkeypatch):
+        def boom(query: str) -> dict:
+            raise RuntimeError("Responses API returned HTTP 500: oops")
+
+        monkeypatch.setattr(mcp_web_search, "_call_responses_api", boom)
+        responses = _drive(
+            [
+                {
+                    "jsonrpc": "2.0",
+                    "id": 5,
+                    "method": "tools/call",
+                    "params": {"name": "web_search", "arguments": {"query": "anything"}},
+                }
+            ]
+        )
+        result = responses[0]["result"]
+        assert result["isError"] is True
+        assert "HTTP 500" in result["content"][0]["text"]
+
+    def test_empty_response_text_returns_tool_error(self, monkeypatch):
+        monkeypatch.setattr(mcp_web_search, "_call_responses_api", lambda q: {"output": []})
+        responses = _drive(
+            [
+                {
+                    "jsonrpc": "2.0",
+                    "id": 6,
+                    "method": "tools/call",
+                    "params": {"name": "web_search", "arguments": {"query": "x"}},
+                }
+            ]
+        )
+        assert responses[0]["result"]["isError"] is True
+
+    def test_unknown_tool_name_returns_protocol_error(self):
+        responses = _drive(
+            [
+                {
+                    "jsonrpc": "2.0",
+                    "id": 7,
+                    "method": "tools/call",
+                    "params": {"name": "not_a_real_tool", "arguments": {}},
+                }
+            ]
+        )
+        assert "error" in responses[0]
+        assert responses[0]["error"]["code"] == -32602
+
+
+class TestProtocolErrors:
+    def test_unknown_method(self):
+        responses = _drive([{"jsonrpc": "2.0", "id": 8, "method": "frobnicate"}])
+        assert responses[0]["error"]["code"] == -32601
+
+    def test_invalid_json_emits_parse_error(self):
+        stdin = io.StringIO("not json\n")
+        stdout = io.StringIO()
+        mcp_web_search.serve(stdin=stdin, stdout=stdout)
+        line = stdout.getvalue().strip()
+        payload = json.loads(line)
+        assert payload["error"]["code"] == -32700
+
+
+class TestExtractText:
+    def test_concatenates_all_message_text_chunks(self):
+        payload = {
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {"type": "output_text", "text": "a"},
+                        {"type": "other", "text": "skip"},
+                        {"type": "output_text", "text": "b"},
+                    ],
+                }
+            ]
+        }
+        assert mcp_web_search._extract_response_text(payload) == "a\nb"
+
+    def test_skips_non_message_items(self):
+        payload = {
+            "output": [
+                {"type": "reasoning", "content": [{"type": "output_text", "text": "hidden"}]},
+            ]
+        }
+        assert mcp_web_search._extract_response_text(payload) == ""
+
+
+class TestCallResponsesApi:
+    def test_missing_workspace_env(self, monkeypatch):
+        monkeypatch.delenv("DATABRICKS_HOST", raising=False)
+        monkeypatch.setenv("UCODE_WEB_SEARCH_MODEL", "x")
+        with pytest.raises(RuntimeError, match="DATABRICKS_HOST"):
+            mcp_web_search._call_responses_api("query")
+
+    def test_missing_model_env(self, monkeypatch):
+        monkeypatch.setenv("DATABRICKS_HOST", WS)
+        monkeypatch.delenv("UCODE_WEB_SEARCH_MODEL", raising=False)
+        with pytest.raises(RuntimeError, match="UCODE_WEB_SEARCH_MODEL"):
+            mcp_web_search._call_responses_api("query")
+
+    def test_posts_to_responses_endpoint(self, monkeypatch):
+        monkeypatch.setenv("DATABRICKS_HOST", WS)
+        monkeypatch.setenv("UCODE_WEB_SEARCH_MODEL", "databricks-gpt-5")
+        monkeypatch.setattr(mcp_web_search, "get_databricks_token", lambda ws: "tok")
+
+        captured: dict[str, Any] = {}
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return json.dumps({"output": []}).encode("utf-8")
+
+        def fake_urlopen(req, timeout):
+            captured["url"] = req.full_url
+            captured["method"] = req.get_method()
+            captured["headers"] = dict(req.header_items())
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return FakeResponse()
+
+        monkeypatch.setattr(mcp_web_search.urllib_request, "urlopen", fake_urlopen)
+        mcp_web_search._call_responses_api("hello")
+
+        assert captured["url"] == f"{WS}/ai-gateway/codex/v1/responses"
+        assert captured["method"] == "POST"
+        assert captured["body"]["model"] == "databricks-gpt-5"
+        assert captured["body"]["tools"] == [{"type": "web_search"}]
+        assert captured["body"]["input"] == [{"role": "user", "content": "hello"}]
+        # urllib lowercases header names in header_items
+        auth_header = next(
+            v for k, v in captured["headers"].items() if k.lower() == "authorization"
+        )
+        assert auth_header == "Bearer tok"


### PR DESCRIPTION
Claude Code's built-in WebSearch routes through Anthropic's hosted infra and fails through the Databricks gateway. Workspaces do host GPT models served via OpenAI's Responses API, which has native server-side web_search.

This adds a stdio MCP server (`ucode mcp web-search`) that proxies a web_search tool through a Databricks GPT Responses API call. When configuring Claude Code, ucode now also disables the broken built-in WebSearch and registers the MCP server via `claude mcp add-json -s user`, reusing the existing add_claude_mcp_server helper. Skipped gracefully when the workspace has no Responses-API endpoint.