### PR TITLE
Exclude databricks-claude-opus-4-8 from Claude model discovery

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -804,6 +804,14 @@ def build_auth_shell_command(workspace: str, profile: str | None = None) -> str:
     )
 
 
+# Model ids the AI Gateway advertises but currently rejects at launch with
+# "The provided model identifier is invalid." Filter them out at discovery so
+# agent harnesses don't try to boot with them.
+_CLAUDE_MODEL_DISCOVERY_DENYLIST = {
+    "databricks-claude-opus-4-8",
+}
+
+
 def discover_claude_models(workspace: str, token: str) -> tuple[dict[str, str], str | None]:
     """Discover Claude families on this workspace's AI Gateway.
 
@@ -820,7 +828,9 @@ def discover_claude_models(workspace: str, token: str) -> tuple[dict[str, str], 
     raw_ids = [
         m["id"]
         for m in data.get("data", [])
-        if isinstance(m.get("id"), str) and not m["id"].endswith("-anthropic")
+        if isinstance(m.get("id"), str)
+        and not m["id"].endswith("-anthropic")
+        and m["id"] not in _CLAUDE_MODEL_DISCOVERY_DENYLIST
     ]
 
     result: dict[str, str] = {}

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -93,19 +93,8 @@ def _run_gemini_gateway_smoke(workspace: str, model: str, token: str) -> str:
     return data.get("candidates", [{}])[0].get("content", {}).get("parts", [{}])[0].get("text", "")
 
 
-E2E_EXCLUDED_MODEL_IDS = {
-    # Listed by AI Gateway model discovery, but currently rejected at launch
-    # with "The provided model identifier is invalid."
-    "databricks-claude-opus-4-8",
-}
-
-
 def _launchable_model_items(models: dict) -> list[tuple[str, str]]:
-    return [
-        (family, model_id)
-        for family, model_id in models.items()
-        if model_id and model_id not in E2E_EXCLUDED_MODEL_IDS
-    ]
+    return [(family, model_id) for family, model_id in models.items() if model_id]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The AI Gateway lists opus-4-8 but currently rejects it at launch with "The provided model identifier is invalid.", so filter it out at discovery to pin agent harnesses to opus-4-7.