### PR TITLE
Fix usage model token breakdown

### DIFF
--- a/src/ucode/usage.py
+++ b/src/ucode/usage.py
@@ -5,6 +5,8 @@ Reads from `system.ai_gateway.usage` via a Databricks SQL warehouse.
 
 from __future__ import annotations
 
+import json
+from collections.abc import Mapping
 from datetime import date, datetime, timedelta
 from typing import cast
 
@@ -22,6 +24,7 @@ from ucode.ui import (
     heading,
     label,
     print_heading,
+    print_note,
     render_box_table,
     spinner,
     value,
@@ -33,6 +36,7 @@ USAGE_SUMMARY_DAYS = 30
 
 def build_usage_report_query() -> str:
     return f"""
+WITH usage_events AS (
 SELECT
   current_user() AS requester_name,
   CASE
@@ -43,11 +47,10 @@ SELECT
     ELSE 'other'
   END AS tool,
   date(event_time) AS usage_day,
-  SUM(COALESCE(total_tokens, 0)) AS total_tokens_used,
-  COUNT(DISTINCT request_id) AS sessions,
-  MIN(event_time) AS first_event_time,
-  MAX(event_time) AS last_event_time,
-  CONCAT_WS(', ', SORT_ARRAY(COLLECT_SET(destination_model))) AS models
+  request_id,
+  event_time,
+  destination_model,
+  COALESCE(total_tokens, 0) AS total_tokens_used
 FROM system.ai_gateway.usage
 WHERE event_time >= current_timestamp() - interval {USAGE_SUMMARY_DAYS} days
   AND requester = current_user()
@@ -57,8 +60,62 @@ WHERE event_time >= current_timestamp() - interval {USAGE_SUMMARY_DAYS} days
     OR lower(user_agent) LIKE '%gemini%'
     OR lower(user_agent) LIKE '%opencode%'
   )
-GROUP BY 1, 2, 3
-ORDER BY usage_day DESC, tool ASC
+),
+daily_usage AS (
+  SELECT
+    requester_name,
+    tool,
+    usage_day,
+    SUM(total_tokens_used) AS total_tokens_used,
+    COUNT(DISTINCT request_id) AS sessions,
+    MIN(event_time) AS first_event_time,
+    MAX(event_time) AS last_event_time
+  FROM usage_events
+  GROUP BY 1, 2, 3
+),
+model_usage AS (
+  SELECT
+    requester_name,
+    tool,
+    usage_day,
+    destination_model,
+    SUM(total_tokens_used) AS model_tokens_used
+  FROM usage_events
+  WHERE destination_model IS NOT NULL AND destination_model != ''
+  GROUP BY 1, 2, 3, 4
+),
+model_rollup AS (
+  SELECT
+    requester_name,
+    tool,
+    usage_day,
+    CONCAT_WS(', ', SORT_ARRAY(COLLECT_SET(destination_model))) AS models,
+    TO_JSON(
+      SORT_ARRAY(
+        COLLECT_LIST(
+          NAMED_STRUCT('model', destination_model, 'tokens', model_tokens_used)
+        )
+      )
+    ) AS model_tokens
+  FROM model_usage
+  GROUP BY 1, 2, 3
+)
+SELECT
+  daily_usage.requester_name,
+  daily_usage.tool,
+  daily_usage.usage_day,
+  daily_usage.total_tokens_used,
+  daily_usage.sessions,
+  daily_usage.first_event_time,
+  daily_usage.last_event_time,
+  COALESCE(model_rollup.models, '') AS models,
+  COALESCE(model_rollup.model_tokens, '[]') AS model_tokens
+FROM daily_usage
+LEFT JOIN model_rollup
+  ON daily_usage.requester_name = model_rollup.requester_name
+  AND daily_usage.tool = model_rollup.tool
+  AND daily_usage.usage_day = model_rollup.usage_day
+ORDER BY daily_usage.usage_day DESC, daily_usage.tool ASC
 """.strip()
 
 
@@ -68,6 +125,21 @@ def build_current_user_query() -> str:
 
 def parse_usage_rows(columns: list[str], rows: list[tuple]) -> list[dict[str, object]]:
     return [dict(zip(columns, row, strict=False)) for row in rows]
+
+
+def configured_usage_tools(state: dict, tool_displays: dict[str, str]) -> list[str]:
+    configured = state.get("available_tools") or state.get("managed_configs", {}).keys()
+    if not isinstance(configured, list):
+        configured = list(configured)
+    return [tool for tool in tool_displays if tool in configured]
+
+
+def filter_records_for_tools(
+    records: list[dict[str, object]],
+    tools: list[str],
+) -> list[dict[str, object]]:
+    configured = set(tools)
+    return [record for record in records if record.get("tool") in configured]
 
 
 def coerce_date(value_obj: object) -> date | None:
@@ -134,6 +206,80 @@ def summarize_models(tool: str, raw_models: object) -> str:
     return ", ".join(parts) if parts else "-"
 
 
+def _coerce_model_token_item(tool: str, item: object) -> tuple[str, int] | None:
+    if not isinstance(item, Mapping):
+        return None
+    item_mapping = cast(Mapping[str, object], item)
+
+    raw_model = item_mapping.get("model")
+    if not isinstance(raw_model, str) or not raw_model.strip():
+        return None
+
+    raw_tokens = item_mapping.get("tokens")
+    try:
+        token_total = int(cast(int | float | str, raw_tokens or 0))
+    except (TypeError, ValueError):
+        token_total = 0
+
+    model_name = simplify_model_name(tool, raw_model)
+    if model_name == "-":
+        return None
+    return model_name, token_total
+
+
+def extract_model_token_breakdown(
+    tool: str,
+    raw_model_tokens: object,
+    raw_models: object = None,
+    total_tokens: int = 0,
+) -> list[tuple[str, int]]:
+    items: object
+    if isinstance(raw_model_tokens, str) and raw_model_tokens.strip():
+        try:
+            items = json.loads(raw_model_tokens)
+        except json.JSONDecodeError:
+            items = []
+    else:
+        items = raw_model_tokens
+
+    model_tokens: dict[str, int] = {}
+    if isinstance(items, list):
+        for item in items:
+            coerced = _coerce_model_token_item(tool, item)
+            if not coerced:
+                continue
+            model_name, token_total = coerced
+            model_tokens[model_name] = model_tokens.get(model_name, 0) + token_total
+
+    if model_tokens:
+        return sorted(model_tokens.items(), key=lambda item: (-item[1], item[0].lower()))
+
+    models = extract_model_names(tool, raw_models)
+    if len(models) == 1 and total_tokens:
+        return [(models[0], total_tokens)]
+    return [(model_name, 0) for model_name in models]
+
+
+def summarize_model_tokens(
+    tool: str,
+    raw_model_tokens: object,
+    raw_models: object,
+    total_tokens: int,
+) -> str:
+    model_tokens = extract_model_token_breakdown(
+        tool,
+        raw_model_tokens,
+        raw_models,
+        total_tokens,
+    )
+    if not model_tokens:
+        return "-"
+    return ", ".join(
+        f"{model_name} ({format_token_count(token_total)})" if token_total else model_name
+        for model_name, token_total in model_tokens
+    )
+
+
 def empty_tool_day(tool: str, usage_day: date) -> dict[str, object]:
     return {
         "tool": tool,
@@ -143,7 +289,24 @@ def empty_tool_day(tool: str, usage_day: date) -> dict[str, object]:
         "first_event_time": None,
         "last_event_time": None,
         "models": "-",
+        "model_tokens": "[]",
     }
+
+
+def has_tool_usage_last_week(records: list[dict[str, object]], tool: str) -> bool:
+    today = date.today()
+    week_start = today - timedelta(days=USAGE_BREAKDOWN_DAYS - 1)
+    for record in records:
+        if record.get("tool") != tool:
+            continue
+        usage_day = coerce_date(record.get("usage_day"))
+        if not usage_day or usage_day < week_start:
+            continue
+        token_total = int(cast(int, record.get("total_tokens_used") or 0))
+        session_total = int(cast(int, record.get("sessions") or 0))
+        if token_total or session_total:
+            return True
+    return False
 
 
 def build_tool_breakdown_rows(records: list[dict[str, object]], tool: str) -> list[list[str]]:
@@ -174,7 +337,12 @@ def build_tool_breakdown_rows(records: list[dict[str, object]], tool: str) -> li
                 format_token_count(token_total) if token_total else "-",
                 str(session_total) if session_total else "-",
                 format_duration(duration),
-                summarize_models(tool, record.get("models")),
+                summarize_model_tokens(
+                    tool,
+                    record.get("model_tokens"),
+                    record.get("models"),
+                    token_total,
+                ),
             ]
         )
 
@@ -232,9 +400,14 @@ def render_usage_summary(
             ):
                 active_tools_last_week.append(tool)
             if isinstance(tool, str):
-                for model_name in extract_model_names(tool, record.get("models")):
+                for model_name, model_token_total in extract_model_token_breakdown(
+                    tool,
+                    record.get("model_tokens"),
+                    record.get("models"),
+                    token_total,
+                ):
                     weekly_model_tokens[model_name] = (
-                        weekly_model_tokens.get(model_name, 0) + token_total
+                        weekly_model_tokens.get(model_name, 0) + model_token_total
                     )
         if usage_day == today:
             daily_total += token_total
@@ -291,13 +464,25 @@ def usage() -> int:
     requester_name = find_requester_name(workspace, resolved_http_path, token, records)
 
     tool_displays = {tool: spec["display"] for tool, spec in TOOL_SPECS.items()}
-    console.print(render_usage_summary(records, requester_name, tool_displays))
+    configured_tools = configured_usage_tools(state, tool_displays)
+    configured_tool_displays = {tool: tool_displays[tool] for tool in configured_tools}
+    records = filter_records_for_tools(records, configured_tools)
+
+    console.print(render_usage_summary(records, requester_name, configured_tool_displays))
 
     table_headers = ["Date", "Day", "Tokens", "Sessions", "Duration", "Models"]
     table_widths = [8, 5, 10, 8, 8, 24]
 
-    for tool, spec in TOOL_SPECS.items():
-        print_heading(f"{spec['display']} · Last {USAGE_BREAKDOWN_DAYS} Days")
+    if not configured_tools:
+        print_note("No coding agents configured. Run `ucode configure` to set up agents.")
+        return 0
+
+    for tool in configured_tools:
+        display = tool_displays[tool]
+        print_heading(f"{display} · Last {USAGE_BREAKDOWN_DAYS} Days")
+        if not has_tool_usage_last_week(records, tool):
+            print_note(f"No usage for {display} in the last {USAGE_BREAKDOWN_DAYS} days.")
+            continue
         console.print(
             render_box_table(
                 table_headers,

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -4,19 +4,27 @@ from __future__ import annotations
 
 from datetime import date, datetime, timedelta
 
+import ucode.usage as usage_mod
 from ucode.usage import (
     USAGE_BREAKDOWN_DAYS,
     USAGE_SUMMARY_DAYS,
     build_current_user_query,
+    build_tool_breakdown_rows,
     build_usage_report_query,
     coerce_date,
     coerce_datetime,
+    configured_usage_tools,
     empty_tool_day,
     extract_model_names,
+    extract_model_token_breakdown,
+    filter_records_for_tools,
+    has_tool_usage_last_week,
     parse_usage_rows,
     render_usage_summary,
     simplify_model_name,
+    summarize_model_tokens,
     summarize_models,
+    usage,
 )
 
 
@@ -34,6 +42,12 @@ class TestBuildUsageReportQuery:
         for tool in ("codex", "claude", "gemini", "opencode"):
             assert tool in q
 
+    def test_includes_per_model_token_rollup(self):
+        q = build_usage_report_query()
+        assert "model_tokens" in q
+        assert "SUM(total_tokens_used) AS model_tokens_used" in q
+        assert "NAMED_STRUCT('model', destination_model, 'tokens', model_tokens_used)" in q
+
 
 class TestBuildCurrentUserQuery:
     def test_uses_current_user(self):
@@ -50,6 +64,82 @@ class TestParseUsageRows:
 
     def test_empty_rows(self):
         assert parse_usage_rows(["a"], []) == []
+
+
+class TestConfiguredUsageTools:
+    def test_uses_available_tools_in_display_order(self):
+        tool_displays = {"claude": "Claude Code", "codex": "Codex", "gemini": "Gemini"}
+        state = {"available_tools": ["codex", "claude"]}
+        assert configured_usage_tools(state, tool_displays) == ["claude", "codex"]
+
+    def test_falls_back_to_managed_configs(self):
+        tool_displays = {"claude": "Claude Code", "codex": "Codex"}
+        state = {"managed_configs": {"codex": {"keys": []}}}
+        assert configured_usage_tools(state, tool_displays) == ["codex"]
+
+    def test_ignores_unknown_tools(self):
+        tool_displays = {"claude": "Claude Code"}
+        state = {"available_tools": ["claude", "unknown"]}
+        assert configured_usage_tools(state, tool_displays) == ["claude"]
+
+
+class TestFilterRecordsForTools:
+    def test_keeps_only_configured_tools(self):
+        records = [
+            {"tool": "claude", "total_tokens_used": 100},
+            {"tool": "gemini", "total_tokens_used": 200},
+            {"tool": "codex", "total_tokens_used": 300},
+        ]
+        assert filter_records_for_tools(records, ["claude", "codex"]) == [
+            {"tool": "claude", "total_tokens_used": 100},
+            {"tool": "codex", "total_tokens_used": 300},
+        ]
+
+
+class TestHasToolUsageLastWeek:
+    def test_true_for_recent_tokens(self):
+        records = [
+            {
+                "tool": "claude",
+                "usage_day": date.today(),
+                "total_tokens_used": 100,
+                "sessions": 1,
+            }
+        ]
+        assert has_tool_usage_last_week(records, "claude") is True
+
+    def test_true_for_recent_session_even_without_tokens(self):
+        records = [
+            {
+                "tool": "claude",
+                "usage_day": date.today(),
+                "total_tokens_used": 0,
+                "sessions": 1,
+            }
+        ]
+        assert has_tool_usage_last_week(records, "claude") is True
+
+    def test_false_for_only_old_usage(self):
+        records = [
+            {
+                "tool": "claude",
+                "usage_day": date.today() - timedelta(days=USAGE_BREAKDOWN_DAYS),
+                "total_tokens_used": 100,
+                "sessions": 1,
+            }
+        ]
+        assert has_tool_usage_last_week(records, "claude") is False
+
+    def test_false_for_other_tool_usage(self):
+        records = [
+            {
+                "tool": "codex",
+                "usage_day": date.today(),
+                "total_tokens_used": 100,
+                "sessions": 1,
+            }
+        ]
+        assert has_tool_usage_last_week(records, "claude") is False
 
 
 class TestCoerceDate:
@@ -159,6 +249,47 @@ class TestSummarizeModels:
         assert summarize_models("claude", None) == "-"
 
 
+class TestModelTokenBreakdown:
+    def test_extracts_json_model_tokens(self):
+        raw = (
+            '[{"model":"databricks-claude-opus-4", "tokens":236000}, '
+            '{"model":"databricks-claude-haiku-4.5", "tokens":920}]'
+        )
+        result = extract_model_token_breakdown("claude", raw)
+        assert result == [("opus-4", 236000), ("haiku-4.5", 920)]
+
+    def test_merges_simplified_duplicate_model_names(self):
+        raw = [
+            {"model": "databricks-claude-opus-4", "tokens": 100},
+            {"model": "claude-opus-4", "tokens": 50},
+        ]
+        result = extract_model_token_breakdown("claude", raw)
+        assert result == [("opus-4", 150)]
+
+    def test_single_model_legacy_fallback_uses_total_tokens(self):
+        result = extract_model_token_breakdown(
+            "codex",
+            None,
+            "databricks-gpt-5",
+            13300,
+        )
+        assert result == [("5", 13300)]
+
+    def test_multi_model_legacy_fallback_does_not_assign_total_to_each_model(self):
+        result = extract_model_token_breakdown(
+            "claude",
+            None,
+            "databricks-claude-haiku-4.5, databricks-claude-opus-4",
+            237000,
+        )
+        assert result == [("haiku-4.5", 0), ("opus-4", 0)]
+
+    def test_summarizes_tokens_next_to_each_model(self):
+        raw = '[{"model":"databricks-claude-opus-4", "tokens":236000}]'
+        result = summarize_model_tokens("claude", raw, "", 0)
+        assert result == "opus-4 (236.0K)"
+
+
 class TestEmptyToolDay:
     def test_structure(self):
         d = date(2024, 6, 1)
@@ -210,6 +341,147 @@ class TestRenderUsageSummary:
         result = render_usage_summary(records, "user", {"claude": "Claude Code"})
         assert "sonnet-4" in result
 
+    def test_top_models_uses_per_model_token_totals(self):
+        records = [
+            {
+                "tool": "claude",
+                "usage_day": date.today(),
+                "total_tokens_used": 237000,
+                "models": "databricks-claude-haiku-4.5, databricks-claude-opus-4",
+                "model_tokens": (
+                    '[{"model":"databricks-claude-haiku-4.5", "tokens":920}, '
+                    '{"model":"databricks-claude-opus-4", "tokens":236080}]'
+                ),
+            },
+            {
+                "tool": "codex",
+                "usage_day": date.today(),
+                "total_tokens_used": 13300,
+                "models": "databricks-gpt-5",
+                "model_tokens": '[{"model":"databricks-gpt-5", "tokens":13300}]',
+            },
+        ]
+        result = render_usage_summary(
+            records,
+            "user",
+            {"claude": "Claude Code", "codex": "Codex"},
+        )
+        assert "opus-4 (236.1K)" in result
+        assert "5 (13.3K)" in result
+        assert "haiku-4.5 (920)" in result
+        assert "haiku-4.5 (237.0K)" not in result
+
+    def test_daily_table_shows_per_model_token_totals(self):
+        records = [
+            {
+                "tool": "claude",
+                "usage_day": date.today(),
+                "total_tokens_used": 237000,
+                "sessions": 2,
+                "models": "databricks-claude-haiku-4.5, databricks-claude-opus-4",
+                "model_tokens": (
+                    '[{"model":"databricks-claude-haiku-4.5", "tokens":920}, '
+                    '{"model":"databricks-claude-opus-4", "tokens":236080}]'
+                ),
+            }
+        ]
+        rows = build_tool_breakdown_rows(records, "claude")
+        assert rows[0][5] == "opus-4 (236.1K), haiku-4.5 (920)"
+
     def test_empty_records(self):
         result = render_usage_summary([], "user", {"claude": "Claude Code"})
         assert "user" in result
+
+
+class TestUsageCommand:
+    def test_filters_to_configured_agents_and_skips_inactive_tables(self, monkeypatch):
+        today = date.today()
+        old_day = today - timedelta(days=USAGE_BREAKDOWN_DAYS)
+        columns = [
+            "requester_name",
+            "tool",
+            "usage_day",
+            "total_tokens_used",
+            "sessions",
+            "first_event_time",
+            "last_event_time",
+            "models",
+            "model_tokens",
+        ]
+        rows = [
+            (
+                "user@example.com",
+                "codex",
+                today,
+                100,
+                1,
+                None,
+                None,
+                "databricks-gpt-5",
+                '[{"model":"databricks-gpt-5", "tokens":100}]',
+            ),
+            (
+                "user@example.com",
+                "claude",
+                old_day,
+                200,
+                1,
+                None,
+                None,
+                "databricks-claude-opus-4",
+                '[{"model":"databricks-claude-opus-4", "tokens":200}]',
+            ),
+            (
+                "user@example.com",
+                "gemini",
+                today,
+                900,
+                1,
+                None,
+                None,
+                "databricks-gemini-2.0-flash",
+                '[{"model":"databricks-gemini-2.0-flash", "tokens":900}]',
+            ),
+        ]
+
+        printed: list[str] = []
+        headings: list[str] = []
+        notes: list[str] = []
+        rendered_tables: list[list[list[str]]] = []
+
+        class DummyConsole:
+            def print(self, value):
+                printed.append(str(value))
+
+        def fake_render_box_table(headers, table_rows, max_widths=None):
+            rendered_tables.append(table_rows)
+            return "TABLE"
+
+        monkeypatch.setattr(
+            usage_mod,
+            "load_state",
+            lambda: {"workspace": "https://workspace", "available_tools": ["claude", "codex"]},
+        )
+        monkeypatch.setattr(usage_mod, "ensure_databricks_auth", lambda *args, **kwargs: None)
+        monkeypatch.setattr(usage_mod, "get_databricks_token", lambda *args, **kwargs: "token")
+        monkeypatch.setattr(
+            usage_mod,
+            "discover_sql_warehouse_http_path",
+            lambda *args, **kwargs: "/sql/1.0/warehouses/abc",
+        )
+        monkeypatch.setattr(usage_mod, "run_usage_query", lambda *args, **kwargs: (columns, rows))
+        monkeypatch.setattr(usage_mod, "console", DummyConsole())
+        monkeypatch.setattr(usage_mod, "print_heading", headings.append)
+        monkeypatch.setattr(usage_mod, "print_note", notes.append)
+        monkeypatch.setattr(usage_mod, "render_box_table", fake_render_box_table)
+
+        assert usage() == 0
+
+        assert "Codex · Last 7 Days" in headings
+        assert "Claude Code · Last 7 Days" in headings
+        assert all("Gemini" not in heading for heading in headings)
+        assert notes == [f"No usage for Claude Code in the last {USAGE_BREAKDOWN_DAYS} days."]
+        assert len(rendered_tables) == 1
+        assert rendered_tables[0][0][2] == "100"
+        assert "gemini" not in "\n".join(printed).lower()
+        assert "900" not in "\n".join(printed)


### PR DESCRIPTION
### Summary

  - Adds per-model token aggregation to the `ucode usage` SQL query via a `model_tokens` rollup.
  - Updates `Top models this week` to use actual per-model token totals instead of applying agent/day totals to every model.
  - Shows per-model token counts in the daily agent usage table.
  - Filters `ucode usage` output to agents configured by ucode.
  - Shows a compact “No usage for <Agent> in the last 7 days.” message instead of an empty table for configured agents with no recent usage.

  ## Tests

  - uv run ruff check .
  - uv run ty check src/
  - uv run pytest tests/test_lint.py tests/test_usage.py -q
  - uv run pytest

### Local Test
<img width="595" height="726" alt="Screenshot 2026-05-26 at 6 11 38 PM" src="https://github.com/user-attachments/assets/c85c4a4f-2d03-4460-93ae-36c58da783ac" />
