### PR TITLE
Fix ValueError when selecting "Enter a different URL" in configure

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -378,6 +378,10 @@ def has_valid_databricks_auth(workspace: str, profile: str | None = None) -> boo
     if os.environ.get("DATABRICKS_BEARER", "").strip():
         return True
     _log_auth_diagnostics()
+    # Mirror run_databricks_login: when ~/.databrickscfg has multiple
+    # profiles for the same host, `databricks auth token --host …` refuses
+    # to disambiguate without --profile, so resolve it from the host here.
+    profile = profile or find_profile_name_for_host(workspace)
     try:
         env = build_databricks_cli_env(workspace)
         result = run(
@@ -522,6 +526,9 @@ def get_databricks_token(
         return bearer
 
     _log_auth_diagnostics()
+    # See has_valid_databricks_auth: resolve the profile from the host when
+    # the caller didn't supply one, so duplicate-host cfgs don't break us.
+    profile = profile or find_profile_name_for_host(workspace)
     env = build_databricks_cli_env(workspace)
     cmd = [
         "databricks",
@@ -586,13 +593,12 @@ def get_databricks_token(
         token = _fetch()
 
     if not token:
-        profile_name = profile or find_profile_name_for_host(workspace)
         stale_profile_hint = ""
-        if profile_name:
+        if profile:
             stale_profile_hint = (
                 " The saved Databricks CLI profile may be stale or invalid. Try:\n"
-                f"  databricks auth logout --profile {profile_name}\n"
-                f"  databricks auth login --host {workspace} --profile {profile_name}"
+                f"  databricks auth logout --profile {profile}\n"
+                f"  databricks auth login --host {workspace} --profile {profile}"
             )
         raise RuntimeError(
             f"Databricks CLI returned no access token for {workspace}. "

--- a/src/ucode/ui.py
+++ b/src/ucode/ui.py
@@ -203,7 +203,7 @@ def prompt_for_workspace(
         choice = questionary.select(
             "Select workspace:", choices=choices, style=style, pointer="›", qmark=""
         ).ask()
-        if choice is not None:
+        if isinstance(choice, tuple):
             host, profile_name = choice
             return normalize_workspace_url(host), profile_name
 

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from unittest.mock import patch
 
 import pytest
 
@@ -10,6 +11,7 @@ from ucode.ui import (
     format_duration,
     format_token_count,
     normalize_workspace_url,
+    prompt_for_workspace,
     render_box_table,
     status_badge,
 )
@@ -144,3 +146,49 @@ class TestRenderBoxTable:
     def test_dash_for_empty_cell(self):
         result = render_box_table(["A"], [[""]])
         assert "-" in result
+
+
+class TestPromptForWorkspace:
+    """Cover the three things `questionary.select(...).ask()` can return:
+    a (host, profile) tuple, None (cancel or "Enter a different URL"),
+    or — in some questionary versions — the choice's title string."""
+
+    PROFILES = [("https://a.databricks.com", "prof-a"), ("https://b.databricks.com", "prof-b")]
+
+    def test_returns_selected_profile_tuple(self):
+        with patch("ucode.ui.questionary.select") as mock_select:
+            mock_select.return_value.ask.return_value = (
+                "https://a.databricks.com",
+                "prof-a",
+            )
+            url, profile = prompt_for_workspace("desc", profiles=self.PROFILES)
+        assert url == "https://a.databricks.com"
+        assert profile == "prof-a"
+
+    def test_none_falls_through_to_manual_prompt(self):
+        with (
+            patch("ucode.ui.questionary.select") as mock_select,
+            patch("ucode.ui.console.input", return_value="https://manual.databricks.com"),
+        ):
+            mock_select.return_value.ask.return_value = None
+            url, profile = prompt_for_workspace("desc", profiles=self.PROFILES)
+        assert url == "https://manual.databricks.com"
+        assert profile is None
+
+    def test_string_value_falls_through_to_manual_prompt(self):
+        # Regression: if questionary returns the choice title (e.g. "Enter a
+        # different URL") instead of its value, we must not try to unpack it.
+        with (
+            patch("ucode.ui.questionary.select") as mock_select,
+            patch("ucode.ui.console.input", return_value="https://manual.databricks.com"),
+        ):
+            mock_select.return_value.ask.return_value = "Enter a different URL"
+            url, profile = prompt_for_workspace("desc", profiles=self.PROFILES)
+        assert url == "https://manual.databricks.com"
+        assert profile is None
+
+    def test_no_profiles_goes_straight_to_manual_prompt(self):
+        with patch("ucode.ui.console.input", return_value="example.databricks.com"):
+            url, profile = prompt_for_workspace("desc", profiles=None)
+        assert url == "https://example.databricks.com"
+        assert profile is None


### PR DESCRIPTION
The workspace picker assumed `questionary.select(...).ask()` returns either a (host, profile) tuple or None, but in some questionary versions selecting the "Enter a different URL" option returns the title string instead, causing `too many values to unpack` on the tuple destructure. Guard the unpack with `isinstance(choice, tuple)` so any non-tuple return (None or a stray string) falls through to the manual URL prompt.

Fix issue https://github.com/databricks/ucode/issues/103