### PR TITLE
Disable Claude Code thinking to unblock Opus 4.7 gateway calls

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -106,6 +106,13 @@ def render_overlay(
         "ANTHROPIC_BASE_URL": base_url,
         "ANTHROPIC_CUSTOM_HEADERS": custom_headers,
         "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+        # Suppress Claude Code's client-side `thinking.type=enabled` field.
+        # The Databricks AI Gateway rejects it for adaptive-only models (Opus 4.7
+        # family) which require `thinking.type=adaptive` + `output_config.effort`.
+        # Claude Code's model detection doesn't recognize the `databricks-` prefix
+        # on gateway model ids, so it sends the legacy shape and the request 400s.
+        # The gateway still applies adaptive reasoning server-side where required.
+        "CLAUDE_CODE_DISABLE_THINKING": "1",
         "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "900000",
     }
     if claude_models:

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -37,6 +37,18 @@ class TestRenderOverlay:
         overlay, _ = claude.render_overlay(WS, "s4")
         assert overlay["env"]["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] == "1"
 
+    def test_disables_thinking(self):
+        # Claude Code's `thinking.type=enabled` field is rejected by the
+        # Databricks AI Gateway for adaptive-only models (Opus 4.7 family).
+        # The gateway applies adaptive reasoning server-side regardless, so
+        # ucode disables Claude Code's client-side thinking unconditionally.
+        overlay, _ = claude.render_overlay(WS, "s4")
+        assert overlay["env"]["CLAUDE_CODE_DISABLE_THINKING"] == "1"
+
+    def test_disable_thinking_is_managed(self):
+        _, keys = claude.render_overlay(WS, "s4")
+        assert ["env", "CLAUDE_CODE_DISABLE_THINKING"] in keys
+
     def test_sets_api_key_helper(self):
         overlay, _ = claude.render_overlay(WS, "s4")
         assert "apiKeyHelper" in overlay


### PR DESCRIPTION
Claude Code sends `thinking.type=enabled` on outbound requests, which the Databricks AI Gateway rejects for adaptive-only models (Opus 4.7 family) with a 400. The gateway expects `thinking.type=adaptive` + `output_config.effort`. Claude Code does support that shape but only when its model-name pattern matches a known Anthropic id — the gateway exposes models as `databricks-claude-opus-4-7`, so the prefix throws off detection and Claude Code falls back to the legacy `enabled` shape. The result: `ucode claude` validation fails and the config is reverted.

Set `CLAUDE_CODE_DISABLE_THINKING=1` in the Claude Code env block so the field is omitted entirely. The gateway still applies adaptive reasoning server-side on Opus 4.7 (where it's mandatory), so reasoning quality is preserved on the new family. Older models lose client-side extended thinking through the gateway, which is the correct tradeoff for a configuration that actually works end-to-end.