### PR TITLE
Show profile name alongside workspace URL in picker

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -815,6 +815,11 @@ def list_profile_entries() -> list[dict]:
     """Return raw profile dicts ({"name", "host", "auth_type", ...}) from
     `databricks auth profiles`.
 
+    Each non-PAT profile is returned individually — duplicate hosts (multiple
+    profiles pointing at the same workspace) appear as separate entries so the
+    workspace picker can offer each profile by name. Order matches the CLI's
+    own ordering.
+
     Returns ``[]`` on any failure (CLI missing, timeout, non-zero exit, JSON
     decode error). When ``UCODE_DEBUG=1`` each dropout path logs *why* the
     result was empty so a silently-disappearing workspace picker is
@@ -846,8 +851,7 @@ def get_databricks_profiles() -> list[tuple[str, str]]:
     """Return [(host_url, profile_name), ...] from Databricks CLI profiles."""
     profiles = list_profile_entries()
 
-    # dict dedupes by host (first non-PAT profile wins).
-    out: dict[str, str] = {}
+    out: list[tuple[str, str]] = []
     pat = 0
     for p in profiles:
         host = (p.get("host") or "").rstrip("/")
@@ -857,13 +861,13 @@ def get_databricks_profiles() -> list[tuple[str, str]]:
         if p.get("auth_type") == "pat":
             pat += 1
             continue
-        out.setdefault(host, name)
+        out.append((host, name))
 
     _debug(
         "get_databricks_profiles",
         f"returned={len(out)} total={len(profiles)} pat={pat}",
     )
-    return list(out.items())
+    return out
 
 
 def find_profile_name_for_host(workspace: str) -> str | None:

--- a/src/ucode/ui.py
+++ b/src/ucode/ui.py
@@ -305,26 +305,34 @@ def prompt_for_workspace(
     """Ask the user for a workspace URL, offering profiles as quick-select.
 
     `profiles` is a list of (host_url, profile_name) tuples. Caller fetches
-    them — `ui.py` stays Databricks-agnostic. Returns ``(url, profile_name)``;
-    profile_name is ``None`` when the user typed a URL manually.
+    them — `ui.py` stays Databricks-agnostic. Duplicate hosts (multiple
+    profiles pointing at the same workspace) are shown separately; the picker
+    returns the exact (host, profile_name) the user selected. Returns
+    ``(url, profile_name)``; profile_name is ``None`` when the user typed a
+    URL manually.
     """
     console.print()
     console.print(Panel(description, title="ucode setup", style="bold blue", expand=False))
 
     if profiles:
-        choices = [
-            questionary.Choice(
-                title=f"{host}  ({profile_name})",
-                value=(host, profile_name),
-            )
-            for host, profile_name in profiles
+        name_header = "Profile Name"
+        url_header = "Workspace URL"
+        name_width = max(len(name_header), *(len(name) for _, name in profiles))
+        # Match the 2-char cursor gutter so the header line aligns with rows.
+        header_title = f"  {name_header.ljust(name_width)}  {url_header}"
+        choices: list[questionary.Choice | questionary.Separator] = [
+            questionary.Separator(header_title)
         ]
+        for host, profile_name in profiles:
+            row_title = f"{profile_name.ljust(name_width)}  {host}"
+            choices.append(questionary.Choice(title=row_title, value=(host, profile_name)))
         choices.append(questionary.Choice(title="Enter a different URL", value=None))
         style = questionary.Style(
             [
                 ("highlighted", "fg:cyan bold"),
                 ("pointer", "fg:cyan bold"),
                 ("answer", "fg:cyan"),
+                ("separator", "fg:white bold"),
             ]
         )
         choice = questionary.select(

--- a/src/ucode/ui.py
+++ b/src/ucode/ui.py
@@ -317,14 +317,28 @@ def prompt_for_workspace(
     if profiles:
         name_header = "Profile Name"
         url_header = "Workspace URL"
-        name_width = max(len(name_header), *(len(name) for _, name in profiles))
+        # Clamp so a single very long profile name can't push the URL column
+        # off-screen on an 80-col terminal — questionary doesn't wrap row
+        # titles cleanly, and a wrapped row breaks the picker visually.
+        max_name_width = 40
+        name_width = min(
+            max_name_width,
+            max(len(name_header), *(len(name) for _, name in profiles)),
+        )
         # Match the 2-char cursor gutter so the header line aligns with rows.
         header_title = f"  {name_header.ljust(name_width)}  {url_header}"
         choices: list[questionary.Choice | questionary.Separator] = [
             questionary.Separator(header_title)
         ]
         for host, profile_name in profiles:
-            row_title = f"{profile_name.ljust(name_width)}  {host}"
+            display_name = (
+                profile_name
+                if len(profile_name) <= name_width
+                else profile_name[: name_width - 1] + "…"
+            )
+            row_title = f"{display_name.ljust(name_width)}  {host}"
+            # Value carries the full untruncated profile name so downstream
+            # `--profile` calls always use the real name, not the display form.
             choices.append(questionary.Choice(title=row_title, value=(host, profile_name)))
         choices.append(questionary.Choice(title="Enter a different URL", value=None))
         style = questionary.Style(
@@ -345,9 +359,17 @@ def prompt_for_workspace(
     while True:
         raw_value = console.input(f"  [bold]Workspace URL[/bold] {muted('›')} ").strip()
         try:
-            return normalize_workspace_url(raw_value), None
+            url = normalize_workspace_url(raw_value)
         except ValueError as exc:
             print_err(str(exc))
+            continue
+        # If the typed URL matches exactly one known profile, attach it so
+        # downstream `--profile` calls resolve unambiguously. Multi-match
+        # cases stay on the existing host-based fallback to avoid silently
+        # picking the wrong profile.
+        matches = [name for host, name in (profiles or []) if host == url]
+        matched_profile = matches[0] if len(matches) == 1 else None
+        return url, matched_profile
 
 
 def prompt_for_tools(

--- a/src/ucode/ui.py
+++ b/src/ucode/ui.py
@@ -359,17 +359,9 @@ def prompt_for_workspace(
     while True:
         raw_value = console.input(f"  [bold]Workspace URL[/bold] {muted('›')} ").strip()
         try:
-            url = normalize_workspace_url(raw_value)
+            return normalize_workspace_url(raw_value), None
         except ValueError as exc:
             print_err(str(exc))
-            continue
-        # If the typed URL matches exactly one known profile, attach it so
-        # downstream `--profile` calls resolve unambiguously. Multi-match
-        # cases stay on the existing host-based fallback to avoid silently
-        # picking the wrong profile.
-        matches = [name for host, name in (profiles or []) if host == url]
-        matched_profile = matches[0] if len(matches) == 1 else None
-        return url, matched_profile
 
 
 def prompt_for_tools(

--- a/src/ucode/ui.py
+++ b/src/ucode/ui.py
@@ -313,7 +313,10 @@ def prompt_for_workspace(
 
     if profiles:
         choices = [
-            questionary.Choice(title=host, value=(host, profile_name))
+            questionary.Choice(
+                title=f"{host}  ({profile_name})",
+                value=(host, profile_name),
+            )
             for host, profile_name in profiles
         ]
         choices.append(questionary.Choice(title="Enter a different URL", value=None))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1447,6 +1447,39 @@ class TestConfigureAgentsSelection:
         with pytest.raises(RuntimeError, match="Codex"):
             cli_mod.configure_workspace_command(selected_tools=["claude", "codex"])
 
+    def test_picker_selected_profile_flows_to_configure_shared_state(self, monkeypatch):
+        """Picker's (host, profile) tuple must reach configure_shared_state's
+        `profile` kwarg, otherwise downstream --profile calls fall back to
+        host-based resolution and silently pick the wrong profile."""
+        import ucode.cli as cli_mod
+
+        monkeypatch.setattr(
+            cli_mod,
+            "_prompt_for_configuration",
+            lambda tool=None: ("https://shared.cloud.databricks.com", "picked-profile"),
+        )
+        captured: dict = {}
+
+        def fake_configure_shared_state(workspace, profile=None, tools=None, force_login=False):
+            captured["workspace"] = workspace
+            captured["profile"] = profile
+            return {**MINIMAL_STATE, "workspace": workspace, "profile": profile}
+
+        monkeypatch.setattr(cli_mod, "configure_shared_state", fake_configure_shared_state)
+        monkeypatch.setattr(cli_mod, "save_state", lambda state: None)
+        monkeypatch.setattr(cli_mod, "check_gateway_endpoint", lambda state, tool: True)
+        monkeypatch.setattr(cli_mod, "prompt_for_tools", lambda available: ["claude"])
+        monkeypatch.setattr(cli_mod, "install_tool_binary", lambda *args, **kwargs: True)
+        monkeypatch.setattr(
+            cli_mod,
+            "configure_selected_tools",
+            lambda state, tools: {**state, "available_tools": tools},
+        )
+        monkeypatch.setattr(cli_mod, "validate_all_tools", lambda state: None)
+
+        assert cli_mod.configure_workspace_command() == 0
+        assert captured["profile"] == "picked-profile"
+
     def test_multiple_workspaces_configure_all_and_use_first(self, monkeypatch):
         import ucode.cli as cli_mod
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1460,7 +1460,15 @@ class TestConfigureAgentsSelection:
         )
         captured: dict = {}
 
-        def fake_configure_shared_state(workspace, profile=None, tools=None, force_login=False):
+        def fake_configure_shared_state(
+            workspace,
+            profile=None,
+            tools=None,
+            force_login=False,
+            use_pat=False,
+            fable_enabled=None,
+            databricks_ai_tools_enabled=None,
+        ):
             captured["workspace"] = workspace
             captured["profile"] = profile
             return {**MINIMAL_STATE, "workspace": workspace, "profile": profile}
@@ -1469,6 +1477,7 @@ class TestConfigureAgentsSelection:
         monkeypatch.setattr(cli_mod, "save_state", lambda state: None)
         monkeypatch.setattr(cli_mod, "check_gateway_endpoint", lambda state, tool: True)
         monkeypatch.setattr(cli_mod, "prompt_for_tools", lambda available: ["claude"])
+        monkeypatch.setattr(cli_mod, "_maybe_select_provider_service", lambda tool, state: state)
         monkeypatch.setattr(cli_mod, "install_tool_binary", lambda *args, **kwargs: True)
         monkeypatch.setattr(
             cli_mod,

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -31,6 +31,7 @@ from ucode.databricks import (
     discover_sql_warehouses,
     ensure_databricks_cli_version,
     ensure_pat_bearer,
+    get_databricks_profiles,
     get_databricks_token,
     install_ai_tools,
     list_databricks_apps,
@@ -1488,6 +1489,63 @@ class TestGetDatabricksToken:
         assert "stale or invalid" in message
         assert "databricks auth logout --profile example-profile" in message
         assert f"databricks auth login --host {WS} --profile example-profile" in message
+
+
+class TestGetDatabricksProfiles:
+    def _patched_run(self, monkeypatch, payload: dict, returncode: int = 0) -> None:
+        def fake_run(args, **kwargs):
+            return subprocess.CompletedProcess(args, returncode, stdout=json.dumps(payload))
+
+        monkeypatch.setattr(db_mod, "run", fake_run)
+
+    def test_keeps_duplicate_hosts_as_separate_entries(self, monkeypatch):
+        self._patched_run(
+            monkeypatch,
+            {
+                "profiles": [
+                    {"host": WS, "name": "first", "auth_type": "databricks-cli"},
+                    {"host": WS, "name": "second", "auth_type": "databricks-cli"},
+                    {
+                        "host": "https://other.databricks.com",
+                        "name": "third",
+                        "auth_type": "databricks-cli",
+                    },
+                ]
+            },
+        )
+        profiles = get_databricks_profiles()
+        assert profiles == [
+            (WS, "first"),
+            (WS, "second"),
+            ("https://other.databricks.com", "third"),
+        ]
+
+    def test_skips_pat_profiles(self, monkeypatch):
+        self._patched_run(
+            monkeypatch,
+            {
+                "profiles": [
+                    {"host": WS, "name": "oauth", "auth_type": "databricks-cli"},
+                    {"host": WS, "name": "tokenized", "auth_type": "pat"},
+                ]
+            },
+        )
+        assert get_databricks_profiles() == [(WS, "oauth")]
+
+    def test_strips_trailing_slash_on_host(self, monkeypatch):
+        self._patched_run(
+            monkeypatch,
+            {
+                "profiles": [
+                    {"host": f"{WS}/", "name": "p", "auth_type": "databricks-cli"},
+                ]
+            },
+        )
+        assert get_databricks_profiles() == [(WS, "p")]
+
+    def test_returns_empty_on_non_zero_exit(self, monkeypatch):
+        self._patched_run(monkeypatch, {"profiles": []}, returncode=1)
+        assert get_databricks_profiles() == []
 
 
 class TestListDatabricksConnections:

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -422,6 +422,75 @@ class TestPromptForWorkspace:
         assert url == "https://example.cloud.databricks.com"
         assert profile == "p"
 
+    # ------------------------------------------------------------------
+    # Long-name display clamping (PR #114 review feedback)
+    # ------------------------------------------------------------------
+
+    def test_long_profile_name_is_truncated_in_display_only(self, monkeypatch):
+        # 60-char name — exceeds the 40-char clamp. The displayed row title
+        # must be truncated with an ellipsis but the value tuple must carry
+        # the full untruncated name through to configure_shared_state.
+        long_name = "x" * 60
+        profiles = [("https://a.cloud.databricks.com", long_name)]
+        captured = self._capture_select(monkeypatch, answer=profiles[0])
+        url, profile = prompt_for_workspace("setup", profiles)
+
+        assert (url, profile) == profiles[0]
+        choices = captured["choices"]
+        # Header + 1 row + "Enter a different URL".
+        assert len(choices) == 3
+        # Display title is truncated to 40 chars (39 of name + "…").
+        row_title = choices[1].title
+        assert long_name not in row_title
+        assert "…" in row_title
+        # Value tuple still carries the full name.
+        assert choices[1].value == profiles[0]
+
+    # ------------------------------------------------------------------
+    # Typed-URL → known-profile match (PR #114 review feedback)
+    # ------------------------------------------------------------------
+
+    def test_typed_url_matching_single_profile_returns_that_profile(self):
+        profiles = [
+            ("https://a.cloud.databricks.com", "prof-a"),
+            ("https://b.cloud.databricks.com", "prof-b"),
+        ]
+        with (
+            patch("ucode.ui.questionary.select") as mock_select,
+            patch("ucode.ui.console.input", return_value="https://a.cloud.databricks.com"),
+        ):
+            mock_select.return_value.ask.return_value = None  # falls through to manual
+            url, profile = prompt_for_workspace("desc", profiles=profiles)
+        assert url == "https://a.cloud.databricks.com"
+        assert profile == "prof-a"
+
+    def test_typed_url_matching_multiple_profiles_returns_none(self):
+        # When the typed URL matches multiple profiles, we can't safely
+        # auto-pick one — fall through to host-based resolution downstream.
+        profiles = [
+            ("https://shared.cloud.databricks.com", "first"),
+            ("https://shared.cloud.databricks.com", "second"),
+        ]
+        with (
+            patch("ucode.ui.questionary.select") as mock_select,
+            patch("ucode.ui.console.input", return_value="https://shared.cloud.databricks.com"),
+        ):
+            mock_select.return_value.ask.return_value = None
+            url, profile = prompt_for_workspace("desc", profiles=profiles)
+        assert url == "https://shared.cloud.databricks.com"
+        assert profile is None
+
+    def test_typed_url_with_no_matching_profile_returns_none(self):
+        profiles = [("https://a.cloud.databricks.com", "prof-a")]
+        with (
+            patch("ucode.ui.questionary.select") as mock_select,
+            patch("ucode.ui.console.input", return_value="https://other.databricks.com"),
+        ):
+            mock_select.return_value.ask.return_value = None
+            url, profile = prompt_for_workspace("desc", profiles=profiles)
+        assert url == "https://other.databricks.com"
+        assert profile is None
+
 
 class TestFormatUsd:
     def test_rounds_to_cents(self):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -446,51 +446,6 @@ class TestPromptForWorkspace:
         # Value tuple still carries the full name.
         assert choices[1].value == profiles[0]
 
-    # ------------------------------------------------------------------
-    # Typed-URL → known-profile match (PR #114 review feedback)
-    # ------------------------------------------------------------------
-
-    def test_typed_url_matching_single_profile_returns_that_profile(self):
-        profiles = [
-            ("https://a.cloud.databricks.com", "prof-a"),
-            ("https://b.cloud.databricks.com", "prof-b"),
-        ]
-        with (
-            patch("ucode.ui.questionary.select") as mock_select,
-            patch("ucode.ui.console.input", return_value="https://a.cloud.databricks.com"),
-        ):
-            mock_select.return_value.ask.return_value = None  # falls through to manual
-            url, profile = prompt_for_workspace("desc", profiles=profiles)
-        assert url == "https://a.cloud.databricks.com"
-        assert profile == "prof-a"
-
-    def test_typed_url_matching_multiple_profiles_returns_none(self):
-        # When the typed URL matches multiple profiles, we can't safely
-        # auto-pick one — fall through to host-based resolution downstream.
-        profiles = [
-            ("https://shared.cloud.databricks.com", "first"),
-            ("https://shared.cloud.databricks.com", "second"),
-        ]
-        with (
-            patch("ucode.ui.questionary.select") as mock_select,
-            patch("ucode.ui.console.input", return_value="https://shared.cloud.databricks.com"),
-        ):
-            mock_select.return_value.ask.return_value = None
-            url, profile = prompt_for_workspace("desc", profiles=profiles)
-        assert url == "https://shared.cloud.databricks.com"
-        assert profile is None
-
-    def test_typed_url_with_no_matching_profile_returns_none(self):
-        profiles = [("https://a.cloud.databricks.com", "prof-a")]
-        with (
-            patch("ucode.ui.questionary.select") as mock_select,
-            patch("ucode.ui.console.input", return_value="https://other.databricks.com"),
-        ):
-            mock_select.return_value.ask.return_value = None
-            url, profile = prompt_for_workspace("desc", profiles=profiles)
-        assert url == "https://other.databricks.com"
-        assert profile is None
-
 
 class TestFormatUsd:
     def test_rounds_to_cents(self):

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -8,8 +8,10 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
+import questionary
 from rich.console import Console
 
+from ucode import ui as ui_mod
 from ucode.ui import (
     format_duration,
     format_meter,
@@ -298,7 +300,7 @@ class TestRenderBoxTable:
         assert "-" in result
 
 
-class TestPromptForWorkspace:
+class TestPromptForWorkspaceFallbacks:
     """Cover the three things `questionary.select(...).ask()` can return:
     a (host, profile) tuple, None (cancel or "Enter a different URL"),
     or — in some questionary versions — the choice's title string."""
@@ -342,6 +344,83 @@ class TestPromptForWorkspace:
             url, profile = prompt_for_workspace("desc", profiles=None)
         assert url == "https://example.databricks.com"
         assert profile is None
+
+
+class _StubQuestion:
+    def __init__(self, answer):
+        self._answer = answer
+
+    def ask(self):
+        return self._answer
+
+
+class TestPromptForWorkspace:
+    """Capture the choices passed to ``questionary.select`` so we can assert on
+    layout (header alignment + duplicate-host preservation) without driving
+    real keyboard I/O."""
+
+    def _capture_select(self, monkeypatch, answer):
+        captured: dict = {}
+
+        def fake_select(message, choices, **kwargs):
+            captured["message"] = message
+            captured["choices"] = choices
+            captured["kwargs"] = kwargs
+            return _StubQuestion(answer)
+
+        monkeypatch.setattr(questionary, "select", fake_select)
+        monkeypatch.setattr(ui_mod.questionary, "select", fake_select)
+        return captured
+
+    def test_shows_header_and_each_profile_row(self, monkeypatch):
+        profiles = [
+            ("https://a.cloud.databricks.com", "alpha"),
+            ("https://b.cloud.databricks.com", "beta-profile-name"),
+        ]
+        captured = self._capture_select(monkeypatch, answer=profiles[0])
+        url, profile = prompt_for_workspace("setup", profiles)
+
+        assert (url, profile) == profiles[0]
+        choices = captured["choices"]
+        # Header (separator), 2 rows, "Enter a different URL" entry.
+        assert len(choices) == 4
+        assert isinstance(choices[0], questionary.Separator)
+        header = choices[0].title
+        assert "Profile Name" in header
+        assert "Workspace URL" in header
+        # Profile names ljust-padded to the longest name (17 chars).
+        name_width = max(len(name) for _, name in profiles)
+        assert "alpha".ljust(name_width) in choices[1].title
+        assert profiles[0][0] in choices[1].title
+        assert "beta-profile-name".ljust(name_width) in choices[2].title
+        assert profiles[1][0] in choices[2].title
+        # Final fallback entry still present.
+        assert choices[3].title == "Enter a different URL"
+
+    def test_keeps_duplicate_hosts_as_separate_rows(self, monkeypatch):
+        profiles = [
+            ("https://shared.cloud.databricks.com", "first"),
+            ("https://shared.cloud.databricks.com", "second"),
+        ]
+        captured = self._capture_select(monkeypatch, answer=profiles[1])
+        url, profile = prompt_for_workspace("setup", profiles)
+
+        assert (url, profile) == profiles[1]
+        # Both rows present — duplicates not collapsed.
+        choices = captured["choices"]
+        # Filter to choices whose value is a (host, profile) tuple — drops the
+        # header separator and the trailing "Enter a different URL" entry.
+        host_choices = [c for c in choices if isinstance(getattr(c, "value", None), tuple)]
+        assert [c.value for c in host_choices] == profiles
+
+    def test_returns_normalized_url_with_profile(self, monkeypatch):
+        # Picker handed back a URL with a trailing slash — normalize_workspace_url
+        # should strip it before returning.
+        profiles = [("https://example.cloud.databricks.com/", "p")]
+        self._capture_select(monkeypatch, answer=profiles[0])
+        url, profile = prompt_for_workspace("setup", profiles)
+        assert url == "https://example.cloud.databricks.com"
+        assert profile == "p"
 
 
 class TestFormatUsd:


### PR DESCRIPTION
## Summary

Reworks the workspace picker shown during `ucode configure` / first launch so it mirrors the layout of `databricks auth profiles` (without the `Valid` column) and so the *exact* profile the user selects is what later `databricks` CLI calls use.

## Changes:
- **Remove deduping of profiles by host.** `get_databricks_profiles()` previously collapsed multiple profiles pointing at the same workspace down to the first match. It now returns one row per non-PAT profile, so each profile is selectable.
- **2-column picker with header.** `prompt_for_workspace()` renders a `Profile Name` / `Workspace URL` header via `questionary.Separator` and ljust-pads the profile names so columns line up.
- **Pass the chosen profile through.** The picker already returns `(host, profile_name)`; that tuple now travels through `configure_shared_state(profile=…)` into `state.json` and into every `--profile`-bearing CLI invocation. Previously, when a host had multiple profiles, downstream code fell back to "first profile for host" via `find_profile_name_for_host`, now this is determined solely by the user's selection

Before:
```
› https://workspace-a.cloud.databricks.com
  https://workspace-b.cloud.databricks.com
  https://workspace-c.cloud.databricks.com
  Enter a different URL
```
(only one row per host even when several profiles target it)

After:
```
    Profile Name        Workspace URL
›   profile-one         https://workspace-a.cloud.databricks.com
    profile-two         https://workspace-a.cloud.databricks.com
    profile-three       https://workspace-a.cloud.databricks.com
    profile-four        https://workspace-b.cloud.databricks.com
    profile-five        https://workspace-c.cloud.databricks.com
    Enter a different URL
```

## Test plan

- [x] `uv run pytest` (546 passed / 28 skipped) — adds `TestGetDatabricksProfiles` (duplicate-host preservation, PAT skip, trailing-slash strip, non-zero-exit) and `TestPromptForWorkspace` (header rendering, duplicate-host preservation, URL normalization).
- [x] `uv run ruff check .` clean.
- [x] `uv run ucode configure` — visually verify column alignment and that all profiles for a duplicated host show up.
- [x] Pick a non-default profile for a host that has multiple, then `uv run ucode status` — confirm `CLI profile` matches the selection (and `~/.ucode/state.json` `profile` key matches).
- [x] `uv run ucode revert && uv run ucode claude` — same picker fires on the launch path.

This pull request and its description were written by Isaac.