### PR TITLE
Handle missing Databricks config in profile lookup

### DIFF
--- a/src/ucode/agents/opencode.py
+++ b/src/ucode/agents/opencode.py
@@ -102,7 +102,7 @@ def render_overlay(
                 "apiKey": token,
                 "headers": auth_headers,
             },
-            "models": {m: anthropic_model_overlay for m in anthropic_models},
+            "models": dict.fromkeys(anthropic_models, anthropic_model_overlay),
         }
         keys.append(["provider", "databricks-anthropic"])
     if gemini_models:

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -165,6 +165,7 @@ def get_databricks_profiles() -> list[tuple[str, str]]:
     try:
         result = run(
             ["databricks", "auth", "profiles", "--output", "json"],
+            check=False,
             capture_output=True,
             text=True,
             timeout=10,


### PR DESCRIPTION
  ## Summary
  - `get_databricks_profiles` called the shared `run()` helper without `check=False`,
    so a non-zero exit from `databricks auth profiles` raised `CalledProcessError`
    before the existing `returncode != 0` guard could return `[]`.
  - With no Databricks config file present, this crashed `ucode configure` (and
    `ucode <provider>`) instead of falling through to the manual workspace-URL
    prompt that triggers `databricks auth login`.
  - Pass `check=False` so the function returns `[]` on first-run setups and the
    normal onboarding flow proceeds.

  Fixes https://github.com/databricks/ucode/issues/54

  ## Test plan
  - [x] Reproduced original crash with `DATABRICKS_CONFIG_FILE=/tmp/nonexistent uv run ucode configure`.
  - [x] With the fix, same command renders the workspace prompt instead of crashing.
  - [x] `uv run pytest`
  - [x] `uv run ruff check .`