### PR TITLE
Disable @ai-sdk/anthropic tool streaming for Claude models

### DIFF
--- a/src/ucode/agents/opencode.py
+++ b/src/ucode/agents/opencode.py
@@ -86,6 +86,15 @@ def render_overlay(
     providers: dict = {}
     keys: list[list[str]] = [["model"]]
     if anthropic_models:
+        # @ai-sdk/anthropic injects `eager_input_streaming: true` on tool defs;
+        # the Databricks gateway's strict validator rejects it. opencode's
+        # auto-disable in transform.ts skips models whose id contains "claude",
+        # so we opt out per-model. The setting lives in per-call providerOptions,
+        # which opencode reads from `models.<m>.options`, not provider `options`.
+        anthropic_model_overlay = {
+            "headers": ua_header,
+            "options": {"toolStreaming": False},
+        }
         providers["databricks-anthropic"] = {
             "npm": "@ai-sdk/anthropic",
             "options": {
@@ -93,7 +102,7 @@ def render_overlay(
                 "apiKey": token,
                 "headers": auth_headers,
             },
-            "models": {m: {"headers": ua_header} for m in anthropic_models},
+            "models": {m: anthropic_model_overlay for m in anthropic_models},
         }
         keys.append(["provider", "databricks-anthropic"])
     if gemini_models:

--- a/tests/test_agent_opencode.py
+++ b/tests/test_agent_opencode.py
@@ -81,6 +81,16 @@ class TestRenderOverlay:
         headers = overlay["provider"]["databricks-anthropic"]["options"]["headers"]
         assert headers["Authorization"] == "Bearer tok"
 
+    def test_anthropic_tool_streaming_disabled(self):
+        # @ai-sdk/anthropic injects `eager_input_streaming: true` on tool defs,
+        # which the Databricks gateway rejects. opencode's auto-disable skips
+        # Claude models, so we opt out per-model. The setting must live in
+        # `models.<m>.options` — per-call providerOptions — not provider options.
+        models = {"anthropic": ["claude-sonnet"]}
+        overlay, _ = opencode.render_overlay("claude-sonnet", "tok", _base_urls(), models)
+        model_entry = overlay["provider"]["databricks-anthropic"]["models"]["claude-sonnet"]
+        assert model_entry["options"]["toolStreaming"] is False
+
     def test_user_agent_header_anthropic(self, monkeypatch):
         # UA must live at the per-model level — OpenCode clobbers
         # provider-level `headers["User-Agent"]` in session/llm.ts.


### PR DESCRIPTION
The Anthropic AI SDK injects `eager_input_streaming: true` on tool definitions, which the Databricks AI Gateway's strict validator rejects. opencode's built-in auto-disable in transform.ts skips models whose id includes "claude", so we opt out per-model. The setting belongs in the per-call providerOptions block (`models.<m>.options`), not the provider construction options.