### PR TITLE
Fix invisible picker rows on light-mode terminals

### DIFF
--- a/src/ucode/mcp.py
+++ b/src/ucode/mcp.py
@@ -464,8 +464,8 @@ def _picker_style() -> questionary.Style:
     return questionary.Style(
         [
             ("pointer", "fg:cyan bold"),
-            ("highlighted", "fg:white noinherit"),
-            ("selected", "fg:white noinherit"),
+            ("highlighted", "noinherit"),
+            ("selected", "noinherit"),
             ("answer", "fg:cyan"),
         ]
     )

--- a/src/ucode/ui.py
+++ b/src/ucode/ui.py
@@ -241,13 +241,13 @@ def prompt_for_tools(available: list[tuple[str, str]]) -> list[str]:
     """
     style = questionary.Style(
         [
-            # questionary applies `selected` to *checked* rows and
-            # `highlighted` to the cursor row — overriding both to plain
-            # white means only the indicator and the `›` pointer carry
-            # signal, instead of the entire row inverting.
+            # Theme-agnostic picker: every row renders in the terminal's
+            # default foreground colour (`noinherit` strips the
+            # prompt_toolkit defaults that would otherwise re-colour the
+            # cursor row or every checked row).
             ("pointer", "fg:cyan bold"),
-            ("highlighted", "fg:white noinherit"),
-            ("selected", "fg:white noinherit"),
+            ("highlighted", "noinherit"),
+            ("selected", "noinherit"),
             ("answer", "fg:cyan"),
         ]
     )


### PR DESCRIPTION
## Fix #159 
Drop the fg:white overrides in both pickers' styles. Use noinherit alone for highlighted and selected, which strips prompt_toolkit's default per-row highlight without applying any colour of its own. The only colour signals left:
- Cursor row → cyan › pointer
- Selected rows → filled ● vs empty ○ circle
Row text always renders in the terminal's default foreground, so the list is readable on both light and dark themes.

**Changes**
- src/ucode/ui.py — prompt_for_tools style
- src/ucode/mcp.py — _picker_style (shared across MCP pickers)

## Test plan
- uv run ruff check .
-  uv run pytest
- Manual: ucode configure and ucode configure mcp on a light terminal — all rows visible, cursor/selection signals work
- Manual: same flows on a dark terminal — no regression