### PR TITLE
Fix Codex GPT model selection

### DIFF
--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -56,6 +56,8 @@ LEGACY_MANAGED_KEYS: list[list[str]] = [
     ["model_providers", CODEX_MODEL_PROVIDER_NAME, "http_headers"],
 ]
 
+_GPT_RE = re.compile(r"(?:databricks-)?gpt-(\d+)(?:[.-](\d+))?(?:[.-](\d+))?(-.+|[a-z].*)?")
+
 
 def is_update_available() -> tuple[str, str] | None:
     return available_npm_package_update(SPEC["package"])
@@ -179,18 +181,31 @@ def _remove_legacy_ucode_profile() -> None:
 
 def _openai_model_id(model: str | None) -> str | None:
     """Map Databricks GPT endpoint ids to OpenAI model ids for Codex metadata."""
-    if not model:
+    parsed = _parse_gpt(model)
+    if parsed is None:
         return model
-    match = re.fullmatch(r"databricks-gpt-(\d+)(?:-(\d+))?(?:-(\d+))?((?:-.+)?)", model)
-    if not match:
-        return model
-    major, minor, patch, suffix = match.groups()
-    version = major
+    major, minor, patch, suffix = parsed
+    version = str(major)
     if minor is not None:
         version += f".{minor}"
     if patch is not None:
         version += f".{patch}"
-    return f"gpt-{version}{suffix or ''}"
+    return f"gpt-{version}{suffix}"
+
+
+def _parse_gpt(model: str | None) -> tuple[int, int | None, int | None, str] | None:
+    if not model:
+        return None
+    match = _GPT_RE.fullmatch(model.split("/")[-1])
+    if not match:
+        return None
+    major, minor, patch, suffix = match.groups()
+    return (
+        int(major),
+        int(minor) if minor is not None else None,
+        int(patch) if patch is not None else None,
+        suffix or "",
+    )
 
 
 def write_tool_config(state: dict, model: str | None = None) -> dict:
@@ -236,24 +251,14 @@ def default_model(state: dict) -> str | None:
         return None
 
     def _gpt_version_key(mid: str) -> tuple[int, int, int, int]:
-        try:
-            name = mid.split("/")[-1]
-            m = re.search(r"gpt-(\d+)(?:[.-](\d+))?(?:[.-](\d+))?", name)
-            if not m:
-                return (0, 0, 0, 0)
-            major = int(m.group(1) or 0)
-            minor = int(m.group(2) or 0)
-            patch = int(m.group(3) or 0)
-            suffix = name[m.end() :]
-            base_bonus = 1 if not suffix else 0
-            return (major, minor, patch, base_bonus)
-        except Exception:
+        parsed = _parse_gpt(mid)
+        if parsed is None:
             return (0, 0, 0, 0)
+        major, minor, patch, suffix = parsed
+        base_bonus = 1 if not suffix else 0
+        return (major, minor or 0, patch or 0, base_bonus)
 
-    try:
-        return max(codex_models, key=_gpt_version_key)
-    except ValueError:
-        return codex_models[0]
+    return max(codex_models, key=_gpt_version_key)
 
 
 def launch(state: dict, tool_args: list[str]) -> None:

--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -58,6 +58,13 @@ LEGACY_MANAGED_KEYS: list[list[str]] = [
 
 _GPT_RE = re.compile(r"(?:databricks-)?gpt-(\d+)(?:[.-](\d+))?(?:[.-](\d+))?(-.+|[a-z].*)?")
 
+# These models should use the Databricks ID, not the OpenAI ID, as the OpenAI
+# ID is incompatible with Codex.
+CODEX_OPENAI_ID_INCOMPATIBLE_MODELS = {
+    "databricks-gpt-5-2-codex",
+    "databricks-gpt-5-4-nano",
+}
+
 
 def is_update_available() -> tuple[str, str] | None:
     return available_npm_package_update(SPEC["package"])
@@ -193,6 +200,12 @@ def _openai_model_id(model: str | None) -> str | None:
     return f"gpt-{version}{suffix}"
 
 
+def _codex_model_id(model: str | None) -> str | None:
+    if model in CODEX_OPENAI_ID_INCOMPATIBLE_MODELS:
+        return model
+    return _openai_model_id(model)
+
+
 def _parse_gpt(model: str | None) -> tuple[int, int | None, int | None, str] | None:
     if not model:
         return None
@@ -210,7 +223,7 @@ def _parse_gpt(model: str | None) -> tuple[int, int | None, int | None, str] | N
 
 def write_tool_config(state: dict, model: str | None = None) -> dict:
     workspace = state["workspace"]
-    chosen_model = _openai_model_id(model or default_model(state))
+    chosen_model = _codex_model_id(model or default_model(state))
     databricks_profile = state.get("profile")
 
     if _use_legacy_layout():

--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -177,9 +177,25 @@ def _remove_legacy_ucode_profile() -> None:
         write_toml_file(path, doc)
 
 
+def _openai_model_id(model: str | None) -> str | None:
+    """Map Databricks GPT endpoint ids to OpenAI model ids for Codex metadata."""
+    if not model:
+        return model
+    match = re.fullmatch(r"databricks-gpt-(\d+)(?:-(\d+))?(?:-(\d+))?((?:-.+)?)", model)
+    if not match:
+        return model
+    major, minor, patch, suffix = match.groups()
+    version = major
+    if minor is not None:
+        version += f".{minor}"
+    if patch is not None:
+        version += f".{patch}"
+    return f"gpt-{version}{suffix or ''}"
+
+
 def write_tool_config(state: dict, model: str | None = None) -> dict:
     workspace = state["workspace"]
-    chosen_model = model or default_model(state)
+    chosen_model = _openai_model_id(model or default_model(state))
     databricks_profile = state.get("profile")
 
     if _use_legacy_layout():
@@ -208,8 +224,36 @@ def write_tool_config(state: dict, model: str | None = None) -> dict:
 
 
 def default_model(state: dict) -> str | None:
+    """Pick the newest GPT model when multiple are available.
+
+    The discovery list is alphabetically sorted, which can put
+    "databricks-gpt-5" ahead of "databricks-gpt-5-5". Prefer the
+    highest semantic version instead. Falls back to the first
+    discovered entry when parsing fails.
+    """
     codex_models = state.get("codex_models") or []
-    return codex_models[0] if codex_models else None
+    if not codex_models:
+        return None
+
+    def _gpt_version_key(mid: str) -> tuple[int, int, int, int]:
+        try:
+            name = mid.split("/")[-1]
+            m = re.search(r"gpt-(\d+)(?:[.-](\d+))?(?:[.-](\d+))?", name)
+            if not m:
+                return (0, 0, 0, 0)
+            major = int(m.group(1) or 0)
+            minor = int(m.group(2) or 0)
+            patch = int(m.group(3) or 0)
+            suffix = name[m.end() :]
+            base_bonus = 1 if not suffix else 0
+            return (major, minor, patch, base_bonus)
+        except Exception:
+            return (0, 0, 0, 0)
+
+    try:
+        return max(codex_models, key=_gpt_version_key)
+    except ValueError:
+        return codex_models[0]
 
 
 def launch(state: dict, tool_args: list[str]) -> None:

--- a/tests/test_agent_codex.py
+++ b/tests/test_agent_codex.py
@@ -91,6 +91,21 @@ class TestCodexWriteConfig:
         assert doc["model"] == "gpt-5"
         assert "profiles" not in doc
 
+    def test_writes_openai_model_id_for_databricks_gpt_endpoint(self, tmp_path, monkeypatch):
+        config_path = tmp_path / ".codex" / "ucode.config.toml"
+        backup_path = tmp_path / "codex-ucode-config.backup.toml"
+        monkeypatch.setattr(codex, "CODEX_CONFIG_PATH", config_path)
+        monkeypatch.setattr(codex, "CODEX_BACKUP_PATH", backup_path)
+        monkeypatch.setattr(codex, "agent_version", lambda binary: "0.134.0")
+        monkeypatch.setattr(codex, "save_state", lambda state: None)
+
+        codex.write_tool_config(
+            {"workspace": WS, "codex_models": ["databricks-gpt-5", "databricks-gpt-5-5"]}
+        )
+
+        doc = read_toml_safe(config_path)
+        assert doc["model"] == "gpt-5.5"
+
     def test_removes_legacy_ucode_profile_from_shared_config(self, tmp_path, monkeypatch):
         config_dir = tmp_path / ".codex"
         config_dir.mkdir()
@@ -187,11 +202,23 @@ class TestCodexLegacyLayoutDetection:
 
 
 class TestCodexDefaultModel:
-    def test_returns_first_codex_model(self):
-        assert codex.default_model({"codex_models": ["gpt-5", "gpt-4o"]}) == "gpt-5"
+    def test_picks_highest_semver_over_alpha(self):
+        state = {"codex_models": ["databricks-gpt-5", "databricks-gpt-5-5"]}
+
+        assert codex.default_model(state) == "databricks-gpt-5-5"
 
     def test_none_when_no_models(self):
         assert codex.default_model({}) is None
+
+    def test_prefers_base_over_suffixed_same_version(self):
+        models = ["gpt-5-5-mini", "gpt-5-5", "gpt-5"]
+
+        assert codex.default_model({"codex_models": models}) == "gpt-5-5"
+
+    def test_openai_model_id_maps_databricks_naming(self):
+        assert codex._openai_model_id("databricks-gpt-5-5") == "gpt-5.5"
+        assert codex._openai_model_id("databricks-gpt-5-5-mini") == "gpt-5.5-mini"
+        assert codex._openai_model_id("gpt-5.5") == "gpt-5.5"
 
 
 class TestCodexValidateCmd:

--- a/tests/test_agent_codex.py
+++ b/tests/test_agent_codex.py
@@ -106,6 +106,24 @@ class TestCodexWriteConfig:
         doc = read_toml_safe(config_path)
         assert doc["model"] == "gpt-5.5"
 
+    def test_preserves_databricks_model_id_when_openai_id_is_incompatible(
+        self, tmp_path, monkeypatch
+    ):
+        config_path = tmp_path / ".codex" / "ucode.config.toml"
+        backup_path = tmp_path / "codex-ucode-config.backup.toml"
+        monkeypatch.setattr(codex, "CODEX_CONFIG_PATH", config_path)
+        monkeypatch.setattr(codex, "CODEX_BACKUP_PATH", backup_path)
+        monkeypatch.setattr(codex, "agent_version", lambda binary: "0.134.0")
+        monkeypatch.setattr(codex, "save_state", lambda state: None)
+
+        codex.write_tool_config(
+            {"workspace": WS, "codex_models": ["databricks-gpt-5-2-codex"]},
+            "databricks-gpt-5-2-codex",
+        )
+
+        doc = read_toml_safe(config_path)
+        assert doc["model"] == "databricks-gpt-5-2-codex"
+
     def test_removes_legacy_ucode_profile_from_shared_config(self, tmp_path, monkeypatch):
         config_dir = tmp_path / ".codex"
         config_dir.mkdir()
@@ -226,6 +244,11 @@ class TestCodexDefaultModel:
         assert codex._openai_model_id("databricks-gpt-4o") == "gpt-4o"
         assert codex._openai_model_id("served-models/databricks-gpt-5-5") == "gpt-5.5"
         assert codex._openai_model_id("gpt-5.5") == "gpt-5.5"
+
+    def test_codex_model_id_preserves_openai_incompatible_models(self):
+        assert codex._codex_model_id("databricks-gpt-5-2-codex") == "databricks-gpt-5-2-codex"
+        assert codex._codex_model_id("databricks-gpt-5-4-nano") == "databricks-gpt-5-4-nano"
+        assert codex._codex_model_id("databricks-gpt-5-5") == "gpt-5.5"
 
 
 class TestCodexValidateCmd:

--- a/tests/test_agent_codex.py
+++ b/tests/test_agent_codex.py
@@ -215,9 +215,16 @@ class TestCodexDefaultModel:
 
         assert codex.default_model({"codex_models": models}) == "gpt-5-5"
 
+    def test_namespaced_models_use_same_version_parser(self):
+        models = ["served-models/databricks-gpt-5", "served-models/databricks-gpt-5-5"]
+
+        assert codex.default_model({"codex_models": models}) == "served-models/databricks-gpt-5-5"
+
     def test_openai_model_id_maps_databricks_naming(self):
         assert codex._openai_model_id("databricks-gpt-5-5") == "gpt-5.5"
         assert codex._openai_model_id("databricks-gpt-5-5-mini") == "gpt-5.5-mini"
+        assert codex._openai_model_id("databricks-gpt-4o") == "gpt-4o"
+        assert codex._openai_model_id("served-models/databricks-gpt-5-5") == "gpt-5.5"
         assert codex._openai_model_id("gpt-5.5") == "gpt-5.5"
 
 


### PR DESCRIPTION
## Summary

  - Select the highest semantic GPT version for Codex instead of relying on discovery order (before, we were auto choosing gpt-5 instead of gpt-5-5
  - Convert Databricks GPT endpoint IDs like `databricks-gpt-5-5` to OpenAI-style model IDs like `gpt-5.5` in Codex config metadata so we don't get the warning signs
 
before:
<img width="880" height="54" alt="Screenshot 2026-05-28 at 7 50 27 PM" src="https://github.com/user-attachments/assets/d8600d42-f4c7-40e6-ab97-92549f0a3498" />

after:
<img width="507" height="431" alt="Screenshot 2026-05-28 at 7 54 36 PM" src="https://github.com/user-attachments/assets/e02bd7ad-6be5-42b4-aae3-63ed6f136651" />


  ## Tests

  - `uv run pytest tests/test_agent_codex.py`