### PR TITLE
Fix macOS Databricks CLI auto-install to install the correct formula

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -483,7 +483,7 @@ def _run_databricks_cli_installer(brew_subcommand: str = "install") -> None:
                 timeout=240,
             )
         elif system == "Darwin" and shutil.which("brew"):
-            run(["brew", brew_subcommand, "databricks"], timeout=240)
+            run(["brew", brew_subcommand, "databricks/tap/databricks"], timeout=240)
         elif shutil.which("curl"):
             run(["sh", "-c", f"curl -fsSL {UNIX_DATABRICKS_INSTALL_URL} | sudo sh"], timeout=240)
         elif shutil.which("wget"):

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -13,6 +13,7 @@ from ucode.databricks import (
     AI_GATEWAY_V2_DOCS_URL,
     _format_subprocess_result,
     _parse_databricks_cli_version,
+    _run_databricks_cli_installer,
     _scrub_databrickscfg,
     _scrub_json,
     build_auth_shell_command,
@@ -802,6 +803,22 @@ class TestEnsureDatabricksCliVersion:
         monkeypatch.setattr("os.environ", env)
         with pytest.raises(RuntimeError, match="Could not parse"):
             ensure_databricks_cli_version()
+
+
+class TestRunDatabricksCliInstaller:
+    @pytest.mark.parametrize("brew_subcommand", ["install", "upgrade"])
+    def test_macos_uses_fully_qualified_tap_formula(self, monkeypatch, brew_subcommand):
+        calls = []
+        monkeypatch.setattr(db_mod.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(db_mod.shutil, "which", lambda cmd: "/opt/homebrew/bin/brew")
+        monkeypatch.setattr(db_mod, "run", lambda cmd, **kw: calls.append(cmd))
+
+        _run_databricks_cli_installer(brew_subcommand=brew_subcommand)
+
+        # The fully-qualified formula forces Homebrew to the Databricks CLI in
+        # databricks/tap and fails if absent, rather than falling back to the
+        # unrelated `databricks` cask.
+        assert calls == [["brew", brew_subcommand, "databricks/tap/databricks"]]
 
 
 class TestIsUsageTableAccessError:


### PR DESCRIPTION
## What

On the macOS/Homebrew path, the Databricks CLI auto-installer now installs the fully-qualified `databricks/tap/databricks` formula instead of `databricks`.

## Why

`brew install databricks` does not install the Databricks CLI — the CLI is published to the `databricks/tap` tap, not homebrew-core. Without qualifying the tap, `databricks` resolves to an unrelated formula (DataGrip), so the CLI is never installed and later `databricks` calls fail.

Using the fully-qualified formula resolves directly to the Databricks CLI and **fails** if the formula is missing, rather than silently falling back to the cask.

## How

In `_run_databricks_cli_installer`, install `databricks/tap/databricks`, matching the [official Homebrew install steps](https://docs.databricks.com/dev-tools/cli/install.html#homebrew). Covers both the fresh-install and auto-upgrade paths.

## Testing

- `TestRunDatabricksCliInstaller` (parametrized over `install`/`upgrade`) pins that the macOS path invokes `brew <sub> databricks/tap/databricks`.
- `uv run pytest tests/test_databricks.py` — 74 passed.
- `uv run ruff check` — clean.

Closes #144