### PR TITLE
Pass --profile to databricks CLI listing commands (fixes MCP discovery with CLI v1.0.0)

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -380,6 +380,7 @@ def _extract_connection_page(payload: object) -> tuple[list[dict], str | None]:
 
 def list_databricks_connections(workspace: str) -> list[dict]:
     env = build_databricks_cli_env(workspace)
+    profile_name = find_profile_name_for_host(workspace)
     connections: list[dict] = []
     page_token: str | None = None
     seen_page_tokens: set[str] = set()
@@ -395,6 +396,8 @@ def list_databricks_connections(workspace: str) -> list[dict]:
                 "--output",
                 "json",
             ]
+            if profile_name:
+                cmd.extend(["--profile", profile_name])
             if page_token:
                 cmd.extend(["--page-token", page_token])
 
@@ -442,6 +445,7 @@ def _extract_genie_spaces_page(payload: object) -> tuple[list[dict], str | None]
 
 def list_genie_spaces(workspace: str) -> list[dict]:
     env = build_databricks_cli_env(workspace)
+    profile_name = find_profile_name_for_host(workspace)
     spaces: list[dict] = []
     page_token: str | None = None
     seen_page_tokens: set[str] = set()
@@ -457,6 +461,8 @@ def list_genie_spaces(workspace: str) -> list[dict]:
                 "--output",
                 "json",
             ]
+            if profile_name:
+                cmd.extend(["--profile", profile_name])
             if page_token:
                 cmd.extend(["--page-token", page_token])
 
@@ -501,17 +507,21 @@ def _extract_apps_payload(payload: object) -> list[dict]:
 
 def list_databricks_apps(workspace: str) -> list[dict]:
     env = build_databricks_cli_env(workspace)
+    profile_name = find_profile_name_for_host(workspace)
+    cmd = [
+        "databricks",
+        "apps",
+        "list",
+        "--limit",
+        "1000",
+        "--output",
+        "json",
+    ]
+    if profile_name:
+        cmd.extend(["--profile", profile_name])
     try:
         result = run(
-            [
-                "databricks",
-                "apps",
-                "list",
-                "--limit",
-                "1000",
-                "--output",
-                "json",
-            ],
+            cmd,
             capture_output=True,
             text=True,
             env=env,

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -206,6 +206,7 @@ class TestListDatabricksConnections:
             return subprocess.CompletedProcess(args, 0, stdout=json.dumps(payload))
 
         monkeypatch.setattr(db_mod, "run", fake_run)
+        monkeypatch.setattr(db_mod, "find_profile_name_for_host", lambda ws: "test-profile")
 
         assert list_databricks_connections(WS) == [
             {"name": "confluence-mcp", "connection_type": "HTTP"},
@@ -219,6 +220,8 @@ class TestListDatabricksConnections:
             "0",
             "--output",
             "json",
+            "--profile",
+            "test-profile",
         ]
         assert calls[0]["kwargs"]["env"]["DATABRICKS_HOST"] == WS
         assert calls[1]["args"][-2:] == ["--page-token", "next-page"]
@@ -228,6 +231,7 @@ class TestListDatabricksConnections:
             return subprocess.CompletedProcess(args, 0, stdout="not-json")
 
         monkeypatch.setattr(db_mod, "run", fake_run)
+        monkeypatch.setattr(db_mod, "find_profile_name_for_host", lambda ws: None)
 
         with pytest.raises(RuntimeError, match="invalid JSON"):
             list_databricks_connections(WS)
@@ -249,6 +253,7 @@ class TestListGenieSpaces:
             return subprocess.CompletedProcess(args, 0, stdout=json.dumps(payload))
 
         monkeypatch.setattr(db_mod, "run", fake_run)
+        monkeypatch.setattr(db_mod, "find_profile_name_for_host", lambda ws: "test-profile")
 
         assert list_genie_spaces(WS) == [
             {"space_id": "space-1", "title": "First"},
@@ -262,6 +267,8 @@ class TestListGenieSpaces:
             "100",
             "--output",
             "json",
+            "--profile",
+            "test-profile",
         ]
         assert calls[0]["kwargs"]["env"]["DATABRICKS_HOST"] == WS
         assert calls[1]["args"][-2:] == ["--page-token", "next-page"]
@@ -271,6 +278,7 @@ class TestListGenieSpaces:
             return subprocess.CompletedProcess(args, 0, stdout="not-json")
 
         monkeypatch.setattr(db_mod, "run", fake_run)
+        monkeypatch.setattr(db_mod, "find_profile_name_for_host", lambda ws: None)
 
         with pytest.raises(RuntimeError, match="invalid JSON"):
             list_genie_spaces(WS)
@@ -291,6 +299,7 @@ class TestListDatabricksApps:
             return subprocess.CompletedProcess(args, 0, stdout=json.dumps(payload))
 
         monkeypatch.setattr(db_mod, "run", fake_run)
+        monkeypatch.setattr(db_mod, "find_profile_name_for_host", lambda ws: "test-profile")
 
         assert list_databricks_apps(WS) == [
             {
@@ -306,6 +315,8 @@ class TestListDatabricksApps:
             "1000",
             "--output",
             "json",
+            "--profile",
+            "test-profile",
         ]
         assert calls[0]["kwargs"]["env"]["DATABRICKS_HOST"] == WS
 


### PR DESCRIPTION
## Problem

`ucode configure mcp` silently skips external connections, Genie spaces, and Databricks apps with \"Skipped\" warnings, leaving the MCP picker empty or showing only \"Databricks SQL\". This is the root cause of the discovery side of #58.

Root cause: Databricks CLI v1.0.0 ([release notes](https://github.com/databricks/cli/releases/tag/v1.0.0)) changed OAuth token storage from `~/.databricks/token-cache.json` to the OS-native keychain (Keychain on macOS, Credential Manager on Windows). Previously, passing `DATABRICKS_HOST` as an env var was sufficient for the CLI to look up the cached token by host URL. With v1.0.0, tokens are keyed by profile name in the keychain — `DATABRICKS_HOST` alone returns:

```
Error: default auth: cannot configure default credentials
```

`get_databricks_token` and `ensure_databricks_auth` already handled this correctly by calling `find_profile_name_for_host` and passing `--profile`. The three listing functions used for MCP discovery missed the same pattern.

## Fix

`list_databricks_connections`, `list_genie_spaces`, and `list_databricks_apps` now call `find_profile_name_for_host` and append `--profile <name>` when a match is found, matching the pattern already used by `get_databricks_token` and `ensure_databricks_auth`.

Detecting the error and warning was considered but rejected — it requires fragile string-matching on CLI error output that can change between versions. Always passing `--profile` is simpler and correct across all CLI versions.

## Related

- Fixes discovery prerequisite of #58 (Databricks App MCP servers fail silently — apps were never reaching the picker due to this auth failure)

## Test plan

- [ ] `uv run pytest` — all 566 tests pass
- [ ] Manual: `ucode configure mcp` on a workspace with CLI v1.0.0 installed now discovers external connections, Genie spaces, and Databricks apps
- [ ] Manual: verified against external connections in a Databricks workspace - MCP server now shows in `~/.config/goose/config.yaml`