### PR TITLE
MCP fix: pass --profile to discovery CLI calls and surface resolver failures in configure mcp

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1067,9 +1067,7 @@ def _is_usage_table_access_error(exc: BaseException) -> bool:
     normalized = str(exc).lower().translate(str.maketrans("", "", """`[]"'"""))
     if "system.ai_gateway" not in normalized:
         return False
-    return (
-        "insufficient_permissions" in normalized
-    )
+    return "insufficient_permissions" in normalized
 
 
 # ---------------------------------------------------------------------------

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -622,7 +622,7 @@ def _extract_connection_page(payload: object) -> tuple[list[dict], str | None]:
     return [item for item in raw_connections if isinstance(item, dict)], next_page_token
 
 
-def list_databricks_connections(workspace: str) -> list[dict]:
+def list_databricks_connections(workspace: str, profile: str | None = None) -> list[dict]:
     env = build_databricks_cli_env(workspace)
     connections: list[dict] = []
     page_token: str | None = None
@@ -634,6 +634,7 @@ def list_databricks_connections(workspace: str) -> list[dict]:
                 "databricks",
                 "connections",
                 "list",
+                *_profile_args(profile),
                 "--max-results",
                 "0",
                 "--output",
@@ -684,7 +685,7 @@ def _extract_genie_spaces_page(payload: object) -> tuple[list[dict], str | None]
     return [item for item in raw_spaces if isinstance(item, dict)], next_page_token
 
 
-def list_genie_spaces(workspace: str) -> list[dict]:
+def list_genie_spaces(workspace: str, profile: str | None = None) -> list[dict]:
     env = build_databricks_cli_env(workspace)
     spaces: list[dict] = []
     page_token: str | None = None
@@ -696,6 +697,7 @@ def list_genie_spaces(workspace: str) -> list[dict]:
                 "databricks",
                 "genie",
                 "list-spaces",
+                *_profile_args(profile),
                 "--page-size",
                 "100",
                 "--output",
@@ -743,7 +745,7 @@ def _extract_apps_payload(payload: object) -> list[dict]:
     raise RuntimeError("Databricks apps listing returned invalid JSON.")
 
 
-def list_databricks_apps(workspace: str) -> list[dict]:
+def list_databricks_apps(workspace: str, profile: str | None = None) -> list[dict]:
     env = build_databricks_cli_env(workspace)
     try:
         result = run(
@@ -751,6 +753,7 @@ def list_databricks_apps(workspace: str) -> list[dict]:
                 "databricks",
                 "apps",
                 "list",
+                *_profile_args(profile),
                 "--limit",
                 "1000",
                 "--output",
@@ -1039,13 +1042,6 @@ def run_usage_query(
                 cursor.execute(query)
                 columns = [desc[0] for desc in (cursor.description or [])]
                 rows = cast(list[tuple], cursor.fetchall())
-    except ServerOperationError as exc:
-        if _is_usage_table_access_error(exc):
-            raise RuntimeError(
-                "Unable to read `system.ai_gateway.usage`. Ask your workspace admin "
-                "to enable READ access to `system.ai_gateway.usage` for your account."
-            ) from exc
-        raise RuntimeError(f"Usage query failed: {exc}") from exc
     except ServerOperationError as exc:
         if _is_usage_table_access_error(exc):
             raise RuntimeError(

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1046,6 +1046,13 @@ def run_usage_query(
                 "to enable READ access to `system.ai_gateway.usage` for your account."
             ) from exc
         raise RuntimeError(f"Usage query failed: {exc}") from exc
+    except ServerOperationError as exc:
+        if _is_usage_table_access_error(exc):
+            raise RuntimeError(
+                "Unable to read `system.ai_gateway.usage`. Ask your workspace admin "
+                "to enable READ access to `system.ai_gateway.usage` for your account."
+            ) from exc
+        raise RuntimeError(f"Usage query failed: {exc}") from exc
     except Exception as exc:
         raise RuntimeError(f"Usage query failed: {exc}") from exc
 
@@ -1055,12 +1062,14 @@ def run_usage_query(
 def _is_usage_table_access_error(exc: BaseException) -> bool:
     """Return True when a `ServerOperationError` blocks reads of
     `system.ai_gateway.usage` — gated on one of the bracketed error codes
-    `INSUFFICIENT_PERMISSIONS` plus a `system.ai_gateway` substring (identifier quoting
+    `INSUFFICIENT_PERMISSIONS` plus a `system.ai_gateway` substring (identifier quoting 
     stripped first)."""
     normalized = str(exc).lower().translate(str.maketrans("", "", """`[]"'"""))
     if "system.ai_gateway" not in normalized:
         return False
-    return "insufficient_permissions" in normalized
+    return (
+        "insufficient_permissions" in normalized
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1062,7 +1062,7 @@ def run_usage_query(
 def _is_usage_table_access_error(exc: BaseException) -> bool:
     """Return True when a `ServerOperationError` blocks reads of
     `system.ai_gateway.usage` — gated on one of the bracketed error codes
-    `INSUFFICIENT_PERMISSIONS` plus a `system.ai_gateway` substring (identifier quoting 
+    `INSUFFICIENT_PERMISSIONS` plus a `system.ai_gateway` substring (identifier quoting
     stripped first)."""
     normalized = str(exc).lower().translate(str.maketrans("", "", """`[]"'"""))
     if "system.ai_gateway" not in normalized:

--- a/src/ucode/mcp.py
+++ b/src/ucode/mcp.py
@@ -346,8 +346,8 @@ def external_mcp_connection_names(connections: list[dict]) -> list[str]:
     return sorted(names)
 
 
-def discover_external_mcp_connection_names(workspace: str) -> list[str]:
-    return external_mcp_connection_names(list_databricks_connections(workspace))
+def discover_external_mcp_connection_names(workspace: str, profile: str | None = None) -> list[str]:
+    return external_mcp_connection_names(list_databricks_connections(workspace, profile))
 
 
 def genie_mcp_servers(spaces: list[dict], workspace: str) -> list[dict]:
@@ -372,8 +372,8 @@ def genie_mcp_servers(spaces: list[dict], workspace: str) -> list[dict]:
     return sorted(servers, key=lambda server: str(server["title"]).lower())
 
 
-def discover_genie_mcp_servers(workspace: str) -> list[dict]:
-    return genie_mcp_servers(list_genie_spaces(workspace), workspace)
+def discover_genie_mcp_servers(workspace: str, profile: str | None = None) -> list[dict]:
+    return genie_mcp_servers(list_genie_spaces(workspace, profile), workspace)
 
 
 def app_mcp_servers(apps: list[dict]) -> list[dict]:
@@ -403,8 +403,8 @@ def app_mcp_servers(apps: list[dict]) -> list[dict]:
     return sorted(servers, key=lambda server: str(server["title"]).lower())
 
 
-def discover_app_mcp_servers(workspace: str) -> list[dict]:
-    return app_mcp_servers(list_databricks_apps(workspace))
+def discover_app_mcp_servers(workspace: str, profile: str | None = None) -> list[dict]:
+    return app_mcp_servers(list_databricks_apps(workspace, profile))
 
 
 def _picker_style() -> questionary.Style:
@@ -674,35 +674,35 @@ def _resolve_mcp_selection(
     selection: str,
     workspace: str,
     available_app_servers: list[dict] | None = None,
-) -> tuple[str, str] | None:
+) -> tuple[str, str]:
     if selection.startswith(APP_MCP_SELECTION_PREFIX):
         app_name = selection.removeprefix(APP_MCP_SELECTION_PREFIX)
         if not app_name:
-            return None
+            raise RuntimeError("missing Databricks app name")
         server = _servers_by_name(available_app_servers or []).get(f"databricks-app-{app_name}")
         if not server:
-            return None
+            raise RuntimeError(f"Databricks app `{app_name}` was not in the discovered app list")
         url = server.get("url")
         if not isinstance(url, str) or not url:
-            return None
+            raise RuntimeError(f"Databricks app `{app_name}` has no MCP URL")
         return f"databricks-app-{app_name}", url
 
     if selection.startswith(GENIE_SPACE_SELECTION_PREFIX):
         space_id = selection.removeprefix(GENIE_SPACE_SELECTION_PREFIX)
         if not space_id:
-            return None
+            raise RuntimeError("missing Genie space id")
         return f"databricks-genie-{space_id}", f"{workspace}/api/2.0/mcp/genie/{space_id}"
 
     if selection.startswith(EXTERNAL_MCP_SELECTION_PREFIX):
         server_name = selection.removeprefix(EXTERNAL_MCP_SELECTION_PREFIX)
         if not server_name:
-            return None
+            raise RuntimeError("missing external connection name")
         return server_name, f"{workspace}/api/2.0/mcp/external/{server_name}"
 
     if selection == SQL_MCP_VALUE:
         return "databricks-sql", f"{workspace}/api/2.0/mcp/sql"
 
-    return None
+    raise RuntimeError(f"unrecognized selection prefix in `{selection}`")
 
 
 def _discover_mcp_source(label: str, discover: Callable[[], list[Any]]) -> list[Any]:
@@ -766,7 +766,8 @@ def configure_mcp_command() -> int:
         client for client in MCP_CLIENTS if client in configured_tools and client not in clients
     ]
 
-    ensure_databricks_auth(workspace, state.get("profile"))
+    profile = state.get("profile")
+    ensure_databricks_auth(workspace, profile)
 
     print_section("MCP Servers")
     client_names = ", ".join(str(MCP_CLIENTS[client]["display"]) for client in clients)
@@ -779,15 +780,15 @@ def configure_mcp_command() -> int:
 
     available_external_mcp_names = _discover_mcp_source(
         "external connections",
-        lambda: discover_external_mcp_connection_names(workspace),
+        lambda: discover_external_mcp_connection_names(workspace, profile),
     )
     available_genie_mcp_servers = _discover_mcp_source(
         "Genie spaces",
-        lambda: discover_genie_mcp_servers(workspace),
+        lambda: discover_genie_mcp_servers(workspace, profile),
     )
     available_app_mcp_servers = _discover_mcp_source(
         "Databricks apps",
-        lambda: discover_app_mcp_servers(workspace),
+        lambda: discover_app_mcp_servers(workspace, profile),
     )
 
     original_mcp_servers: list[dict] = list(state.get("mcp_servers") or [])
@@ -814,14 +815,15 @@ def configure_mcp_command() -> int:
             working_names.add(selection)
 
     for selection in add_selections:
-        resolved = _resolve_mcp_selection(
-            selection,
-            workspace,
-            available_app_mcp_servers,
-        )
-        if resolved is None:
+        try:
+            entry_name, url = _resolve_mcp_selection(
+                selection,
+                workspace,
+                available_app_mcp_servers,
+            )
+        except RuntimeError as exc:
+            print_warning(f"Skipped MCP selection `{selection}`: {exc}.")
             continue
-        entry_name, url = resolved
         if entry_name in working_names:
             continue
         working_mcp_servers.append(
@@ -839,4 +841,7 @@ def configure_mcp_command() -> int:
         state["mcp_servers"] = working_mcp_servers
         save_state(state)
         print_success("Saved")
+    elif not selections and not original_mcp_servers:
+        # User submitted the picker without toggling anything --> make it clear nothing was selected
+        print_note("No MCP servers selected. Press space to toggle an item, then enter to save.")
     return 0

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -375,6 +375,20 @@ class TestListDatabricksConnections:
         assert calls[0]["kwargs"]["env"]["DATABRICKS_HOST"] == WS
         assert calls[1]["args"][-2:] == ["--page-token", "next-page"]
 
+    def test_passes_profile_when_provided(self, monkeypatch):
+        calls: list[list[str]] = []
+
+        def fake_run(args, **kwargs):
+            calls.append(args)
+            return subprocess.CompletedProcess(args, 0, stdout=json.dumps({"connections": []}))
+
+        monkeypatch.setattr(db_mod, "run", fake_run)
+
+        list_databricks_connections(WS, "my-profile")
+
+        assert "--profile" in calls[0]
+        assert calls[0][calls[0].index("--profile") + 1] == "my-profile"
+
     def test_raises_on_invalid_json(self, monkeypatch):
         def fake_run(args, **kwargs):
             return subprocess.CompletedProcess(args, 0, stdout="not-json")
@@ -418,6 +432,20 @@ class TestListGenieSpaces:
         assert calls[0]["kwargs"]["env"]["DATABRICKS_HOST"] == WS
         assert calls[1]["args"][-2:] == ["--page-token", "next-page"]
 
+    def test_passes_profile_when_provided(self, monkeypatch):
+        calls: list[list[str]] = []
+
+        def fake_run(args, **kwargs):
+            calls.append(args)
+            return subprocess.CompletedProcess(args, 0, stdout=json.dumps({"spaces": []}))
+
+        monkeypatch.setattr(db_mod, "run", fake_run)
+
+        list_genie_spaces(WS, "my-profile")
+
+        assert "--profile" in calls[0]
+        assert calls[0][calls[0].index("--profile") + 1] == "my-profile"
+
     def test_raises_on_invalid_json(self, monkeypatch):
         def fake_run(args, **kwargs):
             return subprocess.CompletedProcess(args, 0, stdout="not-json")
@@ -460,6 +488,20 @@ class TestListDatabricksApps:
             "json",
         ]
         assert calls[0]["kwargs"]["env"]["DATABRICKS_HOST"] == WS
+
+    def test_passes_profile_when_provided(self, monkeypatch):
+        calls: list[list[str]] = []
+
+        def fake_run(args, **kwargs):
+            calls.append(args)
+            return subprocess.CompletedProcess(args, 0, stdout=json.dumps([]))
+
+        monkeypatch.setattr(db_mod, "run", fake_run)
+
+        list_databricks_apps(WS, "my-profile")
+
+        assert "--profile" in calls[0]
+        assert calls[0][calls[0].index("--profile") + 1] == "my-profile"
 
     def test_accepts_object_wrapped_apps(self, monkeypatch):
         def fake_run(args, **kwargs):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -406,9 +406,11 @@ class TestConfigureMcpCommand:
         monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
         monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace, profile=None: None)
         monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
-        monkeypatch.setattr(mcp, "discover_external_mcp_connection_names", lambda workspace: [])
-        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace: [])
-        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace: [])
+        monkeypatch.setattr(
+            mcp, "discover_external_mcp_connection_names", lambda workspace, profile=None: []
+        )
+        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace, profile=None: [])
+        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace, profile=None: [])
         _patch_mcp_choices(monkeypatch, "github")
         monkeypatch.setattr(mcp, "remove_claude_mcp_server", lambda name, scope: False)
         monkeypatch.setattr(mcp, "add_claude_mcp_server", lambda name, entry, scope: None)
@@ -437,10 +439,10 @@ class TestConfigureMcpCommand:
         monkeypatch.setattr(
             mcp,
             "discover_external_mcp_connection_names",
-            lambda workspace: ["confluence-mcp", "github-mcp"],
+            lambda workspace, profile=None: ["confluence-mcp", "github-mcp"],
         )
-        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace: [])
-        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace: [])
+        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace, profile=None: [])
+        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace, profile=None: [])
         _patch_mcp_choices(monkeypatch, f"{mcp.MCP_ADD_PREFIX}external:github-mcp")
 
         def fake_configure_client_mcp_server(client, name, url, entry):
@@ -486,11 +488,13 @@ class TestConfigureMcpCommand:
         monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
         monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace, profile=None: None)
         monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
-        monkeypatch.setattr(mcp, "discover_external_mcp_connection_names", lambda workspace: [])
+        monkeypatch.setattr(
+            mcp, "discover_external_mcp_connection_names", lambda workspace, profile=None: []
+        )
         monkeypatch.setattr(
             mcp,
             "discover_genie_mcp_servers",
-            lambda workspace: [
+            lambda workspace, profile=None: [
                 {
                     "name": "databricks-genie-space-123",
                     "title": "Sales Genie",
@@ -498,7 +502,7 @@ class TestConfigureMcpCommand:
                 }
             ],
         )
-        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace: [])
+        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace, profile=None: [])
         _patch_mcp_choices(monkeypatch, f"{mcp.MCP_ADD_PREFIX}genie-space:space-123")
         monkeypatch.setattr(
             mcp,
@@ -538,12 +542,14 @@ class TestConfigureMcpCommand:
         monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
         monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace, profile=None: None)
         monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
-        monkeypatch.setattr(mcp, "discover_external_mcp_connection_names", lambda workspace: [])
-        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace: [])
+        monkeypatch.setattr(
+            mcp, "discover_external_mcp_connection_names", lambda workspace, profile=None: []
+        )
+        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace, profile=None: [])
         monkeypatch.setattr(
             mcp,
             "discover_app_mcp_servers",
-            lambda workspace: [
+            lambda workspace, profile=None: [
                 {
                     "name": "databricks-app-mcp-my-app",
                     "title": "mcp-my-app",
@@ -582,6 +588,84 @@ class TestConfigureMcpCommand:
             }
         ]
 
+    def test_hints_when_no_selections_and_no_existing_servers(self, monkeypatch, capsys):
+        saved_states: list[dict] = []
+
+        monkeypatch.setattr(mcp, "load_state", lambda: {**CLAUDE_STATE})
+        monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+        monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace, profile=None: None)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
+        monkeypatch.setattr(
+            mcp, "discover_external_mcp_connection_names", lambda workspace, profile=None: []
+        )
+        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace, profile=None: [])
+        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace, profile=None: [])
+        _patch_mcp_choices(monkeypatch)
+        monkeypatch.setattr(mcp, "save_state", lambda state: saved_states.append(state.copy()))
+
+        assert mcp.configure_mcp_command() == 0
+
+        output = capsys.readouterr().out
+        assert "No MCP servers selected" in output
+        assert "space to toggle" in output
+        assert saved_states == []
+
+    def test_warns_when_app_selection_is_no_longer_discoverable(self, monkeypatch, capsys):
+        saved_states: list[dict] = []
+        configured: list[tuple[str, str, str, dict]] = []
+
+        monkeypatch.setattr(mcp, "load_state", lambda: {**CLAUDE_STATE})
+        monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+        monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace, profile=None: None)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
+        monkeypatch.setattr(
+            mcp, "discover_external_mcp_connection_names", lambda workspace, profile=None: []
+        )
+        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace, profile=None: [])
+        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace, profile=None: [])
+        _patch_mcp_choices(monkeypatch, f"{mcp.MCP_ADD_PREFIX}app:mcp-vanished")
+        monkeypatch.setattr(
+            mcp,
+            "configure_client_mcp_server",
+            lambda client, name, url, entry: configured.append((client, name, url, entry)) or [],
+        )
+        monkeypatch.setattr(mcp, "save_state", lambda state: saved_states.append(state.copy()))
+
+        assert mcp.configure_mcp_command() == 0
+
+        output = capsys.readouterr().out
+        assert "Skipped MCP selection `app:mcp-vanished`" in output
+        assert "mcp-vanished" in output
+        assert configured == []
+
+    def test_warns_for_unrecognized_selection_prefix(self, monkeypatch, capsys):
+        saved_states: list[dict] = []
+        configured: list[tuple[str, str, str, dict]] = []
+
+        monkeypatch.setattr(mcp, "load_state", lambda: {**CLAUDE_STATE})
+        monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+        monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace, profile=None: None)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
+        monkeypatch.setattr(
+            mcp, "discover_external_mcp_connection_names", lambda workspace, profile=None: []
+        )
+        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace, profile=None: [])
+        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace, profile=None: [])
+        _patch_mcp_choices(monkeypatch, f"{mcp.MCP_ADD_PREFIX}bogus:value")
+        monkeypatch.setattr(
+            mcp,
+            "configure_client_mcp_server",
+            lambda client, name, url, entry: configured.append((client, name, url, entry)) or [],
+        )
+        monkeypatch.setattr(mcp, "save_state", lambda state: saved_states.append(state.copy()))
+
+        assert mcp.configure_mcp_command() == 0
+
+        output = capsys.readouterr().out
+        assert "Skipped MCP selection `bogus:value`" in output
+        assert "unrecognized" in output
+        assert configured == []
+
     def test_continues_when_optional_discovery_fails(self, monkeypatch, capsys):
         saved_states: list[dict] = []
         configured: list[tuple[str, str, str, dict]] = []
@@ -593,17 +677,23 @@ class TestConfigureMcpCommand:
         monkeypatch.setattr(
             mcp,
             "discover_external_mcp_connection_names",
-            lambda workspace: (_ for _ in ()).throw(RuntimeError("permission denied")),
+            lambda workspace, profile=None: (_ for _ in ()).throw(
+                RuntimeError("permission denied")
+            ),
         )
         monkeypatch.setattr(
             mcp,
             "discover_genie_mcp_servers",
-            lambda workspace: (_ for _ in ()).throw(RuntimeError("permission denied")),
+            lambda workspace, profile=None: (_ for _ in ()).throw(
+                RuntimeError("permission denied")
+            ),
         )
         monkeypatch.setattr(
             mcp,
             "discover_app_mcp_servers",
-            lambda workspace: (_ for _ in ()).throw(RuntimeError("permission denied")),
+            lambda workspace, profile=None: (_ for _ in ()).throw(
+                RuntimeError("permission denied")
+            ),
         )
         _patch_mcp_choices(monkeypatch, f"{mcp.MCP_ADD_PREFIX}managed:sql")
         monkeypatch.setattr(
@@ -622,6 +712,44 @@ class TestConfigureMcpCommand:
         assert configured[0][1] == "databricks-sql"
         assert saved_states[-1]["mcp_servers"][0]["name"] == "databricks-sql"
 
+    def test_forwards_profile_to_discovery(self, monkeypatch):
+        saved_states: list[dict] = []
+        seen_profiles: dict[str, str | None] = {}
+
+        monkeypatch.setattr(
+            mcp,
+            "load_state",
+            lambda: {**CLAUDE_STATE, "profile": "my-profile"},
+        )
+        monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+        monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace, profile=None: None)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
+
+        def fake_external(workspace, profile=None):
+            seen_profiles["external"] = profile
+            return []
+
+        def fake_genie(workspace, profile=None):
+            seen_profiles["genie"] = profile
+            return []
+
+        def fake_apps(workspace, profile=None):
+            seen_profiles["apps"] = profile
+            return []
+
+        monkeypatch.setattr(mcp, "discover_external_mcp_connection_names", fake_external)
+        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", fake_genie)
+        monkeypatch.setattr(mcp, "discover_app_mcp_servers", fake_apps)
+        _patch_mcp_choices(monkeypatch)
+        monkeypatch.setattr(mcp, "save_state", lambda state: saved_states.append(state.copy()))
+
+        assert mcp.configure_mcp_command() == 0
+        assert seen_profiles == {
+            "external": "my-profile",
+            "genie": "my-profile",
+            "apps": "my-profile",
+        }
+
     def test_configures_only_ucode_configured_clients(self, monkeypatch, capsys):
         saved_states: list[dict] = []
         configured: list[tuple[str, str, str, dict]] = []
@@ -633,9 +761,11 @@ class TestConfigureMcpCommand:
         monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
         monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace, profile=None: None)
         monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ALL_MCP_CLIENTS)
-        monkeypatch.setattr(mcp, "discover_external_mcp_connection_names", lambda workspace: [])
-        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace: [])
-        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace: [])
+        monkeypatch.setattr(
+            mcp, "discover_external_mcp_connection_names", lambda workspace, profile=None: []
+        )
+        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace, profile=None: [])
+        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace, profile=None: [])
         _patch_mcp_choices(monkeypatch, f"{mcp.MCP_ADD_PREFIX}managed:sql")
         monkeypatch.setattr(
             mcp,
@@ -665,9 +795,11 @@ class TestConfigureMcpCommand:
         monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
         monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace, profile=None: None)
         monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
-        monkeypatch.setattr(mcp, "discover_external_mcp_connection_names", lambda workspace: [])
-        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace: [])
-        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace: [])
+        monkeypatch.setattr(
+            mcp, "discover_external_mcp_connection_names", lambda workspace, profile=None: []
+        )
+        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace, profile=None: [])
+        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace, profile=None: [])
         _patch_mcp_choices(monkeypatch, f"{mcp.MCP_ADD_PREFIX}managed:sql")
         monkeypatch.setattr(
             mcp,
@@ -719,9 +851,11 @@ class TestConfigureMcpCommand:
         monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
         monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace, profile=None: None)
         monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
-        monkeypatch.setattr(mcp, "discover_external_mcp_connection_names", lambda workspace: [])
-        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace: [])
-        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace: [])
+        monkeypatch.setattr(
+            mcp, "discover_external_mcp_connection_names", lambda workspace, profile=None: []
+        )
+        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace, profile=None: [])
+        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace, profile=None: [])
         _patch_mcp_choices(monkeypatch)
         monkeypatch.setattr(
             mcp,


### PR DESCRIPTION
**Issue:**
- ucode configure mcp printed ! Skipped external connections / Genie spaces / Databricks apps on workspaces where the Databricks CLI's DATABRICKS_HOST-only auth resolver returns an Invalid Token. The auth helpers already passed --profile, but list_databricks_connections, list_genie_spaces, and list_databricks_apps did not, so _discover_mcp_source swallowed the resulting RuntimeError as ! Skipped ….
- _resolve_mcp_selection returned None for any unresolvable picker pick and the caller silently continue'd, so dropped picks were invisible.
- The picker prints done whether or not anything was toggled, so an Enter-without-space submission on fresh state looked identical to a successful save.

**Change:**
- Threaded an optional profile through list_databricks_connections, list_genie_spaces, list_databricks_apps and their discover_* wrappers, injected via the existing _profile_args() helper; configure_mcp_command reads it from state and forwards it to all three discovery calls.
- Changed _resolve_mcp_selection to raise RuntimeError with a per-cause reason (missing app name, app not in discovered list, app has no MCP URL, missing Genie space id, missing external connection name, unrecognized prefix); configure_mcp_command prints ! Skipped MCP selection \`: ` instead of dropping the pick.
- Added a ! No MCP servers selected. Press space to toggle an item, then enter to save. hint when the picker submits zero selections on fresh state.
- Added regression tests for --profile plumbing (tests/test_databricks.py, tests/test_mcp.py) and for each new warning/hint; updated existing monkeypatch stubs from lambda workspace: … to lambda workspace, profile=None: ….

**Validation:**
uv run pytest tests/test_databricks.py tests/test_mcp.py -q → 99 passed
uv run ruff check src/ucode/databricks.py src/ucode/mcp.py tests/test_databricks.py tests/test_mcp.py → passed
uv run pytest -q --ignore=tests/test_e2e.py --ignore=tests/test_e2e_user_agent.py → 552 passed
uv run ruff check . → passed
Manually verified on eng-ml-inference-team-ca-central-1: picker now shows external connections, Genie spaces, and Databricks apps (previously ! Skipped …); a toggled selection is written to ~/.ucode/state.json and shows up in claude mcp list; Enter-without-space on fresh state prints the new hint instead of a silent no-op.

fixes #58 