### PR TITLE
fix gemini mcp registration to write to correct settings.json

### DIFF
--- a/src/ucode/mcp.py
+++ b/src/ucode/mcp.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import string
 import subprocess
@@ -23,7 +24,7 @@ from questionary.prompts.common import InquirerControl
 from questionary.question import Question
 from questionary.styles import merge_styles_default
 
-from ucode.agents import copilot, opencode
+from ucode.agents import copilot, gemini, opencode
 from ucode.config_io import restore_file
 from ucode.databricks import (
     ensure_databricks_auth,
@@ -177,6 +178,13 @@ def remove_codex_mcp_server(name: str) -> bool:
     return True
 
 
+def _gemini_cli_env() -> dict[str, str]:
+    # Pin GEMINI_CLI_HOME to the same directory the launcher.
+    env = os.environ.copy()
+    env["GEMINI_CLI_HOME"] = str(gemini.GEMINI_HOME_DIR)
+    return env
+
+
 def add_gemini_mcp_server(name: str, url: str) -> None:
     try:
         subprocess.run(
@@ -197,6 +205,7 @@ def add_gemini_mcp_server(name: str, url: str) -> None:
             capture_output=True,
             text=True,
             timeout=30,
+            env=_gemini_cli_env(),
         )
     except subprocess.CalledProcessError as exc:
         raise RuntimeError(f"Failed to add MCP server '{name}' via gemini CLI.") from exc
@@ -210,6 +219,7 @@ def remove_gemini_mcp_server(name: str) -> bool:
             capture_output=True,
             text=True,
             timeout=30,
+            env=_gemini_cli_env(),
         )
     except subprocess.TimeoutExpired as exc:
         raise RuntimeError(f"Timed out removing MCP server '{name}' via gemini CLI.") from exc

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -94,29 +94,29 @@ class TestAddGeminiMcpServer:
 
         mcp.add_gemini_mcp_server("github", f"{WS}/api/2.0/mcp/external/github")
 
-        assert calls == [
-            {
-                "args": [
-                    "gemini",
-                    "mcp",
-                    "add",
-                    "github",
-                    f"{WS}/api/2.0/mcp/external/github",
-                    "--type",
-                    "http",
-                    "--scope",
-                    "user",
-                    "--header",
-                    "Authorization: Bearer ${OAUTH_TOKEN}",
-                ],
-                "kwargs": {
-                    "check": True,
-                    "capture_output": True,
-                    "text": True,
-                    "timeout": 30,
-                },
-            }
+        assert len(calls) == 1
+        call = calls[0]
+        assert call["args"] == [
+            "gemini",
+            "mcp",
+            "add",
+            "github",
+            f"{WS}/api/2.0/mcp/external/github",
+            "--type",
+            "http",
+            "--scope",
+            "user",
+            "--header",
+            "Authorization: Bearer ${OAUTH_TOKEN}",
         ]
+        kwargs = call["kwargs"]
+        assert kwargs["check"] is True
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        assert kwargs["timeout"] == 30
+        # GEMINI_CLI_HOME must point at the launcher's home so `gemini mcp
+        # add` writes the same settings.json the ucode session reads from.
+        assert kwargs["env"]["GEMINI_CLI_HOME"] == str(mcp.gemini.GEMINI_HOME_DIR)
 
 
 class TestRemoveClaudeMcpServer:


### PR DESCRIPTION
## Summary

Before:
`ucode configure mcp` would silently register Gemini MCP servers into a file the launcher never reads, so `/mcp` inside `ucode gemini` always showed "No MCP servers configured." even after a successful save.

`add_gemini_mcp_server` / `remove_gemini_mcp_server` ran `gemini mcp add/remove` without setting `GEMINI_CLI_HOME`, so entries went to `$HOME/.gemini/settings.json`. But `agents/gemini.py` launches Gemini with `GEMINI_CLI_HOME=~/.ucode/.gemini-home`, which makes the session read from a different settings.json. The two never intersected.


Fix: pin `GEMINI_CLI_HOME` to the same `gemini.GEMINI_HOME_DIR` for both subprocess calls so registrations write to the file the launcher reads.

## Test plan

- [x] `uv run ruff check src/ucode/mcp.py tests/test_mcp.py`
- [x] `uv run pytest tests/test_mcp.py` (39/39)
- [x] `ucode configure mcp` → select an entry → `ucode gemini` → `/mcp` lists the registered servers and `tools/list` works.
- [x] `~/.ucode/.gemini-home/.gemini/settings.json` contains the new `mcpServers` entries; `~/.gemini/settings.json` is no longer written by ucode.

<img width="726" height="586" alt="Screenshot 2026-06-11 at 5 20 51 PM" src="https://github.com/user-attachments/assets/a441e9ea-c046-4ae8-8039-69015419673e" />

