### PR TITLE
Instrument databricks auth for UCODE_DEBUG diagnostics

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -3,6 +3,7 @@ discovery, AI Gateway v2 enforcement, SQL warehouse discovery, URL builders."""
 
 from __future__ import annotations
 
+import functools
 import json
 import logging
 import logging.handlers
@@ -11,6 +12,7 @@ import platform
 import re
 import shutil
 import subprocess
+from pathlib import Path
 from typing import cast
 from urllib import error as urllib_error
 from urllib import request as urllib_request
@@ -85,6 +87,105 @@ def _debug(label: str, detail: str) -> None:
     logger = _get_debug_logger()
     if logger is not None:
         logger.debug("%s: %s", label, detail)
+
+
+_SECRET_KEY_PATTERN = re.compile(
+    r"(token|secret|password|bearer|api_key|apikey)", re.IGNORECASE
+)
+
+
+def _format_subprocess_result(
+    result: subprocess.CompletedProcess[str],
+) -> str:
+    """Format a CompletedProcess for the debug log without leaking tokens.
+
+    On success, stdout is suppressed (it often contains the access token).
+    On failure, stdout/stderr are included truncated."""
+    stderr = (result.stderr or "").strip()[:500]
+    if result.returncode == 0:
+        return f"rc=0 stderr={stderr!r}"
+    stdout = (result.stdout or "").strip()[:500]
+    return f"rc={result.returncode} stdout={stdout!r} stderr={stderr!r}"
+
+
+def _scrub_databrickscfg(text: str) -> str:
+    """Redact value of any INI key that looks secret-bearing."""
+    out: list[str] = []
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if "=" in stripped and not stripped.startswith(("#", ";")):
+            key = stripped.split("=", 1)[0].strip()
+            if _SECRET_KEY_PATTERN.search(key):
+                indent = line[: len(line) - len(stripped)]
+                out.append(f"{indent}{key} = <redacted>")
+                continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def _scrub_json(value: object) -> object:
+    if isinstance(value, dict):
+        return {
+            k: ("<redacted>" if _SECRET_KEY_PATTERN.search(k) else _scrub_json(v))
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_scrub_json(v) for v in value]
+    return value
+
+
+@functools.cache
+def _log_auth_diagnostics() -> None:
+    """Dump CLI version, profiles, and ~/.databrickscfg (scrubbed) to the debug log.
+
+    No-op unless UCODE_DEBUG=1; cached so it runs at most once per process."""
+    if not _debug_enabled():
+        return
+
+    try:
+        version_result = subprocess.run(
+            ["databricks", "--version"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        version = (version_result.stdout or version_result.stderr or "").strip()
+        _debug("databricks --version", version[:200])
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        _debug("databricks --version", f"exception: {type(exc).__name__}: {exc}")
+
+    try:
+        profiles_result = subprocess.run(
+            ["databricks", "auth", "profiles", "--output", "json"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        _debug(
+            "databricks auth profiles",
+            f"rc={profiles_result.returncode} "
+            f"stderr={(profiles_result.stderr or '').strip()[:300]!r}",
+        )
+        if profiles_result.returncode == 0 and profiles_result.stdout:
+            try:
+                payload = json.loads(profiles_result.stdout)
+                _debug("profiles json", json.dumps(_scrub_json(payload))[:2000])
+            except json.JSONDecodeError as exc:
+                _debug("profiles json", f"decode error: {exc}")
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        _debug("databricks auth profiles", f"exception: {type(exc).__name__}: {exc}")
+
+    cfg_path = Path(os.environ.get("DATABRICKS_CONFIG_FILE") or "~/.databrickscfg").expanduser()
+    try:
+        if cfg_path.is_file():
+            raw = cfg_path.read_text(encoding="utf-8", errors="replace")
+            _debug(f"databrickscfg ({cfg_path})", _scrub_databrickscfg(raw)[:4000])
+        else:
+            _debug(f"databrickscfg ({cfg_path})", "not present")
+    except OSError as exc:
+        _debug(f"databrickscfg ({cfg_path})", f"read error: {exc}")
 
 
 def _http_get_json(
@@ -229,6 +330,7 @@ def install_databricks_cli() -> None:
 
 
 def has_valid_databricks_auth(workspace: str) -> bool:
+    _log_auth_diagnostics()
     try:
         env = build_databricks_cli_env(workspace)
         result = run(
@@ -239,11 +341,16 @@ def has_valid_databricks_auth(workspace: str) -> bool:
             env=env,
             timeout=15,
         )
+        _debug(
+            "has_valid_databricks_auth",
+            _format_subprocess_result(result),
+        )
         if result.returncode != 0:
             return False
         data = json.loads(result.stdout or "{}")
         return bool(data.get("access_token"))
-    except (json.JSONDecodeError, OSError, subprocess.TimeoutExpired):
+    except (json.JSONDecodeError, OSError, subprocess.TimeoutExpired) as exc:
+        _debug("has_valid_databricks_auth", f"exception: {type(exc).__name__}: {exc}")
         return False
 
 
@@ -311,37 +418,37 @@ def ensure_databricks_auth(workspace: str) -> None:
 
 
 def get_databricks_token(workspace: str, *, force_refresh: bool = False) -> str:
+    _log_auth_diagnostics()
     env = build_databricks_cli_env(workspace)
     cmd = ["databricks", "auth", "token", "--host", workspace, "--output", "json"]
     if force_refresh:
         cmd.append("--force-refresh")
 
-    def _fetch() -> str:
-        try:
-            result = run(
-                cmd,
-                capture_output=True,
-                text=True,
-                env=env,
-                timeout=15,
+    _debug(
+        "get_databricks_token.env",
+        "set="
+        + ",".join(
+            sorted(
+                k for k in env if k.startswith("DATABRICKS_") or k in {"BUNDLE_PROFILE"}
             )
-            return json.loads(result.stdout or "{}").get("access_token", "")
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, json.JSONDecodeError):
-            return ""
+        ),
+    )
 
-    token = _fetch()
-    if not token:
-        # Session may have expired — attempt non-interactive re-auth and retry once.
-        try:
-            run(
-                ["databricks", "auth", "login", "--host", workspace, "--no-browser"],
-                capture_output=True,
-                env=env,
-                timeout=30,
-            )
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
-            pass
-        token = _fetch()
+    token = ""
+    try:
+        result = run(
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=15,
+        )
+        _debug("auth token", _format_subprocess_result(result))
+        if result.returncode == 0:
+            token = json.loads(result.stdout or "{}").get("access_token", "")
+    except (subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+        _debug("auth token", f"exception: {type(exc).__name__}: {exc}")
 
     if not token:
         profile_name = find_profile_name_for_host(workspace)

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -434,21 +434,39 @@ def get_databricks_token(workspace: str, *, force_refresh: bool = False) -> str:
         ),
     )
 
-    token = ""
-    try:
-        result = run(
-            cmd,
-            check=False,
-            capture_output=True,
-            text=True,
-            env=env,
-            timeout=15,
-        )
-        _debug("auth token", _format_subprocess_result(result))
-        if result.returncode == 0:
-            token = json.loads(result.stdout or "{}").get("access_token", "")
-    except (subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
-        _debug("auth token", f"exception: {type(exc).__name__}: {exc}")
+    def _fetch() -> str:
+        try:
+            result = run(
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=15,
+            )
+            _debug("auth token", _format_subprocess_result(result))
+            if result.returncode == 0:
+                return json.loads(result.stdout or "{}").get("access_token", "")
+        except (subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+            _debug("auth token", f"exception: {type(exc).__name__}: {exc}")
+        return ""
+
+    token = _fetch()
+    if not token:
+        # Session may have expired — attempt non-interactive re-auth and retry once.
+        _debug("auth token", "empty on first fetch; attempting auth login --no-browser")
+        try:
+            reauth = run(
+                ["databricks", "auth", "login", "--host", workspace, "--no-browser"],
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=30,
+            )
+            _debug("auth login", _format_subprocess_result(reauth))
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            _debug("auth login", f"exception: {type(exc).__name__}: {exc}")
+        token = _fetch()
 
     if not token:
         profile_name = find_profile_name_for_host(workspace)

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -238,7 +238,27 @@ class TestGetDatabricksToken:
         token = get_databricks_token(WS)
         assert token == "good-token"
 
-    def test_raises_when_token_empty(self, tmp_path, monkeypatch):
+    def test_reauths_and_retries_when_token_empty(self, tmp_path, monkeypatch):
+        call_count = tmp_path / "calls"
+        call_count.write_text("0")
+        env = self._fake_databricks(
+            tmp_path,
+            f"count=$(cat {call_count})\n"
+            f"echo $((count + 1)) > {call_count}\n"
+            'case "$*" in\n'
+            '  *"auth login"*) exit 0 ;;\n'
+            "esac\n"
+            'if [ "$count" -eq 0 ]; then\n'
+            '  echo \'{"access_token": "", "token_type": "Bearer"}\'\n'
+            "else\n"
+            '  echo \'{"access_token": "refreshed-token", "token_type": "Bearer"}\'\n'
+            "fi",
+        )
+        monkeypatch.setattr("os.environ", env)
+        token = get_databricks_token(WS)
+        assert token == "refreshed-token"
+
+    def test_raises_when_reauth_also_fails(self, tmp_path, monkeypatch):
         env = self._fake_databricks(
             tmp_path,
             'echo \'{"access_token": "", "token_type": "Bearer"}\'',

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -11,7 +11,10 @@ import pytest
 import ucode.databricks as db_mod
 from ucode.databricks import (
     AI_GATEWAY_V2_DOCS_URL,
+    _format_subprocess_result,
     _parse_databricks_cli_version,
+    _scrub_databrickscfg,
+    _scrub_json,
     build_auth_shell_command,
     build_databricks_cli_env,
     build_opencode_base_urls,
@@ -123,6 +126,102 @@ class TestBuildAuthShellCommand:
         assert result.stdout.strip() == "good-token"
 
 
+class TestFormatSubprocessResult:
+    def test_suppresses_stdout_on_success(self):
+        result = subprocess.CompletedProcess(
+            args=["databricks", "auth", "token"],
+            returncode=0,
+            stdout='{"access_token": "dapi-secret-do-not-leak", "token_type": "Bearer"}',
+            stderr="",
+        )
+        formatted = _format_subprocess_result(result)
+        assert "dapi-secret-do-not-leak" not in formatted
+        assert "rc=0" in formatted
+
+    def test_includes_stdout_on_failure(self):
+        result = subprocess.CompletedProcess(
+            args=["databricks", "auth", "token"],
+            returncode=1,
+            stdout="useful diagnostic output",
+            stderr="error: no matching profile",
+        )
+        formatted = _format_subprocess_result(result)
+        assert "rc=1" in formatted
+        assert "useful diagnostic output" in formatted
+        assert "no matching profile" in formatted
+
+
+class TestScrubDatabrickscfg:
+    def test_redacts_token_value(self):
+        text = "[DEFAULT]\nhost = https://example.databricks.com\ntoken = dapi-secret\n"
+        scrubbed = _scrub_databrickscfg(text)
+        assert "dapi-secret" not in scrubbed
+        assert "token = <redacted>" in scrubbed
+        assert "host = https://example.databricks.com" in scrubbed
+
+    def test_redacts_various_secret_keys(self):
+        text = (
+            "[p]\n"
+            "client_secret = secret-val-1\n"
+            "bearer_token = secret-val-2\n"
+            "api_key = secret-val-3\n"
+            "password = secret-val-4\n"
+            "auth_type = oauth-u2m\n"
+        )
+        scrubbed = _scrub_databrickscfg(text)
+        for secret in ("secret-val-1", "secret-val-2", "secret-val-3", "secret-val-4"):
+            assert secret not in scrubbed
+        assert "auth_type = oauth-u2m" in scrubbed
+
+    def test_preserves_comments_and_sections(self):
+        text = "# comment\n[DEFAULT]\nhost = https://x\n; another comment with token = leak\n"
+        scrubbed = _scrub_databrickscfg(text)
+        assert "# comment" in scrubbed
+        assert "[DEFAULT]" in scrubbed
+        assert "; another comment with token = leak" in scrubbed
+
+    def test_key_matching_is_case_insensitive(self):
+        text = "[p]\nTOKEN = upper\nAccess_Token = mixed\n"
+        scrubbed = _scrub_databrickscfg(text)
+        assert "upper" not in scrubbed
+        assert "mixed" not in scrubbed
+
+
+class TestScrubJson:
+    def test_redacts_secret_keys(self):
+        payload = {
+            "access_token": "dapi-secret",
+            "host": "https://example.databricks.com",
+        }
+        scrubbed = _scrub_json(payload)
+        assert isinstance(scrubbed, dict)
+        assert scrubbed["access_token"] == "<redacted>"
+        assert scrubbed["host"] == "https://example.databricks.com"
+
+    def test_recurses_into_nested_structures(self):
+        payload = {
+            "profiles": [
+                {"name": "DEFAULT", "client_secret": "abc"},
+                {"name": "other", "password": "pw"},
+            ]
+        }
+        scrubbed = _scrub_json(payload)
+        assert scrubbed == {
+            "profiles": [
+                {"name": "DEFAULT", "client_secret": "<redacted>"},
+                {"name": "other", "password": "<redacted>"},
+            ]
+        }
+
+    def test_passes_through_scalars_and_non_secret_keys(self):
+        assert _scrub_json("plain") == "plain"
+        assert _scrub_json(42) == 42
+        assert _scrub_json({"host": "x", "auth_type": "pat"}) == {
+            "host": "x",
+            "auth_type": "pat",
+        }
+
+
 class TestGetDatabricksToken:
     def _fake_databricks(self, tmp_path, script: str) -> dict:
         fake = tmp_path / "databricks"
@@ -139,27 +238,7 @@ class TestGetDatabricksToken:
         token = get_databricks_token(WS)
         assert token == "good-token"
 
-    def test_reauths_and_retries_when_token_empty(self, tmp_path, monkeypatch):
-        call_count = tmp_path / "calls"
-        call_count.write_text("0")
-        env = self._fake_databricks(
-            tmp_path,
-            f"count=$(cat {call_count})\n"
-            f"echo $((count + 1)) > {call_count}\n"
-            'case "$*" in\n'
-            '  *"auth login"*) exit 0 ;;\n'
-            "esac\n"
-            'if [ "$count" -eq 0 ]; then\n'
-            '  echo \'{"access_token": "", "token_type": "Bearer"}\'\n'
-            "else\n"
-            '  echo \'{"access_token": "refreshed-token", "token_type": "Bearer"}\'\n'
-            "fi",
-        )
-        monkeypatch.setattr("os.environ", env)
-        token = get_databricks_token(WS)
-        assert token == "refreshed-token"
-
-    def test_raises_when_reauth_also_fails(self, tmp_path, monkeypatch):
+    def test_raises_when_token_empty(self, tmp_path, monkeypatch):
         env = self._fake_databricks(
             tmp_path,
             'echo \'{"access_token": "", "token_type": "Bearer"}\'',

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
@@ -19,7 +19,7 @@ wheels = [
 [[package]]
 name = "certifi"
 version = "2026.4.22"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
@@ -28,7 +28,7 @@ wheels = [
 [[package]]
 name = "charset-normalizer"
 version = "3.4.7"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
@@ -101,7 +101,7 @@ wheels = [
 [[package]]
 name = "click"
 version = "8.3.3"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
@@ -113,7 +113,7 @@ wheels = [
 [[package]]
 name = "colorama"
 version = "0.4.6"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
@@ -122,7 +122,7 @@ wheels = [
 [[package]]
 name = "databricks-sql-connector"
 version = "4.2.5"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "lz4" },
     { name = "oauthlib" },
@@ -143,7 +143,7 @@ wheels = [
 [[package]]
 name = "et-xmlfile"
 version = "2.0.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
@@ -152,7 +152,7 @@ wheels = [
 [[package]]
 name = "idna"
 version = "3.13"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
@@ -161,7 +161,7 @@ wheels = [
 [[package]]
 name = "iniconfig"
 version = "2.3.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
@@ -170,7 +170,7 @@ wheels = [
 [[package]]
 name = "lz4"
 version = "4.4.5"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/57/51/f1b86d93029f418033dddf9b9f79c8d2641e7454080478ee2aab5123173e/lz4-4.4.5.tar.gz", hash = "sha256:5f0b9e53c1e82e88c10d7c180069363980136b9d7a8306c4dca4f760d60c39f0", size = 172886, upload-time = "2025-11-03T13:02:36.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1b/ac/016e4f6de37d806f7cc8f13add0a46c9a7cfc41a5ddc2bc831d7954cf1ce/lz4-4.4.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:df5aa4cead2044bab83e0ebae56e0944cc7fcc1505c7787e9e1057d6d549897e", size = 207163, upload-time = "2025-11-03T13:01:45.895Z" },
@@ -210,7 +210,7 @@ wheels = [
 [[package]]
 name = "markdown-it-py"
 version = "4.0.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
@@ -222,7 +222,7 @@ wheels = [
 [[package]]
 name = "mdurl"
 version = "0.1.2"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
@@ -231,7 +231,7 @@ wheels = [
 [[package]]
 name = "numpy"
 version = "2.4.4"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
@@ -292,7 +292,7 @@ wheels = [
 [[package]]
 name = "oauthlib"
 version = "3.3.1"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
@@ -301,7 +301,7 @@ wheels = [
 [[package]]
 name = "openpyxl"
 version = "3.1.5"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "et-xmlfile" },
 ]
@@ -313,7 +313,7 @@ wheels = [
 [[package]]
 name = "packaging"
 version = "26.2"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
@@ -322,7 +322,7 @@ wheels = [
 [[package]]
 name = "pandas"
 version = "2.3.3"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
@@ -369,7 +369,7 @@ wheels = [
 [[package]]
 name = "pluggy"
 version = "1.6.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
@@ -378,7 +378,7 @@ wheels = [
 [[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
@@ -390,7 +390,7 @@ wheels = [
 [[package]]
 name = "pybreaker"
 version = "1.4.1"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f2/89/fbf98e383f1ec6d117af2cd983efdb3eb7018b63834c427025764194cac2/pybreaker-1.4.1.tar.gz", hash = "sha256:8df2d245c73ba40c8242c56ffb4f12138fbadc23e296224740c2028ea9dc1178", size = 15555, upload-time = "2025-09-21T15:12:04.499Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/75/e64d3d40a741e2be21d69154f4e5c43a66f0c603c5ef11f49e01429a5932/pybreaker-1.4.1-py3-none-any.whl", hash = "sha256:b4dab4a05195b7f2a64a6c1a6c4ba7a96534ef56ea7210e6bcb59f28897160e0", size = 12915, upload-time = "2025-09-21T15:12:02.284Z" },
@@ -399,7 +399,7 @@ wheels = [
 [[package]]
 name = "pygments"
 version = "2.20.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
@@ -408,7 +408,7 @@ wheels = [
 [[package]]
 name = "pyjwt"
 version = "2.12.1"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
@@ -417,7 +417,7 @@ wheels = [
 [[package]]
 name = "pytest"
 version = "9.0.3"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
@@ -433,7 +433,7 @@ wheels = [
 [[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "six" },
 ]
@@ -445,7 +445,7 @@ wheels = [
 [[package]]
 name = "pytz"
 version = "2026.1.post1"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
@@ -454,7 +454,7 @@ wheels = [
 [[package]]
 name = "questionary"
 version = "2.1.1"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "prompt-toolkit" },
 ]
@@ -466,7 +466,7 @@ wheels = [
 [[package]]
 name = "requests"
 version = "2.33.1"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "charset-normalizer" },
@@ -481,7 +481,7 @@ wheels = [
 [[package]]
 name = "rich"
 version = "15.0.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
@@ -494,7 +494,7 @@ wheels = [
 [[package]]
 name = "ruff"
 version = "0.15.12"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
@@ -519,7 +519,7 @@ wheels = [
 [[package]]
 name = "shellingham"
 version = "1.5.4"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
@@ -528,7 +528,7 @@ wheels = [
 [[package]]
 name = "six"
 version = "1.17.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
@@ -537,7 +537,7 @@ wheels = [
 [[package]]
 name = "thrift"
 version = "0.20.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "six" },
 ]
@@ -546,7 +546,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3c/2d/8946864f716ac82dc
 [[package]]
 name = "tomlkit"
 version = "0.14.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
@@ -555,7 +555,7 @@ wheels = [
 [[package]]
 name = "ty"
 version = "0.0.33"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/84/44/9478c50c266826c1bf30d1692e589755bffa8f1c0a3eb7af8a346c255991/ty-0.0.33.tar.gz", hash = "sha256:46d63bda07403322cb6c28ccfdd5536be916e13df725c29f7ccd0a21f06bd9e8", size = 5559373, upload-time = "2026-04-28T10:45:13.18Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/24/e287388c63a19191be26b32ff4dbd06029834068150ebe2532939bc4c851/ty-0.0.33-py3-none-linux_armv6l.whl", hash = "sha256:94d0a9d2234261a8911396d59e506b5923fe0971dbda43b9dcea287936887fcc", size = 11021308, upload-time = "2026-04-28T10:45:43.34Z" },
@@ -579,7 +579,7 @@ wheels = [
 [[package]]
 name = "typer"
 version = "0.24.2"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "click" },
@@ -594,7 +594,7 @@ wheels = [
 [[package]]
 name = "tzdata"
 version = "2026.1"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
@@ -636,7 +636,7 @@ dev = [
 [[package]]
 name = "urllib3"
 version = "2.6.3"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
@@ -645,7 +645,7 @@ wheels = [
 [[package]]
 name = "wcwidth"
 version = "0.6.0"
-source = { registry = "https://pypi-proxy.dev.databricks.com/simple" }
+source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },


### PR DESCRIPTION
Adds opt-in debug logging to diagnose cases where `databricks auth token` returns no token even though the CLI itself is authenticated. When `UCODE_DEBUG=1`, `has_valid_databricks_auth` and `get_databricks_token` now dump (once per process) the CLI version, the scrubbed profiles list, the scrubbed `~/.databrickscfg`, and the set of `DATABRICKS_*` env vars visible to the subprocess, plus the rc/stderr of each `auth token` call. A `_format_subprocess_result` helper suppresses stdout on success so the access token never lands in `~/.ucode/debug.log`.

Also removes the dead `databricks auth login --no-browser` retry block in `get_databricks_token`: with `capture_output=True` the device-code URL is never visible to the user, so the retry can never complete a fresh auth — it only obscures the original failure.