### PR TITLE
Diagnose agent-discovery failures and switch v2 probe to listing API

### DIFF
--- a/src/ucode/agents/__init__.py
+++ b/src/ucode/agents/__init__.py
@@ -219,12 +219,36 @@ def check_gateway_endpoint(state: dict, tool: str) -> bool:
     return False
 
 
+_TOOL_DISCOVERY_SOURCES: dict[str, tuple[str, ...]] = {
+    "claude": ("claude",),
+    "opencode": ("claude", "gemini"),
+    "codex": ("codex",),
+    "gemini": ("gemini",),
+    "copilot": ("claude", "codex"),
+    "pi": ("claude", "codex", "gemini"),
+}
+
+
+def _availability_failure_detail(tool: str, state: dict) -> str:
+    reasons = state.get("_discovery_reasons") or {}
+    if not reasons:
+        return ""
+    sources = _TOOL_DISCOVERY_SOURCES.get(tool, ())
+    parts = [f"{source} discovery: {reasons[source]}" for source in sources if reasons.get(source)]
+    if not parts:
+        return ""
+    return " (" + "; ".join(parts) + ")"
+
+
 def configure_single_tool(tool: str, state: dict) -> dict:
     """Check availability, configure, and persist state for one tool only."""
     with spinner(f"Checking {TOOL_SPECS[tool]['display']} availability..."):
         ok = check_gateway_endpoint(state, tool)
     if not ok:
-        raise RuntimeError(f"{TOOL_SPECS[tool]['display']} is not available on this workspace.")
+        detail = _availability_failure_detail(tool, state)
+        raise RuntimeError(
+            f"{TOOL_SPECS[tool]['display']} is not available on this workspace.{detail}"
+        )
     if tool == "codex":
         state = configure_tool("codex", state)
     else:

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -28,11 +28,11 @@ from ucode.agents import (
 from ucode.config_io import restore_file, set_dry_run
 from ucode.databricks import (
     build_shared_base_urls,
+    discover_claude_models,
+    discover_codex_models,
+    discover_gemini_models,
     ensure_ai_gateway_v2,
     ensure_databricks_auth,
-    fetch_ai_gateway_claude_models,
-    fetch_codex_models,
-    fetch_gemini_models,
     get_databricks_profiles,
     get_databricks_token,
     install_databricks_cli,
@@ -56,6 +56,29 @@ from ucode.ui import (
     status_badge,
 )
 from ucode.usage import usage as usage_report
+
+_DISCOVERY_CONSUMERS: dict[str, tuple[str, ...]] = {
+    "claude": ("claude", "opencode", "copilot", "pi"),
+    "codex": ("codex", "copilot", "pi"),
+    "gemini": ("gemini", "opencode", "pi"),
+}
+
+
+def _print_discovery_diagnostics(state: dict) -> None:
+    """Surface per-source reasons after a failed discovery so the user knows
+    which API call returned what — instead of the generic 'no agents' line."""
+    reasons = state.get("_discovery_reasons") or {}
+    if not reasons:
+        return
+    labels = {"claude": "Claude models", "codex": "Codex models", "gemini": "Gemini models"}
+    for source, reason in reasons.items():
+        consumers = ", ".join(_DISCOVERY_CONSUMERS.get(source, ()))
+        label = labels.get(source, source)
+        if reason:
+            print_note(f"{label} (needed for: {consumers}): {reason}")
+        else:
+            print_note(f"{label} (needed for: {consumers}): no models returned")
+    print_note("Re-run with `UCODE_DEBUG=1` to log raw discovery responses to ~/.ucode/debug.log.")
 
 
 def _prompt_for_configuration(tool: str | None = None) -> str:
@@ -81,31 +104,33 @@ def configure_shared_state(
         run_databricks_login(workspace)
     else:
         ensure_databricks_auth(workspace)
-    with spinner("Verifying AI Gateway V2..."):
+    with spinner("Verifying Unity AI Gateway..."):
         token = get_databricks_token(workspace)
         ensure_ai_gateway_v2(workspace, token)
     print_success("Unity AI Gateway detected")
 
+    want_claude = (
+        fetch_all or "claude" in tools or "opencode" in tools or "copilot" in tools or "pi" in tools
+    )
+    want_gemini = fetch_all or "gemini" in tools or "opencode" in tools or "pi" in tools
+    want_codex = fetch_all or "codex" in tools or "copilot" in tools or "pi" in tools
+
+    claude_reason: str | None = None
+    gemini_reason: str | None = None
+    codex_reason: str | None = None
     with spinner("Fetching available models..."):
-        claude_models = (
-            fetch_ai_gateway_claude_models(workspace, token)
-            if fetch_all
-            or "claude" in tools
-            or "opencode" in tools
-            or "copilot" in tools
-            or "pi" in tools
-            else {}
-        )
-        gemini_models = (
-            fetch_gemini_models(workspace, token)
-            if fetch_all or "gemini" in tools or "opencode" in tools or "pi" in tools
-            else []
-        )
-        codex_models = (
-            fetch_codex_models(workspace, token)
-            if fetch_all or "codex" in tools or "copilot" in tools or "pi" in tools
-            else []
-        )
+        if want_claude:
+            claude_models, claude_reason = discover_claude_models(workspace, token)
+        else:
+            claude_models = {}
+        if want_gemini:
+            gemini_models, gemini_reason = discover_gemini_models(workspace, token)
+        else:
+            gemini_models = []
+        if want_codex:
+            codex_models, codex_reason = discover_codex_models(workspace, token)
+        else:
+            codex_models = []
     opencode_models: dict[str, list[str]] = {}
     if claude_models:
         opencode_models["anthropic"] = list(claude_models.values())
@@ -116,15 +141,22 @@ def configure_shared_state(
     state = load_state()
     state["workspace"] = workspace
     state["base_urls"] = build_shared_base_urls(workspace)
-    if fetch_all or "claude" in tools or "opencode" in tools or "copilot" in tools or "pi" in tools:
+    if want_claude:
         state["claude_models"] = claude_models
-    if fetch_all or "gemini" in tools or "opencode" in tools or "pi" in tools:
+    if want_gemini:
         state["gemini_models"] = gemini_models
-    if fetch_all or "codex" in tools or "copilot" in tools or "pi" in tools:
+    if want_codex:
         state["codex_models"] = codex_models
     if fetch_all or "opencode" in tools:
         state["opencode_models"] = opencode_models
     save_state(state)
+    # Diagnostic reasons are transient — attach after save_state so they don't
+    # land on disk but are available to the caller for this run.
+    state["_discovery_reasons"] = {
+        "claude": claude_reason,
+        "gemini": gemini_reason,
+        "codex": codex_reason,
+    }
     return state
 
 
@@ -168,6 +200,7 @@ def configure_workspace_command(tool: str | None = None) -> int:
 
     if not available_on_workspace:
         print_err("No coding agents are available on this workspace.")
+        _print_discovery_diagnostics(state)
         return 1
 
     picked = prompt_for_tools([(t, TOOL_SPECS[t]["display"]) for t in available_on_workspace])

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import logging
+import logging.handlers
 import os
 import platform
 import re
@@ -15,7 +16,9 @@ from urllib import error as urllib_error
 from urllib import request as urllib_request
 from urllib.parse import urlparse
 
+from ucode.config_io import APP_DIR
 from ucode.ui import (
+    err_console,
     normalize_workspace_url,
     print_kv,
     print_note,
@@ -34,6 +37,90 @@ WINDOWS_DATABRICKS_INSTALL_URL = (
 AI_GATEWAY_V2_DOCS_URL = "https://docs.databricks.com/aws/en/ai-gateway/overview-beta"
 MIN_DATABRICKS_CLI_VERSION = (0, 298, 0)
 TOKEN_REFRESH_INTERVAL_SECONDS = 1800
+
+
+def _debug_enabled() -> bool:
+    return os.environ.get("UCODE_DEBUG") == "1"
+
+
+_DEBUG_LOGGER: logging.Logger | None = None
+
+
+def _get_debug_logger() -> logging.Logger | None:
+    """Lazily configure a rotating file logger when UCODE_DEBUG=1.
+
+    Returns the logger on first call (and caches it), or None if debug is
+    disabled or the log file could not be opened. A one-time breadcrumb is
+    printed to stderr so the user knows where to tail."""
+    global _DEBUG_LOGGER
+    if _DEBUG_LOGGER is not None or not _debug_enabled():
+        return _DEBUG_LOGGER
+
+    log_path = APP_DIR / "debug.log"
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        handler = logging.handlers.RotatingFileHandler(
+            log_path,
+            maxBytes=1_000_000,
+            backupCount=3,
+            encoding="utf-8",
+        )
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(message)s", datefmt="%Y-%m-%dT%H:%M:%S")
+        )
+    except OSError:
+        return None
+
+    logger = logging.getLogger("ucode.debug")
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    logger.propagate = False
+    _DEBUG_LOGGER = logger
+    err_console.print(f"[dim]\\[ucode debug] logging to {log_path}[/dim]")
+    return _DEBUG_LOGGER
+
+
+def _debug(label: str, detail: str) -> None:
+    """When UCODE_DEBUG=1, append a timestamped entry to ~/.ucode/debug.log."""
+    logger = _get_debug_logger()
+    if logger is not None:
+        logger.debug("%s: %s", label, detail)
+
+
+def _http_get_json(
+    url: str, token: str, *, timeout: int = 10
+) -> tuple[dict | list | None, str | None]:
+    """GET a JSON endpoint. Returns (payload, None) on success, (None, reason) on failure.
+
+    Honors UCODE_DEBUG=1 to append status + truncated body to ~/.ucode/debug.log.
+    """
+    request = urllib_request.Request(
+        url,
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    try:
+        with urllib_request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+        _debug(f"GET {url}", f"HTTP 200, {len(body)} bytes")
+        if _debug_enabled():
+            _debug("body", body[:4000])
+        try:
+            return json.loads(body), None
+        except json.JSONDecodeError as exc:
+            return None, f"response was not valid JSON ({exc.msg})"
+    except urllib_error.HTTPError as exc:
+        body = ""
+        try:
+            body = exc.read().decode("utf-8", errors="replace") if exc.fp else ""
+        except Exception:
+            body = ""
+        _debug(f"GET {url}", f"HTTP {exc.code} {exc.reason}")
+        if _debug_enabled() and body:
+            _debug("body", body[:4000])
+        return None, f"HTTP {exc.code} {exc.reason}"
+    except urllib_error.URLError as exc:
+        _debug(f"GET {url}", f"URLError: {exc.reason}")
+        return None, f"network error: {exc.reason}"
 
 
 def run(
@@ -446,19 +533,20 @@ def build_auth_shell_command(workspace: str) -> str:
     )
 
 
-def fetch_ai_gateway_claude_models(workspace: str, token: str) -> dict[str, str]:
-    hostname = workspace_hostname(workspace)
-    request = urllib_request.Request(
-        f"https://{hostname}/ai-gateway/anthropic/v1/models",
-        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
-    )
-    try:
-        with urllib_request.urlopen(request, timeout=10) as response:
-            data = json.loads(response.read().decode("utf-8"))
-    except (urllib_error.URLError, urllib_error.HTTPError, json.JSONDecodeError):
-        return {}
+def discover_claude_models(workspace: str, token: str) -> tuple[dict[str, str], str | None]:
+    """Discover Claude families on this workspace's AI Gateway.
 
-    models = [
+    Returns (models_by_family, reason). reason is None on success; otherwise it
+    describes why the dict is empty (HTTP error, network error, or no models
+    matching the expected naming convention).
+    """
+    hostname = workspace_hostname(workspace)
+    payload, reason = _http_get_json(f"https://{hostname}/ai-gateway/anthropic/v1/models", token)
+    if payload is None:
+        return {}, reason
+
+    data = cast(dict, payload) if isinstance(payload, dict) else {}
+    raw_ids = [
         m["id"]
         for m in data.get("data", [])
         if isinstance(m.get("id"), str) and not m["id"].endswith("-anthropic")
@@ -467,71 +555,114 @@ def fetch_ai_gateway_claude_models(workspace: str, token: str) -> dict[str, str]
     result: dict[str, str] = {}
     for family, key in [("opus", "opus"), ("sonnet", "sonnet"), ("haiku", "haiku")]:
         candidates = sorted(
-            [m for m in models if f"databricks-claude-{family}-" in m],
+            [m for m in raw_ids if f"databricks-claude-{family}-" in m],
             reverse=True,
         )
         if candidates:
             result[key] = candidates[0]
-    return result
-
-
-def _fetch_endpoints_with_api_type(workspace: str, token: str, api_type: str) -> list[str]:
-    """Generic helper: list endpoint names whose served_entities expose api_type."""
-    hostname = workspace_hostname(workspace)
-    request = urllib_request.Request(
-        f"https://{hostname}/api/2.0/serving-endpoints:foundation-models",
-        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    if result:
+        return result, None
+    if not raw_ids:
+        return {}, "AI Gateway returned no Claude model ids"
+    sample = ", ".join(raw_ids[:5])
+    return {}, (
+        "AI Gateway returned model ids but none matched "
+        f"`databricks-claude-{{opus,sonnet,haiku}}-*` (got: {sample})"
     )
-    try:
-        with urllib_request.urlopen(request, timeout=10) as response:
-            data = json.loads(response.read().decode("utf-8"))
-    except (urllib_error.URLError, urllib_error.HTTPError, json.JSONDecodeError):
-        return []
 
+
+def fetch_ai_gateway_claude_models(workspace: str, token: str) -> dict[str, str]:
+    """Backwards-compatible wrapper that discards the diagnostic reason."""
+    models, _ = discover_claude_models(workspace, token)
+    return models
+
+
+def discover_endpoints_with_api_type(
+    workspace: str, token: str, api_type: str
+) -> tuple[list[str], str | None]:
+    """List endpoint names whose served_entities expose api_type with v2 support.
+
+    Returns (endpoints, reason). reason is None on success; otherwise it
+    describes why the list is empty.
+    """
+    hostname = workspace_hostname(workspace)
+    payload, reason = _http_get_json(
+        f"https://{hostname}/api/2.0/serving-endpoints:foundation-models", token
+    )
+    if payload is None:
+        return [], reason
+
+    data = cast(dict, payload) if isinstance(payload, dict) else {}
+    endpoints = data.get("endpoints", [])
     out: list[str] = []
-    for ep in data.get("endpoints", []):
+    saw_endpoint_without_v2 = False
+    for ep in endpoints:
         name = ep.get("name", "")
         entities = ep.get("config", {}).get("served_entities", [])
         api_types: set[str] = set()
+        any_v2 = False
         for se in entities:
             fm = se.get("foundation_model", {})
             if fm.get("ai_gateway_v2_supported") is True:
+                any_v2 = True
                 api_types.update(fm.get("api_types", []))
+        if not any_v2 and entities:
+            saw_endpoint_without_v2 = True
         if api_type in api_types:
             out.append(name)
-    return sorted(out)
+    if out:
+        return sorted(out), None
+    if not endpoints:
+        return [], "foundation-models listing returned no endpoints"
+    if saw_endpoint_without_v2:
+        return [], (
+            f"no endpoint exposes api_type `{api_type}` with "
+            "`ai_gateway_v2_supported=true` (workspace has v1-only endpoints)"
+        )
+    return [], f"no endpoint exposes api_type `{api_type}`"
+
+
+def _fetch_endpoints_with_api_type(workspace: str, token: str, api_type: str) -> list[str]:
+    """Backwards-compatible wrapper that discards the diagnostic reason."""
+    endpoints, _ = discover_endpoints_with_api_type(workspace, token, api_type)
+    return endpoints
+
+
+def discover_gemini_models(workspace: str, token: str) -> tuple[list[str], str | None]:
+    return discover_endpoints_with_api_type(workspace, token, "gemini/v1/generateContent")
+
+
+def discover_codex_models(workspace: str, token: str) -> tuple[list[str], str | None]:
+    return discover_endpoints_with_api_type(workspace, token, "openai/v1/responses")
 
 
 def fetch_gemini_models(workspace: str, token: str) -> list[str]:
-    return _fetch_endpoints_with_api_type(workspace, token, "gemini/v1/generateContent")
+    models, _ = discover_gemini_models(workspace, token)
+    return models
 
 
 def fetch_codex_models(workspace: str, token: str) -> list[str]:
-    return _fetch_endpoints_with_api_type(workspace, token, "openai/v1/responses")
+    models, _ = discover_codex_models(workspace, token)
+    return models
 
 
 def ensure_ai_gateway_v2(workspace: str, token: str) -> None:
     """Probe AI Gateway v2 and raise if unavailable.
 
-    Replaces the prior detect/fall-back pattern: v2 is now mandatory.
+    Uses the dedicated v2 listing endpoint `GET /api/ai-gateway/v2/endpoints`:
+    a 200 response (even with an empty list) means v2 is wired up on this
+    workspace — a "no endpoints provisioned" case will surface naturally in
+    downstream discovery. 404 / 401 / 403 / network failures all raise a
+    clear error with the docs link instead of silently progressing.
     """
     hostname = workspace_hostname(workspace)
-    request = urllib_request.Request(
-        f"https://{hostname}/ai-gateway/anthropic/v1/messages",
-        method="HEAD",
-        headers={"Authorization": f"Bearer {token}"},
-    )
-    try:
-        urllib_request.urlopen(request, timeout=10)
+    url = f"https://{hostname}/api/ai-gateway/v2/endpoints?page_size=1"
+    payload, reason = _http_get_json(url, token)
+    if payload is not None:
         return
-    except urllib_error.HTTPError as exc:
-        if exc.code != 404:
-            return
-    except urllib_error.URLError:
-        pass
     raise RuntimeError(
-        "Databricks AI Gateway V2 is required but not available on this workspace. "
-        f"See {AI_GATEWAY_V2_DOCS_URL}"
+        "Databricks AI Gateway V2 is required but not available on this workspace "
+        f"({reason}). See {AI_GATEWAY_V2_DOCS_URL}"
     )
 
 

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -332,7 +332,22 @@ class TestListDatabricksApps:
 
 
 class TestEnsureAiGatewayV2:
-    """Test ensure_ai_gateway_v2 without real network calls."""
+    """Test ensure_ai_gateway_v2 without real network calls.
+
+    The probe is `GET /api/ai-gateway/v2/endpoints`: a successful JSON
+    response means v2 is wired up (even if `endpoints` is empty), while
+    404/401/403/network errors all raise a RuntimeError with the docs URL.
+    """
+
+    @staticmethod
+    def _mock_json_response(body: str):
+        from unittest.mock import MagicMock
+
+        mock_resp = MagicMock()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_resp.read.return_value = body.encode("utf-8")
+        return mock_resp
 
     def test_raises_on_404(self):
         from unittest.mock import MagicMock, patch
@@ -343,6 +358,17 @@ class TestEnsureAiGatewayV2:
             from ucode.databricks import ensure_ai_gateway_v2
 
             with pytest.raises(RuntimeError, match=AI_GATEWAY_V2_DOCS_URL):
+                ensure_ai_gateway_v2(WS, "fake-token")
+
+    def test_raises_on_401(self):
+        from unittest.mock import MagicMock, patch
+        from urllib.error import HTTPError
+
+        exc = HTTPError(url="", code=401, msg="Unauthorized", hdrs=MagicMock(), fp=None)
+        with patch("ucode.databricks.urllib_request.urlopen", side_effect=exc):
+            from ucode.databricks import ensure_ai_gateway_v2
+
+            with pytest.raises(RuntimeError, match="401"):
                 ensure_ai_gateway_v2(WS, "fake-token")
 
     def test_raises_on_url_error(self):
@@ -358,24 +384,26 @@ class TestEnsureAiGatewayV2:
             with pytest.raises(RuntimeError, match=AI_GATEWAY_V2_DOCS_URL):
                 ensure_ai_gateway_v2(WS, "fake-token")
 
-    def test_succeeds_on_non_404_http_error(self):
-        from unittest.mock import MagicMock, patch
-        from urllib.error import HTTPError
+    def test_succeeds_with_endpoints_list(self):
+        from unittest.mock import patch
 
-        # 405 Method Not Allowed → still means v2 is there (method mismatch, not missing route)
-        exc = HTTPError(url="", code=405, msg="Method Not Allowed", hdrs=MagicMock(), fp=None)
-        with patch("ucode.databricks.urllib_request.urlopen", side_effect=exc):
+        with patch(
+            "ucode.databricks.urllib_request.urlopen",
+            return_value=self._mock_json_response('{"endpoints": [{"name": "foo"}]}'),
+        ):
             from ucode.databricks import ensure_ai_gateway_v2
 
             ensure_ai_gateway_v2(WS, "fake-token")  # should not raise
 
-    def test_succeeds_when_urlopen_returns(self):
-        from unittest.mock import MagicMock, patch
+    def test_succeeds_with_empty_endpoints_list(self):
+        from unittest.mock import patch
 
-        mock_resp = MagicMock()
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
-        with patch("ucode.databricks.urllib_request.urlopen", return_value=mock_resp):
+        # A 200 with no endpoints still means v2 is wired up on this workspace —
+        # downstream discovery will surface "no models" with a clearer reason.
+        with patch(
+            "ucode.databricks.urllib_request.urlopen",
+            return_value=self._mock_json_response('{"endpoints": []}'),
+        ):
             from ucode.databricks import ensure_ai_gateway_v2
 
             ensure_ai_gateway_v2(WS, "fake-token")  # should not raise


### PR DESCRIPTION
## Summary
  - The previous `ucode configure` path printed `Unity AI Gateway detected`
    and then `No coding agents are available on this workspace.` with no
    way to tell which API call returned empty or why — as reported in #53.
  - `ensure_ai_gateway_v2` was a HEAD on `/ai-gateway/anthropic/v1/messages`
    (a POST-only endpoint) and accepted any non-404 response as success, so
    401/403/5xx all silently progressed to discovery. Replaced with a GET
    on `/api/ai-gateway/v2/endpoints` — a JSON listing endpoint where 200
    unambiguously means v2 is wired up, and 401/403/404/network errors all
    raise with the docs link.
  - Discovery functions now return `(data, reason)`. When no agents are
    detected, each source's failure reason is surfaced (`HTTP 403`,
    `no endpoint exposes api_type 'openai/v1/responses'`, `got: foo, bar`
    for Claude name-mismatches) so the user can see exactly which call
    failed.
  - `UCODE_DEBUG=1` enables a rotating file logger at `~/.ucode/debug.log`
    (1 MB × 3 backups, `logging.handlers.RotatingFileHandler`). Each
    discovery GET, HTTP status, and truncated body lands there; a one-line
    stderr breadcrumb on first use points to the file.
  - Targeted `configure --agent <tool>` failures now include the relevant
    discovery reasons in the `RuntimeError` message.

  ## Test plan
  - [x] `uv run pytest` (510 passed)
  - [x] `uv run ruff check .` / `ruff format --check`
  - [x] `UCODE_TEST_WORKSPACE=https://eng-ml-inference-team-us-east-1.cloud.databricks.com/ uv run pytest tests/test_e2e.py -v` (25 passed)
  - [x] Manually verified `ucode configure` against the same workspace — v2 probe succeeds, model discovery populates Claude/Codex/Gemini.