### PR TITLE
clear stale MCP entries when switching workspaces

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -40,7 +40,12 @@ from ucode.databricks import (
     normalize_workspace_url,
     run_databricks_login,
 )
-from ucode.mcp import MCP_CLIENTS, configure_mcp_command, revert_mcp_configs
+from ucode.mcp import (
+    MCP_CLIENTS,
+    configure_mcp_command,
+    purge_cross_workspace_mcp_residue,
+    revert_mcp_configs,
+)
 from ucode.state import STATE_PATH, clear_state, load_state, save_state
 from ucode.ui import (
     console,
@@ -151,6 +156,7 @@ def configure_shared_state(
     don't error out. If ``None``, we resolve it from the host after login.
     """
     workspace = normalize_workspace_url(workspace)
+    previous_workspace = load_state().get("workspace")
     fetch_all = tools is None
     if force_login:
         run_databricks_login(workspace, profile)
@@ -210,6 +216,10 @@ def configure_shared_state(
     if fetch_all or "opencode" in tools:
         state["opencode_models"] = opencode_models
     save_state(state)
+    # Scrub MCP entries that ucode wrote for the previous workspace so the new
+    # workspace's agent configs aren't stale.
+    if previous_workspace and previous_workspace != workspace:
+        purge_cross_workspace_mcp_residue(state, workspace)
     # Diagnostic reasons are transient — attach after save_state so they don't
     # land on disk but are available to the caller for this run.
     state["_discovery_reasons"] = {

--- a/src/ucode/mcp.py
+++ b/src/ucode/mcp.py
@@ -8,6 +8,7 @@ import string
 import subprocess
 from collections.abc import Callable
 from typing import Any
+from urllib.parse import urlparse
 
 import questionary
 from prompt_toolkit.application import Application
@@ -29,8 +30,9 @@ from ucode.databricks import (
     list_databricks_apps,
     list_databricks_connections,
     list_genie_spaces,
+    workspace_hostname,
 )
-from ucode.state import load_state, save_state
+from ucode.state import load_full_state, load_state, save_state
 from ucode.ui import (
     print_note,
     print_section,
@@ -432,6 +434,61 @@ def _servers_by_name(mcp_servers: list[dict]) -> dict[str, dict]:
     return servers
 
 
+def _mcp_entry_url_host(entry: dict) -> str | None:
+    """Return the host of an MCP entry's URL, or ``None`` if missing/malformed."""
+    url = entry.get("url")
+    if not isinstance(url, str) or not url:
+        return None
+    try:
+        return urlparse(url).hostname
+    except ValueError:
+        return None
+
+
+def _partition_mcp_entries_by_workspace(
+    entries: list[dict], workspace: str
+) -> tuple[list[dict], list[dict]]:
+    """Split MCP entries into ones that belong to ``workspace`` and ones that don't."""
+    workspace_host = workspace_hostname(workspace)
+    current: list[dict] = []
+    foreign: list[dict] = []
+    for entry in entries:
+        if _mcp_entry_url_host(entry) == workspace_host:
+            current.append(entry)
+        else:
+            foreign.append(entry)
+    return current, foreign
+
+
+def _mcp_entries_only_in_other_workspaces(current_workspace: str) -> dict[str, set[str]]:
+    """Return ``{name: {client, ...}}`` for MCPs ucode tracks only in workspaces other than ``current_workspace``."""
+    full_state = load_full_state()
+    workspaces = full_state.get("workspaces")
+    if not isinstance(workspaces, dict):
+        return {}
+
+    current_names: set[str] = set()
+    current_bucket = workspaces.get(current_workspace)
+    if isinstance(current_bucket, dict):
+        for entry in current_bucket.get("mcp_servers") or []:
+            name = _server_name(entry)
+            if name:
+                current_names.add(name)
+
+    external_entries: dict[str, set[str]] = {}
+    for ws, bucket in workspaces.items():
+        if ws == current_workspace or not isinstance(bucket, dict):
+            continue
+        for entry in bucket.get("mcp_servers") or []:
+            name = _server_name(entry)
+            if not name or name in current_names:
+                continue
+            client_set = external_entries.setdefault(name, set())
+            for client in entry.get("clients") or []:
+                client_set.add(client)
+    return external_entries
+
+
 def _server_choice(name: str, checked: bool, title: str | None = None) -> questionary.Choice:
     return questionary.Choice(
         title=title or name,
@@ -743,11 +800,71 @@ def apply_mcp_server_changes(
     return changed
 
 
+def purge_cross_workspace_mcp_residue(state: dict, workspace: str) -> None:
+    installed = set(available_mcp_clients())
+
+    raw_mcp_servers = list(state.get("mcp_servers") or [])
+    current_mcp_servers, foreign_mcp_servers = _partition_mcp_entries_by_workspace(
+        raw_mcp_servers, workspace
+    )
+    if foreign_mcp_servers:
+        foreign_names = ", ".join(
+            (_server_name(server) or "(unnamed)") for server in foreign_mcp_servers
+        )
+        noun = "entry" if len(foreign_mcp_servers) == 1 else "entries"
+        print_warning(
+            f"Dropping {len(foreign_mcp_servers)} stale MCP {noun} "
+            f"not bound to this workspace: {foreign_names}."
+        )
+        for server in foreign_mcp_servers:
+            name = _server_name(server)
+            if not name:
+                continue
+            for client in server.get("clients") or []:
+                if client not in installed or client not in MCP_CLIENTS:
+                    continue
+                try:
+                    remove_client_mcp_server(client, name)
+                except RuntimeError as exc:
+                    print_warning(
+                        f"Failed to remove `{name}` from {MCP_CLIENTS[client]['display']}: {exc}"
+                    )
+        state["mcp_servers"] = current_mcp_servers
+        save_state(state)
+
+    other_ws_mcps = _mcp_entries_only_in_other_workspaces(workspace)
+    actually_removed: list[str] = []
+    for name in sorted(other_ws_mcps):
+        any_removed = False
+        for client in other_ws_mcps[name]:
+            if client not in installed or client not in MCP_CLIENTS:
+                continue
+            try:
+                removed_scopes = remove_client_mcp_server(client, name)
+            except RuntimeError as exc:
+                print_warning(
+                    f"Failed to remove `{name}` from {MCP_CLIENTS[client]['display']}: {exc}"
+                )
+                continue
+            if removed_scopes:
+                any_removed = True
+        if any_removed:
+            actually_removed.append(name)
+    if actually_removed:
+        noun = "entry" if len(actually_removed) == 1 else "entries"
+        print_warning(
+            f"Removed {len(actually_removed)} MCP {noun} left over from "
+            f"previously-configured workspaces: {', '.join(actually_removed)}."
+        )
+
+
 def configure_mcp_command() -> int:
     state = load_state()
     workspace = state.get("workspace")
     if not workspace:
         raise RuntimeError("Workspace is not configured. Run `ucode configure` first.")
+
+    purge_cross_workspace_mcp_residue(state, workspace)
 
     installed_clients = available_mcp_clients()
     if not installed_clients:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -646,3 +646,61 @@ class TestConfigureAgentsSelection:
         ]
         assert saved == ["https://first.com"]
         assert configured_tools == [("https://first.com", ["codex"])]
+
+
+class TestConfigureSharedStateMcpCleanup:
+    """A workspace switch should scrub the previous workspace's MCP entries from
+    installed client configs. Switching to the same workspace must not."""
+
+    @staticmethod
+    def _stub_external_deps(monkeypatch):
+        import ucode.cli as cli_mod
+
+        monkeypatch.setattr(cli_mod, "normalize_workspace_url", lambda w: w)
+        monkeypatch.setattr(cli_mod, "run_databricks_login", lambda w, p: None)
+        monkeypatch.setattr(cli_mod, "ensure_databricks_auth", lambda w, p=None: None)
+        monkeypatch.setattr(cli_mod, "find_profile_name_for_host", lambda w: None)
+        monkeypatch.setattr(cli_mod, "get_databricks_token", lambda w, p: "token")
+        monkeypatch.setattr(cli_mod, "ensure_ai_gateway_v2", lambda w, t: None)
+        monkeypatch.setattr(cli_mod, "discover_claude_models", lambda w, t: ({}, None))
+        monkeypatch.setattr(cli_mod, "discover_gemini_models", lambda w, t: ([], None))
+        monkeypatch.setattr(cli_mod, "discover_codex_models", lambda w, t: ([], None))
+        monkeypatch.setattr(cli_mod, "build_shared_base_urls", lambda w: {})
+
+    def test_purges_residue_when_workspace_changes(self, monkeypatch):
+        import ucode.cli as cli_mod
+
+        self._stub_external_deps(monkeypatch)
+        monkeypatch.setattr(
+            cli_mod, "load_state", lambda: {"workspace": "https://old.databricks.com"}
+        )
+        purge_calls: list[tuple[dict, str]] = []
+        monkeypatch.setattr(
+            cli_mod,
+            "purge_cross_workspace_mcp_residue",
+            lambda state, workspace: purge_calls.append((state, workspace)),
+        )
+
+        cli_mod.configure_shared_state("https://new.databricks.com")
+
+        assert len(purge_calls) == 1
+        _, called_workspace = purge_calls[0]
+        assert called_workspace == "https://new.databricks.com"
+
+    def test_skips_purge_when_workspace_unchanged(self, monkeypatch):
+        import ucode.cli as cli_mod
+
+        self._stub_external_deps(monkeypatch)
+        monkeypatch.setattr(
+            cli_mod, "load_state", lambda: {"workspace": "https://same.databricks.com"}
+        )
+        purge_calls: list = []
+        monkeypatch.setattr(
+            cli_mod,
+            "purge_cross_workspace_mcp_residue",
+            lambda state, workspace: purge_calls.append((state, workspace)),
+        )
+
+        cli_mod.configure_shared_state("https://same.databricks.com")
+
+        assert purge_calls == []

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -610,6 +610,171 @@ class TestConfigureMcpCommand:
         assert "space to toggle" in output
         assert saved_states == []
 
+    def test_drops_stale_foreign_workspace_mcp_entries(self, monkeypatch, capsys):
+        saved_states: list[dict] = []
+        cleanup_calls: list[tuple[str, str]] = []
+        other_ws = "https://other-workspace.cloud.databricks.com"
+        stale_entry = {
+            "name": "databricks-genie-foreign",
+            "url": f"{other_ws}/api/2.0/mcp/genie/foreign",
+            "auth": "env:OAUTH_TOKEN",
+            "clients": ["claude", "codex"],
+        }
+        kept_entry = {
+            "name": "databricks-sql",
+            "url": f"{WS}/api/2.0/mcp/sql",
+            "auth": "env:OAUTH_TOKEN",
+            "clients": ["claude"],
+        }
+
+        monkeypatch.setattr(
+            mcp,
+            "load_state",
+            lambda: {
+                "workspace": WS,
+                "available_tools": ["claude"],
+                "mcp_servers": [stale_entry, kept_entry],
+            },
+        )
+        monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+        monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace, profile=None: None)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
+        monkeypatch.setattr(
+            mcp, "discover_external_mcp_connection_names", lambda workspace, profile=None: []
+        )
+        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace, profile=None: [])
+        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace, profile=None: [])
+        _patch_mcp_choices(monkeypatch, "databricks-sql")
+        monkeypatch.setattr(
+            mcp,
+            "remove_client_mcp_server",
+            lambda client, name: cleanup_calls.append((client, name)) or [],
+        )
+        monkeypatch.setattr(mcp, "save_state", lambda state: saved_states.append(state.copy()))
+
+        assert mcp.configure_mcp_command() == 0
+
+        output = capsys.readouterr().out
+        assert "Dropping 1 stale MCP entry" in output
+        assert "databricks-genie-foreign" in output
+        # codex is listed on the stale entry but not installed -> skipped.
+        assert cleanup_calls == [("claude", "databricks-genie-foreign")]
+        assert saved_states, "expected sanitized state to be persisted"
+        assert saved_states[0]["mcp_servers"] == [kept_entry]
+
+    def test_removes_orphan_mcp_entries_from_other_workspace_buckets(self, monkeypatch, capsys):
+        saved_states: list[dict] = []
+        cleanup_calls: list[tuple[str, str]] = []
+        other_ws = "https://other-workspace.cloud.databricks.com"
+        current_entry = {
+            "name": "databricks-sql",
+            "url": f"{WS}/api/2.0/mcp/sql",
+            "auth": "env:OAUTH_TOKEN",
+            "clients": ["claude"],
+        }
+        orphan_entry = {
+            "name": "orphan-mcp",
+            "url": f"{other_ws}/api/2.0/mcp/external/orphan-mcp",
+            "auth": "env:OAUTH_TOKEN",
+            "clients": ["claude", "codex"],
+        }
+
+        monkeypatch.setattr(
+            mcp,
+            "load_state",
+            lambda: {
+                "workspace": WS,
+                "available_tools": ["claude"],
+                "mcp_servers": [current_entry],
+            },
+        )
+        monkeypatch.setattr(
+            mcp,
+            "load_full_state",
+            lambda: {
+                "current_workspace": WS,
+                "workspaces": {
+                    WS: {"mcp_servers": [current_entry]},
+                    other_ws: {"mcp_servers": [orphan_entry]},
+                },
+            },
+        )
+        monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+        monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace, profile=None: None)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
+        monkeypatch.setattr(
+            mcp, "discover_external_mcp_connection_names", lambda workspace, profile=None: []
+        )
+        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace, profile=None: [])
+        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace, profile=None: [])
+        _patch_mcp_choices(monkeypatch, "databricks-sql")
+        monkeypatch.setattr(
+            mcp,
+            "remove_client_mcp_server",
+            lambda client, name: cleanup_calls.append((client, name)) or [mcp.MCP_USER_SCOPE],
+        )
+        monkeypatch.setattr(mcp, "save_state", lambda state: saved_states.append(state.copy()))
+
+        assert mcp.configure_mcp_command() == 0
+
+        output = capsys.readouterr().out
+        assert "left over from previously-configured workspaces" in output
+        assert "orphan-mcp" in output
+        # codex was in orphan-mcp's clients but isn't installed -> skipped.
+        assert cleanup_calls == [("claude", "orphan-mcp")]
+
+    def test_skips_orphan_warning_when_nothing_was_actually_removed(self, monkeypatch, capsys):
+        """Re-running configure mcp on the same workspace shouldn't repeat the warning
+        if the leftover entries were already removed by a previous run."""
+        cleanup_calls: list[tuple[str, str]] = []
+        other_ws = "https://other-workspace.cloud.databricks.com"
+        orphan_entry = {
+            "name": "orphan-mcp",
+            "url": f"{other_ws}/api/2.0/mcp/external/orphan-mcp",
+            "auth": "env:OAUTH_TOKEN",
+            "clients": ["claude"],
+        }
+
+        monkeypatch.setattr(
+            mcp,
+            "load_state",
+            lambda: {"workspace": WS, "available_tools": ["claude"]},
+        )
+        monkeypatch.setattr(
+            mcp,
+            "load_full_state",
+            lambda: {
+                "current_workspace": WS,
+                "workspaces": {
+                    WS: {},
+                    other_ws: {"mcp_servers": [orphan_entry]},
+                },
+            },
+        )
+        monkeypatch.setattr(mcp.shutil, "which", lambda binary: f"/usr/bin/{binary}")
+        monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace, profile=None: None)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
+        monkeypatch.setattr(
+            mcp, "discover_external_mcp_connection_names", lambda workspace, profile=None: []
+        )
+        monkeypatch.setattr(mcp, "discover_genie_mcp_servers", lambda workspace, profile=None: [])
+        monkeypatch.setattr(mcp, "discover_app_mcp_servers", lambda workspace, profile=None: [])
+        _patch_mcp_choices(monkeypatch)
+        # Stub returns empty list -> "entry wasn't in this agent's config".
+        monkeypatch.setattr(
+            mcp,
+            "remove_client_mcp_server",
+            lambda client, name: cleanup_calls.append((client, name)) or [],
+        )
+        monkeypatch.setattr(mcp, "save_state", lambda state: None)
+
+        assert mcp.configure_mcp_command() == 0
+
+        output = capsys.readouterr().out
+        assert "left over from previously-configured workspaces" not in output
+        # The removal attempt was still made (cheap and safe); we just don't announce it.
+        assert cleanup_calls == [("claude", "orphan-mcp")]
+
     def test_warns_when_app_selection_is_no_longer_discoverable(self, monkeypatch, capsys):
         saved_states: list[dict] = []
         configured: list[tuple[str, str, str, dict]] = []


### PR DESCRIPTION
## Summary

Fixes #110. After switching Databricks workspaces in ucode, agent configs (`~/.claude.json`, `~/.codex/...`, etc.) used to keep MCP entries pointing at the previous workspace until the user explicitly re-ran `ucode configure mcp`. This PR scrubs them automatically.

## What Changed

- New helper `purge_cross_workspace_mcp_residue(state, workspace)` in `mcp.py` runs two passes:
  1. Drops entries from `state["mcp_servers"]` whose URL host doesn't match the current workspace and unregisters them from installed clients.
  2. Removes MCP names tracked only in *other* workspaces' state buckets from installed clients (idempotent — re-runs stay quiet once configs are clean).
- Called from two places:
  - `configure_mcp_command` — heals state pollution from before this fix existed.
  - `configure_shared_state` — runs on every workspace switch, so users no longer need a follow-up `configure mcp` to reconcile agent configs.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check src/ tests/`
- [x] `uv run pytest --ignore=tests/test_e2e.py`
- New focused tests in `tests/test_mcp.py` cover both cleanup passes and the idempotency case.
- New tests in `tests/test_cli.py` verify the switch-time trigger fires only when the workspace actually changes.
