### PR TITLE
Inject ucode/<ver> <agent>/<ver> User-Agent on outbound agent traffic

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -20,6 +20,7 @@ from ucode.databricks import (
     get_databricks_token,
 )
 from ucode.state import mark_tool_managed, save_state
+from ucode.telemetry import agent_version, ucode_version
 
 CLAUDE_CONFIG_DIR = Path.home() / ".claude"
 CLAUDE_SETTINGS_PATH = CLAUDE_CONFIG_DIR / "settings.json"
@@ -81,10 +82,20 @@ def render_overlay(
     from `~/.claude.json`, not `~/.claude/settings.json` — registration goes
     through `claude mcp add-json` (see `_register_web_search_mcp`)."""
     base_url = build_tool_base_url("claude", workspace)
+    # ANTHROPIC_CUSTOM_HEADERS is parsed as `key: value` pairs separated by
+    # newlines (Anthropic SDK convention). Setting User-Agent here overrides
+    # the SDK's default UA on outbound requests so the gateway can attribute
+    # traffic to ucode.
+    custom_headers = "\n".join(
+        [
+            "x-databricks-use-coding-agent-mode: true",
+            f"User-Agent: ucode/{ucode_version()} claude/{agent_version('claude')}",
+        ]
+    )
     env: dict[str, str] = {
         "ANTHROPIC_MODEL": model,
         "ANTHROPIC_BASE_URL": base_url,
-        "ANTHROPIC_CUSTOM_HEADERS": "x-databricks-use-coding-agent-mode: true",
+        "ANTHROPIC_CUSTOM_HEADERS": custom_headers,
         "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
         "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "900000",
     }

--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -19,6 +19,7 @@ from ucode.databricks import (
     get_databricks_token,
 )
 from ucode.state import mark_tool_managed, save_state
+from ucode.telemetry import agent_version, ucode_version
 
 CODEX_CONFIG_DIR = Path.home() / ".codex"
 CODEX_CONFIG_PATH = CODEX_CONFIG_DIR / "config.toml"
@@ -36,6 +37,7 @@ MANAGED_KEYS: list[list[str]] = [
     ["profile"],
     ["profiles", "default", "model_provider"],
     ["model_providers", "Databricks"],
+    ["model_providers", "Databricks", "http_headers"],
 ]
 
 
@@ -50,6 +52,9 @@ def render_overlay(workspace: str) -> dict:
                 "name": "Databricks AI Gateway",
                 "base_url": base_url,
                 "wire_api": "responses",
+                "http_headers": {
+                    "User-Agent": f"ucode/{ucode_version()} codex/{agent_version('codex')}",
+                },
                 "auth": {
                     "command": "sh",
                     "args": ["-c", auth_command],

--- a/src/ucode/agents/gemini.py
+++ b/src/ucode/agents/gemini.py
@@ -23,6 +23,7 @@ from ucode.databricks import (
     get_databricks_token,
 )
 from ucode.state import mark_tool_managed, save_state
+from ucode.telemetry import agent_version, ucode_version
 
 GEMINI_CONFIG_DIR = Path.home() / ".gemini"
 GEMINI_ENV_PATH = GEMINI_CONFIG_DIR / ".env"
@@ -42,27 +43,30 @@ MANAGED_KEYS: list[str] = [
     "GOOGLE_GEMINI_BASE_URL",
     "GEMINI_API_KEY_AUTH_MECHANISM",
     "GEMINI_API_KEY",
+    "GEMINI_CLI_CUSTOM_HEADERS",
     "OAUTH_TOKEN",
 ]
 
 
 def render_env_overlay(workspace: str, model: str, token: str) -> dict[str, str]:
+    # Gemini CLI parses GEMINI_CLI_CUSTOM_HEADERS as comma-separated
+    # `Key:Value` pairs and spreads them after the SDK's default User-Agent,
+    # so a key named `User-Agent` overrides the default. Resolved via
+    # upstream issue google-gemini/gemini-cli#10088.
+    custom_headers = f"User-Agent:ucode/{ucode_version()} gemini/{agent_version('gemini')}"
     return {
         "GEMINI_MODEL": model,
         "GOOGLE_GEMINI_BASE_URL": build_tool_base_url("gemini", workspace),
         "GEMINI_API_KEY_AUTH_MECHANISM": "bearer",
         "GEMINI_API_KEY": token,
+        "GEMINI_CLI_CUSTOM_HEADERS": custom_headers,
         "OAUTH_TOKEN": token,
     }
 
 
 def build_runtime_env(workspace: str, model: str, token: str) -> dict[str, str]:
     env = os.environ.copy()
-    env["GEMINI_MODEL"] = model
-    env["GOOGLE_GEMINI_BASE_URL"] = build_tool_base_url("gemini", workspace)
-    env["GEMINI_API_KEY_AUTH_MECHANISM"] = "bearer"
-    env["GEMINI_API_KEY"] = token
-    env["OAUTH_TOKEN"] = token
+    env.update(render_env_overlay(workspace, model, token))
     # Newer Gemini CLI releases refuse to run in untrusted directories;
     # opt every launch into trust so `ucode gemini` works in any folder.
     env["GEMINI_CLI_TRUST_WORKSPACE"] = "true"

--- a/src/ucode/agents/opencode.py
+++ b/src/ucode/agents/opencode.py
@@ -22,6 +22,7 @@ from ucode.databricks import (
     get_databricks_token,
 )
 from ucode.state import mark_tool_managed, save_state
+from ucode.telemetry import agent_version, ucode_version
 
 OPENCODE_CONFIG_DIR = Path.home() / ".config" / "opencode"
 OPENCODE_CONFIG_PATH = OPENCODE_CONFIG_DIR / "opencode.json"
@@ -66,6 +67,13 @@ def render_overlay(
 ) -> tuple[dict, list[list[str]]]:
     """Return (overlay, managed_key_paths) for opencode.json."""
     auth_headers = {"Authorization": f"Bearer {token}"}
+    # OpenCode hardcodes `User-Agent: opencode/<ver>` in session/llm.ts for
+    # every provider, after the AI SDK's combineHeaders. The provider-level
+    # `headers` are clobbered by that injection, but per-model `headers` are
+    # merged AFTER and win — so the UA must live on each model entry.
+    ua_header = {
+        "User-Agent": f"ucode/{ucode_version()} opencode/{agent_version('opencode')}",
+    }
 
     anthropic_models = opencode_models.get("anthropic") or []
     gemini_models = opencode_models.get("gemini") or []
@@ -80,7 +88,7 @@ def render_overlay(
                 "apiKey": token,
                 "headers": auth_headers,
             },
-            "models": {m: {} for m in anthropic_models},
+            "models": {m: {"headers": ua_header} for m in anthropic_models},
         }
         keys.append(["provider", "databricks-anthropic"])
     if gemini_models:
@@ -91,7 +99,7 @@ def render_overlay(
                 "apiKey": token,
                 "headers": auth_headers,
             },
-            "models": {m: {} for m in gemini_models},
+            "models": {m: {"headers": ua_header} for m in gemini_models},
         }
         keys.append(["provider", "databricks-google"])
 

--- a/src/ucode/agents/pi.py
+++ b/src/ucode/agents/pi.py
@@ -47,6 +47,7 @@ from ucode.databricks import (
     get_databricks_token,
 )
 from ucode.state import mark_tool_managed, save_state
+from ucode.telemetry import agent_version, ucode_version
 
 PI_CONFIG_DIR = Path.home() / ".pi" / "agent"
 PI_CONFIG_PATH = PI_CONFIG_DIR / "models.json"
@@ -103,6 +104,9 @@ def render_overlay(
     """Return (overlay, managed_key_paths) for ~/.pi/agent/models.json."""
     providers: dict = {}
     keys: list[list[str]] = [["model"]]
+    # Pi expands header values that match an env var name. Our UA contains
+    # `/` and a space so it can never collide — safe to pass as a literal.
+    ua_headers = {"User-Agent": f"ucode/{ucode_version()} pi/{agent_version('pi')}"}
 
     claude_ids = sorted(set(claude_models.values()))
     if claude_ids:
@@ -115,6 +119,7 @@ def render_overlay(
             # `eager_input_streaming` on the streaming + tools path. Pi sends
             # the legacy beta header instead when this is false.
             "compat": {"supportsEagerToolInputStreaming": False},
+            "headers": ua_headers,
             "models": [{"id": m} for m in claude_ids],
         }
         keys.append(["providers", "databricks-claude"])
@@ -124,6 +129,7 @@ def render_overlay(
             "api": "openai-responses",
             "apiKey": token,
             "authHeader": True,
+            "headers": ua_headers,
             "models": [{"id": m} for m in codex_models],
         }
         keys.append(["providers", "databricks-openai"])
@@ -133,6 +139,7 @@ def render_overlay(
             "api": "google-generative-ai",
             "apiKey": token,
             "authHeader": True,
+            "headers": ua_headers,
             "models": [{"id": m} for m in gemini_models],
         }
         keys.append(["providers", "databricks-gemini"])

--- a/src/ucode/telemetry.py
+++ b/src/ucode/telemetry.py
@@ -1,0 +1,52 @@
+"""Helpers for building the outbound `User-Agent` we attach to agent traffic.
+
+The gateway uses the UA to attribute requests to ucode and to a specific
+wrapped agent + version. Format: `ucode/<ucode_ver> <agent>/<agent_ver>`.
+
+Both helpers fall back to "unknown" rather than raising — telemetry must
+never block a launch.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from functools import cache
+from importlib.metadata import PackageNotFoundError, version
+
+_SEMVER_RE = re.compile(r"\d+\.\d+\.\d+[-+0-9A-Za-z.]*")
+
+
+@cache
+def ucode_version() -> str:
+    try:
+        return version("ucode")
+    except PackageNotFoundError:
+        return "unknown"
+
+
+@cache
+def agent_version(binary: str) -> str:
+    """Return the agent CLI's reported version, or "unknown" on any failure.
+
+    Spawned at most once per binary per session (cached). Each agent CLI
+    formats `--version` differently — we extract the first semver-shaped
+    token from stdout (then stderr) so the same parser handles all of them.
+    """
+    try:
+        result = subprocess.run(
+            [binary, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        return "unknown"
+    for stream in (result.stdout, result.stderr):
+        if not stream:
+            continue
+        match = _SEMVER_RE.search(stream)
+        if match:
+            return match.group(0)
+    return "unknown"

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -72,6 +72,23 @@ class TestRenderOverlay:
         assert len(env_keys) > 0
 
 
+class TestRenderOverlayUserAgent:
+    def _ua(self, monkeypatch) -> str:
+        monkeypatch.setattr(claude, "ucode_version", lambda: "0.1.0")
+        monkeypatch.setattr(claude, "agent_version", lambda binary: "2.1.136")
+        overlay, _ = claude.render_overlay(WS, "s4")
+        return overlay["env"]["ANTHROPIC_CUSTOM_HEADERS"]
+
+    def test_user_agent_present(self, monkeypatch):
+        assert "User-Agent: ucode/0.1.0 claude/2.1.136" in self._ua(monkeypatch)
+
+    def test_existing_databricks_header_preserved(self, monkeypatch):
+        assert "x-databricks-use-coding-agent-mode: true" in self._ua(monkeypatch)
+
+    def test_headers_newline_delimited(self, monkeypatch):
+        assert "\n" in self._ua(monkeypatch)
+
+
 class TestRenderOverlayWebSearchDisable:
     def test_settings_overlay_never_includes_mcp_servers(self):
         # MCP servers belong in ~/.claude.json, not settings.json.

--- a/tests/test_agent_codex.py
+++ b/tests/test_agent_codex.py
@@ -56,6 +56,19 @@ class TestRenderOverlay:
         assert auth["refresh_interval_ms"] == 900_000
 
 
+class TestRenderOverlayUserAgent:
+    def test_user_agent_set_on_provider(self, monkeypatch):
+        monkeypatch.setattr(codex, "ucode_version", lambda: "0.1.0")
+        monkeypatch.setattr(codex, "agent_version", lambda binary: "0.123.0")
+        overlay = codex.render_overlay(WS)
+        provider = overlay["model_providers"]["Databricks"]
+        assert provider["http_headers"]["User-Agent"] == "ucode/0.1.0 codex/0.123.0"
+
+    def test_managed_keys_include_http_headers(self):
+        # Revert must clean up the new key.
+        assert ["model_providers", "Databricks", "http_headers"] in codex.MANAGED_KEYS
+
+
 class TestCodexDefaultModel:
     def test_always_none(self):
         assert codex.default_model({}) is None

--- a/tests/test_agent_gemini.py
+++ b/tests/test_agent_gemini.py
@@ -41,6 +41,12 @@ class TestRenderEnvOverlay:
         env = gemini.render_env_overlay(WS, "gemini-2.0-flash", "tok123")
         assert env["GEMINI_API_KEY_AUTH_MECHANISM"] == "bearer"
 
+    def test_sets_user_agent_via_custom_headers(self, monkeypatch):
+        monkeypatch.setattr(gemini, "ucode_version", lambda: "0.1.0")
+        monkeypatch.setattr(gemini, "agent_version", lambda binary: "0.40.0")
+        env = gemini.render_env_overlay(WS, "gemini-2", "tok")
+        assert env["GEMINI_CLI_CUSTOM_HEADERS"] == "User-Agent:ucode/0.1.0 gemini/0.40.0"
+
 
 class TestBuildRuntimeEnv:
     def test_merges_os_environment(self):

--- a/tests/test_agent_opencode.py
+++ b/tests/test_agent_opencode.py
@@ -76,6 +76,35 @@ class TestRenderOverlay:
         headers = overlay["provider"]["databricks-anthropic"]["options"]["headers"]
         assert headers["Authorization"] == "Bearer tok"
 
+    def test_user_agent_header_anthropic(self, monkeypatch):
+        # UA must live at the per-model level — OpenCode clobbers
+        # provider-level `headers["User-Agent"]` in session/llm.ts.
+        monkeypatch.setattr(opencode, "ucode_version", lambda: "0.1.0")
+        monkeypatch.setattr(opencode, "agent_version", lambda binary: "0.74.0")
+        models = {"anthropic": ["claude-sonnet"]}
+        overlay, _ = opencode.render_overlay("claude-sonnet", "tok", _base_urls(), models)
+        model_headers = overlay["provider"]["databricks-anthropic"]["models"]["claude-sonnet"][
+            "headers"
+        ]
+        assert model_headers["User-Agent"] == "ucode/0.1.0 opencode/0.74.0"
+
+    def test_user_agent_header_gemini(self, monkeypatch):
+        monkeypatch.setattr(opencode, "ucode_version", lambda: "0.1.0")
+        monkeypatch.setattr(opencode, "agent_version", lambda binary: "0.74.0")
+        models = {"gemini": ["gemini-2"]}
+        overlay, _ = opencode.render_overlay("gemini-2", "tok", _base_urls(), models)
+        model_headers = overlay["provider"]["databricks-google"]["models"]["gemini-2"]["headers"]
+        assert model_headers["User-Agent"] == "ucode/0.1.0 opencode/0.74.0"
+
+    def test_provider_level_headers_only_authorization(self, monkeypatch):
+        # Sanity: provider-level headers should NOT include User-Agent (since
+        # it's clobbered there) — only Authorization.
+        models = {"anthropic": ["claude-sonnet"]}
+        overlay, _ = opencode.render_overlay("claude-sonnet", "tok", _base_urls(), models)
+        provider_headers = overlay["provider"]["databricks-anthropic"]["options"]["headers"]
+        assert "User-Agent" not in provider_headers
+        assert provider_headers["Authorization"] == "Bearer tok"
+
     def test_managed_keys_include_model(self):
         _, keys = opencode.render_overlay("model", "tok", _base_urls(), {})
         assert ["model"] in keys

--- a/tests/test_agent_pi.py
+++ b/tests/test_agent_pi.py
@@ -93,6 +93,21 @@ class TestRenderOverlayProviders:
         }
 
 
+class TestRenderOverlayUserAgent:
+    def test_user_agent_set_on_all_three_providers(self, monkeypatch):
+        monkeypatch.setattr(pi, "ucode_version", lambda: "0.1.0")
+        monkeypatch.setattr(pi, "agent_version", lambda binary: "0.74.0")
+        overlay, _ = _overlay(
+            "claude-sonnet",
+            claude_models={"sonnet": "claude-sonnet"},
+            codex_models=["gpt-5"],
+            gemini_models=["gemini-2"],
+        )
+        expected = "ucode/0.1.0 pi/0.74.0"
+        for name in ("databricks-claude", "databricks-openai", "databricks-gemini"):
+            assert overlay["providers"][name]["headers"]["User-Agent"] == expected
+
+
 class TestRenderOverlayCompatFlags:
     def test_claude_disables_eager_tool_input_streaming(self):
         # Gateway's Anthropic translator rejects per-tool

--- a/tests/test_e2e_user_agent.py
+++ b/tests/test_e2e_user_agent.py
@@ -1,0 +1,348 @@
+"""End-to-end test that the User-Agent header ucode injects actually reaches the wire.
+
+We don't talk to a real Databricks workspace here — instead we stand up a
+tiny HTTP capture server on localhost, point each agent's *_BASE_URL at it,
+launch the agent, and assert on the User-Agent the server saw.
+
+The server returns a canned error so the agent itself fails; we don't care
+about the agent's exit code, only the headers that arrived before it bailed.
+This is the cheapest way to verify "ucode wired the UA into the request"
+end-to-end without TLS, real models, or workspace credentials.
+
+Skipped per-agent when the binary isn't installed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from ucode.telemetry import agent_version, ucode_version
+
+
+def _require_binary(binary: str):
+    if not shutil.which(binary):
+        pytest.skip(f"`{binary}` is not installed")
+
+
+class _CapturedRequest:
+    """Bag of fields recorded by the capture server for one inbound request."""
+
+    def __init__(self, method: str, path: str, headers: dict[str, str]):
+        self.method = method
+        self.path = path
+        self.headers = headers
+
+
+class _CaptureServer:
+    """HTTP server that records every inbound request's method/path/headers
+    and replies 401 with a JSON error so the agent fails fast and exits."""
+
+    def __init__(self):
+        self.requests: list[_CapturedRequest] = []
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    @property
+    def port(self) -> int:
+        assert self._server is not None
+        return self._server.server_address[1]
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}"
+
+    def start(self) -> None:
+        captured = self.requests
+
+        class Handler(BaseHTTPRequestHandler):
+            def _record_and_reply(self):
+                # Drain any request body so the client doesn't block on write.
+                length = int(self.headers.get("Content-Length") or 0)
+                if length:
+                    try:
+                        self.rfile.read(length)
+                    except Exception:
+                        pass
+                captured.append(
+                    _CapturedRequest(
+                        method=self.command,
+                        path=self.path,
+                        headers=dict(self.headers.items()),
+                    )
+                )
+                body = json.dumps(
+                    {"error": {"type": "invalid_api_key", "message": "ucode test capture"}}
+                ).encode()
+                self.send_response(401)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_GET(self):  # noqa: N802
+                self._record_and_reply()
+
+            def do_POST(self):  # noqa: N802
+                self._record_and_reply()
+
+            def log_message(self, format, *args):  # noqa: A002
+                # Silence the default stderr access log.
+                pass
+
+        # Bind to an ephemeral port on localhost.
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None
+
+    def first_request_with_path_prefix(self, prefix: str) -> _CapturedRequest | None:
+        for req in self.requests:
+            if req.path.startswith(prefix):
+                return req
+        return None
+
+
+@pytest.fixture
+def capture_server():
+    server = _CaptureServer()
+    server.start()
+    yield server
+    server.stop()
+
+
+def _expected_ua(agent_name: str, binary: str) -> str:
+    return f"ucode/{ucode_version()} {agent_name}/{agent_version(binary)}"
+
+
+def _assert_ua(req: _CapturedRequest, expected: str) -> None:
+    # http.server lowercases header lookup keys; check both common spellings.
+    ua = req.headers.get("User-Agent") or req.headers.get("user-agent")
+    assert ua == expected, f"User-Agent mismatch.\n  got:      {ua!r}\n  expected: {expected!r}"
+
+
+def _run_until_first_request(
+    cmd: list[str], env: dict[str, str], timeout: int = 20
+) -> subprocess.CompletedProcess | None:
+    """Spawn the agent. We only need it to fire its first HTTP request; some
+    agents retry on 401 indefinitely. Swallow timeouts — the capture server
+    has what we need by then. Returns the CompletedProcess (or None on
+    timeout) so callers can surface stderr on failure."""
+    try:
+        return subprocess.run(
+            cmd,
+            env=env,
+            capture_output=True,
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+
+
+def _no_request_msg(server: _CaptureServer, result: subprocess.CompletedProcess | None) -> str:
+    if result is None:
+        return "Agent timed out before any request reached the capture server."
+    stderr = (result.stderr or b"").decode(errors="replace")[:600]
+    stdout = (result.stdout or b"").decode(errors="replace")[:300]
+    return (
+        f"No request reached the capture server.\n"
+        f"  paths: {[r.path for r in server.requests]}\n"
+        f"  rc:    {result.returncode}\n"
+        f"  stderr: {stderr!r}\n"
+        f"  stdout: {stdout!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-agent tests
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeUserAgent:
+    def test_user_agent_arrives_at_gateway(self, tmp_path, monkeypatch, capture_server):
+        import ucode.config_io as config_io_mod
+        from ucode.agents import claude
+
+        _require_binary("claude")
+        config_dir = tmp_path / "claude_config"
+        config_dir.mkdir()
+        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
+        monkeypatch.setattr(claude, "CLAUDE_SETTINGS_PATH", config_dir / "settings.json")
+        monkeypatch.setattr(claude, "CLAUDE_BACKUP_PATH", tmp_path / "claude.backup.json")
+
+        # Render the overlay against the capture server (treated as the workspace).
+        # render_overlay just builds the env block; we write it ourselves to
+        # avoid the apiKeyHelper / save_state plumbing.
+        overlay, _ = claude.render_overlay(capture_server.base_url, "test-model")
+        env = {
+            **os.environ,
+            "CLAUDE_CONFIG_DIR": str(config_dir),
+            "ANTHROPIC_API_KEY": "test-key-not-real",
+            **overlay["env"],
+        }
+
+        result = _run_until_first_request(claude.validate_cmd("claude"), env)
+
+        req = capture_server.first_request_with_path_prefix("/ai-gateway/anthropic")
+        assert req is not None, _no_request_msg(capture_server, result)
+        _assert_ua(req, _expected_ua("claude", "claude"))
+
+
+class TestCodexUserAgent:
+    def test_user_agent_arrives_at_gateway(self, tmp_path, monkeypatch, capture_server):
+        import ucode.config_io as config_io_mod
+        from ucode.agents import codex
+
+        _require_binary("codex")
+        config_dir = tmp_path / "codex_home" / ".codex"
+        config_dir.mkdir(parents=True)
+        config_path = config_dir / "config.toml"
+
+        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
+        monkeypatch.setattr(codex, "CODEX_CONFIG_PATH", config_path)
+        monkeypatch.setattr(codex, "CODEX_BACKUP_PATH", tmp_path / "codex.backup.toml")
+
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr("ucode.state.save_state", lambda s: None)
+            codex.write_tool_config({"workspace": capture_server.base_url})
+
+        # Point codex at the redirected config dir and let $OPENAI_API_KEY
+        # bypass the auth command.
+        env = {
+            **os.environ,
+            "CODEX_HOME": str(config_dir),
+            "OPENAI_API_KEY": "test-key-not-real",
+        }
+        result = _run_until_first_request(codex.validate_cmd("codex"), env)
+
+        req = capture_server.first_request_with_path_prefix("/ai-gateway/codex")
+        assert req is not None, _no_request_msg(capture_server, result)
+        _assert_ua(req, _expected_ua("codex", "codex"))
+
+
+class TestOpencodeUserAgent:
+    def test_user_agent_arrives_at_gateway(self, tmp_path, monkeypatch, capture_server):
+        import ucode.config_io as config_io_mod
+        from ucode.agents import opencode
+
+        _require_binary("opencode")
+        # Redirect via XDG_CONFIG_HOME so the spawned opencode reads from
+        # tmp_path instead of the developer's real ~/.config/opencode.
+        xdg = tmp_path / "xdg"
+        opencode_dir = xdg / "opencode"
+        opencode_dir.mkdir(parents=True)
+        config_path = opencode_dir / "opencode.json"
+        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
+        monkeypatch.setattr(opencode, "OPENCODE_CONFIG_PATH", config_path)
+        monkeypatch.setattr(opencode, "OPENCODE_BACKUP_PATH", tmp_path / "opencode.backup.json")
+
+        # Construct a state with localhost base URLs so render_overlay points
+        # both providers at the capture server.
+        state = {
+            "workspace": capture_server.base_url,
+            "opencode_models": {"anthropic": ["test-claude-model"]},
+            "base_urls": {
+                "opencode": {
+                    "anthropic": f"{capture_server.base_url}/ai-gateway/anthropic/v1",
+                    "gemini": f"{capture_server.base_url}/ai-gateway/gemini/v1beta",
+                },
+            },
+        }
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr("ucode.state.save_state", lambda s: None)
+            mp.setattr(
+                "ucode.agents.opencode.get_databricks_token", lambda ws, **kwargs: "test-token"
+            )
+            opencode.write_tool_config(state, "test-claude-model", token="test-token")
+
+        env = {**os.environ, "OAUTH_TOKEN": "test-token", "XDG_CONFIG_HOME": str(xdg)}
+        result = _run_until_first_request(opencode.validate_cmd("opencode"), env)
+
+        req = capture_server.first_request_with_path_prefix("/ai-gateway/anthropic")
+        assert req is not None, _no_request_msg(capture_server, result)
+        # The Vercel AI SDK appends its own suffix to UA; ucode's prefix
+        # appears at the front. Per upstream investigation, the AI SDK
+        # prepends our value then suffixes "ai-sdk/anthropic/X
+        # ai-sdk/provider-utils/X runtime/bun/X". We assert the prefix only.
+        ua = req.headers.get("User-Agent") or req.headers.get("user-agent") or ""
+        expected_prefix = _expected_ua("opencode", "opencode")
+        assert ua.startswith(expected_prefix), (
+            f"OpenCode UA missing ucode prefix.\n  got:    {ua!r}\n  prefix: {expected_prefix!r}"
+        )
+
+
+class TestGeminiUserAgent:
+    def test_user_agent_arrives_at_gateway(self, tmp_path, monkeypatch, capture_server):
+        import ucode.config_io as config_io_mod
+        from ucode.agents import gemini
+
+        _require_binary("gemini")
+        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
+        monkeypatch.setattr(gemini, "GEMINI_ENV_PATH", tmp_path / ".env")
+        monkeypatch.setattr(gemini, "GEMINI_SETTINGS_PATH", tmp_path / "settings.json")
+        monkeypatch.setattr(gemini, "GEMINI_BACKUP_PATH", tmp_path / "gemini-env.backup")
+        # Run from tmp_path so Gemini sees an untrusted folder (the trust env
+        # var built into build_runtime_env handles it).
+        monkeypatch.chdir(tmp_path)
+
+        env = gemini.build_runtime_env(capture_server.base_url, "test-model", "test-token")
+        result = _run_until_first_request(gemini.validate_cmd("gemini"), env)
+
+        req = capture_server.first_request_with_path_prefix("/ai-gateway/gemini")
+        assert req is not None, _no_request_msg(capture_server, result)
+        _assert_ua(req, _expected_ua("gemini", "gemini"))
+
+
+class TestPiUserAgent:
+    def test_user_agent_arrives_at_gateway(self, tmp_path, monkeypatch, capture_server):
+        import ucode.config_io as config_io_mod
+        from ucode.agents import pi
+
+        _require_binary("pi")
+        pi_dir = tmp_path / "pi-agent"
+        pi_dir.mkdir()
+        config_path = pi_dir / "models.json"
+
+        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
+        monkeypatch.setattr(pi, "PI_CONFIG_PATH", config_path)
+        monkeypatch.setattr(pi, "PI_BACKUP_PATH", tmp_path / "pi.backup.json")
+
+        state = {
+            "workspace": capture_server.base_url,
+            "claude_models": {"sonnet": "test-claude-model"},
+            "codex_models": [],
+            "gemini_models": [],
+            "base_urls": {
+                "pi": {
+                    "claude": f"{capture_server.base_url}/ai-gateway/anthropic",
+                    "openai": f"{capture_server.base_url}/ai-gateway/codex/v1",
+                    "gemini": f"{capture_server.base_url}/ai-gateway/gemini/v1beta",
+                },
+            },
+        }
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setattr("ucode.state.save_state", lambda s: None)
+            mp.setattr("ucode.agents.pi.get_databricks_token", lambda ws, **kwargs: "test-token")
+            pi.write_tool_config(state, "test-claude-model", token="test-token")
+
+        env = {**pi.build_runtime_env("test-token"), "PI_CODING_AGENT_DIR": str(pi_dir)}
+        result = _run_until_first_request(pi.validate_cmd("pi"), env)
+
+        req = capture_server.first_request_with_path_prefix("/ai-gateway/anthropic")
+        assert req is not None, _no_request_msg(capture_server, result)
+        _assert_ua(req, _expected_ua("pi", "pi"))

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,84 @@
+"""Tests for ucode.telemetry."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from ucode import telemetry
+
+
+class TestUcodeVersion:
+    def test_returns_string(self):
+        # Either a real version like "0.1.0" or "unknown" — both are strings.
+        assert isinstance(telemetry.ucode_version(), str)
+        assert telemetry.ucode_version() != ""
+
+
+class TestAgentVersion:
+    def setup_method(self):
+        # The helper is @cache'd; clear between tests so each gets a clean run.
+        telemetry.agent_version.cache_clear()
+
+    def test_falls_back_when_binary_missing(self):
+        assert telemetry.agent_version("definitely-not-a-real-binary-9f8a") == "unknown"
+
+    def test_falls_back_on_timeout(self):
+        with patch.object(
+            subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(cmd="x", timeout=2),
+        ):
+            assert telemetry.agent_version("anything") == "unknown"
+
+    def test_parses_claude_format(self):
+        result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="2.1.136 (Claude Code)\n", stderr=""
+        )
+        with patch.object(subprocess, "run", return_value=result):
+            assert telemetry.agent_version("claude") == "2.1.136"
+
+    def test_parses_codex_format(self):
+        result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="codex-cli 0.123.0-alpha.8\n", stderr=""
+        )
+        with patch.object(subprocess, "run", return_value=result):
+            assert telemetry.agent_version("codex") == "0.123.0-alpha.8"
+
+    def test_parses_gemini_format(self):
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout="0.40.0\n", stderr="")
+        with patch.object(subprocess, "run", return_value=result):
+            assert telemetry.agent_version("gemini") == "0.40.0"
+
+    def test_parses_opencode_format(self):
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout="0.74.0\n", stderr="")
+        with patch.object(subprocess, "run", return_value=result):
+            assert telemetry.agent_version("opencode") == "0.74.0"
+
+    def test_parses_copilot_format(self):
+        # Copilot prints a banner with the version embedded mid-line.
+        stdout = "GitHub Copilot CLI 1.0.42-0.\nRun 'copilot update' to check for updates.\n"
+        result = subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout, stderr="")
+        with patch.object(subprocess, "run", return_value=result):
+            assert telemetry.agent_version("copilot") == "1.0.42-0."
+
+    def test_parses_pi_dev_build_format(self):
+        result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="0.0.0-dev-202604280149\n", stderr=""
+        )
+        with patch.object(subprocess, "run", return_value=result):
+            assert telemetry.agent_version("pi") == "0.0.0-dev-202604280149"
+
+    def test_falls_back_to_stderr_when_stdout_empty(self):
+        result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr="my-tool 9.9.9\n"
+        )
+        with patch.object(subprocess, "run", return_value=result):
+            assert telemetry.agent_version("foo") == "9.9.9"
+
+    def test_unknown_when_no_semver_in_output(self):
+        result = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="hello world\n", stderr=""
+        )
+        with patch.object(subprocess, "run", return_value=result):
+            assert telemetry.agent_version("foo") == "unknown"


### PR DESCRIPTION
Lets the Databricks AI Gateway attribute traffic to ucode and to the specific wrapped agent + its version, by parsing standard HTTP logs.

Per-agent header injection mechanisms (each verified end-to-end with a localhost capture server in tests/test_e2e_user_agent.py):

- Claude: ANTHROPIC_CUSTOM_HEADERS env var
- Codex: [model_providers.X.http_headers] in ~/.codex/config.toml
- Gemini: GEMINI_CLI_CUSTOM_HEADERS env var (per upstream google-gemini/gemini-cli#10088)
- OpenCode: per-model `headers` in opencode.json — provider-level headers are clobbered by OpenCode's hardcoded UA injection in session/llm.ts; per-model headers merge after and win
- Pi: per-provider `headers` in ~/.pi/agent/models.json

GitHub Copilot CLI has no client-side hook today; its BYOK code path constructs the OpenAI client without populating defaultHeaders from any env var. Out of scope until upstream support exists or we add a forwarding proxy.