### PR TITLE
Make web_search MCP registration non-blocking on claude setup

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -22,6 +22,7 @@ from ucode.databricks import (
 )
 from ucode.state import mark_tool_managed, save_state
 from ucode.telemetry import agent_version, ucode_version
+from ucode.ui import print_warning
 
 CLAUDE_CONFIG_DIR = Path.home() / ".claude"
 CLAUDE_SETTINGS_PATH = CLAUDE_CONFIG_DIR / "ucode-settings.json"
@@ -128,10 +129,14 @@ def render_overlay(
     return overlay, keys
 
 
-def _register_web_search_mcp(workspace: str, search_model: str, profile: str | None = None) -> None:
+def _register_web_search_mcp(workspace: str, search_model: str, profile: str | None = None) -> bool:
     """Register (or replace) the web_search MCP server in Claude Code's user
     scope via `claude mcp add-json`. Removes any prior entry first so re-runs
-    pick up changes to the workspace, model, or ucode binary path."""
+    pick up changes to the workspace, model, or ucode binary path.
+
+    Returns True if registration succeeded. Failures are non-blocking: we warn
+    and return False so the rest of `ucode claude` setup can complete.
+    """
     # Imported lazily to avoid a circular import via ucode.mcp -> ucode.agents.
     from ucode.mcp import (
         MCP_CLEANUP_SCOPES,
@@ -146,7 +151,12 @@ def _register_web_search_mcp(workspace: str, search_model: str, profile: str | N
             # Best-effort cleanup of stale entries — keep going.
             pass
     entry = _web_search_mcp_entry(workspace, search_model, profile)
-    add_claude_mcp_server(WEB_SEARCH_MCP_NAME, entry)
+    try:
+        add_claude_mcp_server(WEB_SEARCH_MCP_NAME, entry)
+    except RuntimeError as exc:
+        print_warning(f"{exc} Web search will be unavailable; re-run `ucode claude` to retry.")
+        return False
+    return True
 
 
 def _unregister_web_search_mcp() -> None:

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -252,6 +252,56 @@ class TestRegisterWebSearchMcp:
         claude._register_web_search_mcp(WS, "m")
         assert added == ["web_search"]
 
+    def test_add_failure_is_non_blocking_and_warns(self, monkeypatch, capsys):
+        # Regression: a failing `claude mcp add-json` used to abort the whole
+        # `ucode claude` setup. It must now warn and return False instead.
+        import ucode.mcp as mcp_mod
+
+        monkeypatch.setattr(mcp_mod, "remove_claude_mcp_server", lambda name, scope: False)
+
+        def boom(name, entry, scope=mcp_mod.MCP_USER_SCOPE):
+            raise RuntimeError("Failed to add MCP server 'web_search' via claude CLI.")
+
+        monkeypatch.setattr(mcp_mod, "add_claude_mcp_server", boom)
+        result = claude._register_web_search_mcp(WS, "m")
+        assert result is False
+        captured = capsys.readouterr()
+        assert "web_search" in captured.out.lower() or "web search" in captured.out.lower()
+
+    def test_add_success_returns_true(self, monkeypatch):
+        import ucode.mcp as mcp_mod
+
+        monkeypatch.setattr(mcp_mod, "remove_claude_mcp_server", lambda name, scope: False)
+        monkeypatch.setattr(
+            mcp_mod,
+            "add_claude_mcp_server",
+            lambda name, entry, scope=mcp_mod.MCP_USER_SCOPE: None,
+        )
+        assert claude._register_web_search_mcp(WS, "m") is True
+
+    def test_write_tool_config_completes_when_mcp_registration_fails(self, monkeypatch):
+        # Regression for issue #100: a `claude mcp add-json` failure must not
+        # block the rest of `ucode claude` setup (state save, managed-key
+        # marking, etc.) from completing.
+        import ucode.mcp as mcp_mod
+
+        monkeypatch.setattr(claude, "backup_existing_file", lambda *a, **kw: True)
+        monkeypatch.setattr(claude, "read_json_safe", lambda path: {})
+        monkeypatch.setattr(claude, "write_json_file", lambda path, payload: None)
+        saved: list[dict] = []
+        monkeypatch.setattr(claude, "save_state", lambda state: saved.append(state))
+        monkeypatch.setattr(mcp_mod, "remove_claude_mcp_server", lambda name, scope: False)
+
+        def boom(name, entry, scope=mcp_mod.MCP_USER_SCOPE):
+            raise RuntimeError("Failed to add MCP server 'web_search' via claude CLI.")
+
+        monkeypatch.setattr(mcp_mod, "add_claude_mcp_server", boom)
+
+        state = {"workspace": WS, "codex_models": ["databricks-gpt-5"]}
+        result = claude.write_tool_config(state, "databricks-claude-sonnet-4")
+        assert saved, "save_state should still be called when MCP registration fails"
+        assert result["workspace"] == WS
+
 
 class TestClaudeLaunch:
     def test_sets_oauth_token_before_exec(self, monkeypatch):


### PR DESCRIPTION
Fixes #100. When `claude mcp add-json` failed, the RuntimeError raised by `add_claude_mcp_server` propagated out of `write_tool_config` and aborted the whole `ucode claude` flow before state could be saved or the tool marked as managed. Catch the error in `_register_web_search_mcp`, warn the user, and return False so setup completes. Re-running `ucode claude` will retry the MCP registration.