### PR TITLE
support glm-5-2 on opencode 

### DIFF
--- a/src/ucode/agents/opencode.py
+++ b/src/ucode/agents/opencode.py
@@ -20,6 +20,7 @@ from ucode.databricks import (
     TOKEN_REFRESH_INTERVAL_SECONDS,
     build_opencode_base_urls,
     get_databricks_token,
+    model_token_limits,
 )
 from ucode.state import mark_tool_managed, save_state
 from ucode.telemetry import agent_version, ucode_version
@@ -67,6 +68,20 @@ def _resolve_model_selector(model: str, opencode_models: dict[str, list[str]]) -
         return f"databricks-oss/{model}"
 
     return model
+
+
+def _oss_model_overlay(model: str, ua_header: dict[str, str]) -> dict:
+    """Per-model overlay for an OSS model entry.
+
+    All OSS models carry the User-Agent header; models with known token limits
+    also pin `limit` (context + output) so OpenCode clamps `max_tokens` to a
+    value the gateway accepts. OpenCode's schema requires both fields together,
+    so the limits table always supplies both."""
+    overlay: dict = {"headers": ua_header}
+    limits = model_token_limits(model)
+    if limits is not None:
+        overlay["limit"] = limits
+    return overlay
 
 
 def render_overlay(
@@ -130,7 +145,7 @@ def render_overlay(
                 "apiKey": token,
                 "headers": auth_headers,
             },
-            "models": {m: {"headers": ua_header} for m in oss_models},
+            "models": {m: _oss_model_overlay(m, ua_header) for m in oss_models},
         }
         keys.append(["provider", "databricks-oss"])
 

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1096,6 +1096,11 @@ _MODEL_SERVICE_NAME_PREFIX = "model-services/"
 # Databricks-managed foundation models under `system.ai`.
 _MODEL_SERVICE_REQUIRED_PREFIX = "system.ai."
 
+# Substrings identifying non-chat model services under `system.ai.` (embeddings,
+# rerankers, etc.). These are excluded from the OSS catch-all bucket because they
+# can't back a chat agent.
+_NON_CHAT_MODEL_MARKERS = ("embed", "rerank", "bge", "gte")
+
 
 def _model_service_id(service: dict) -> str | None:
     """Extract the `system.ai.<model-name>` id from one model-service entry.
@@ -1223,7 +1228,22 @@ def discover_model_services(
 
     codex_models = [m for m in ids if "gpt-" in m]
     gemini_models = sorted([m for m in ids if "gemini-" in m], key=model_version_sort_key)
-    oss_models = [m for m in ids if "kimi-" in m]
+
+    # OSS is the catch-all for chat models that aren't claude/gpt/gemini (kimi,
+    # glm, llama, qwen, deepseek, ...), all served OpenAI-compatibly via the
+    # gateway's mlflow route. Bucket by exclusion rather than an allowlist so new
+    # families show up without a code change. `claude-` matches any claude id
+    # (not just the deduped picks in `claude_models`) so no claude model leaks
+    # into OSS. Non-chat model services (embeddings, rerankers) are also listed
+    # under `system.ai.` but can't back a chat agent, so they're filtered out.
+    def _is_non_chat(model_id: str) -> bool:
+        return any(marker in model_id for marker in _NON_CHAT_MODEL_MARKERS)
+
+    oss_models = [
+        m
+        for m in ids
+        if "claude-" not in m and "gpt-" not in m and "gemini-" not in m and not _is_non_chat(m)
+    ]
 
     if not (claude_models or codex_models or gemini_models or oss_models):
         sample = ", ".join(ids[:5])

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1096,10 +1096,11 @@ _MODEL_SERVICE_NAME_PREFIX = "model-services/"
 # Databricks-managed foundation models under `system.ai`.
 _MODEL_SERVICE_REQUIRED_PREFIX = "system.ai."
 
-# Substrings identifying non-chat model services under `system.ai.` (embeddings,
-# rerankers, etc.). These are excluded from the OSS catch-all bucket because they
-# can't back a chat agent.
-_NON_CHAT_MODEL_MARKERS = ("embed", "rerank", "bge", "gte")
+# OSS chat families we currently support. Bucketed by name substring; add an
+# entry here to surface a new OSS family in OpenCode. Kept as an allowlist
+# (rather than a catch-all) so untested families aren't offered before we're
+# ready to support them.
+_OSS_MODEL_FAMILIES = ("kimi-", "glm-")
 
 # Per-family token limits (context window + max output tokens). These are a
 # property of the model + its `/ai-gateway/mlflow/v1` route (the gateway rejects
@@ -1231,7 +1232,8 @@ def discover_model_services(
       matching ``system.ai.claude-*`` id (mirrors ``discover_claude_models``).
     - ``codex_models`` is the list of ``system.ai.*gpt-*`` ids.
     - ``gemini_models`` is the list of ``system.ai.*gemini-*`` ids, newest first.
-    - ``oss_models`` is the list of OSS-model ``system.ai.*`` ids.
+    - ``oss_models`` is the list of supported OSS-model ``system.ai.*`` ids
+      (kimi, glm; see ``_OSS_MODEL_FAMILIES``).
 
     ``reason`` is None on success, else explains why nothing was found. Family
     bucketing is by name substring because the model-services API does not
@@ -1253,21 +1255,11 @@ def discover_model_services(
     codex_models = [m for m in ids if "gpt-" in m]
     gemini_models = sorted([m for m in ids if "gemini-" in m], key=model_version_sort_key)
 
-    # OSS is the catch-all for chat models that aren't claude/gpt/gemini (kimi,
-    # glm, llama, qwen, deepseek, ...), all served OpenAI-compatibly via the
-    # gateway's mlflow route. Bucket by exclusion rather than an allowlist so new
-    # families show up without a code change. `claude-` matches any claude id
-    # (not just the deduped picks in `claude_models`) so no claude model leaks
-    # into OSS. Non-chat model services (embeddings, rerankers) are also listed
-    # under `system.ai.` but can't back a chat agent, so they're filtered out.
-    def _is_non_chat(model_id: str) -> bool:
-        return any(marker in model_id for marker in _NON_CHAT_MODEL_MARKERS)
-
-    oss_models = [
-        m
-        for m in ids
-        if "claude-" not in m and "gpt-" not in m and "gemini-" not in m and not _is_non_chat(m)
-    ]
+    # OSS models (kimi, glm) are served OpenAI-compatibly via the gateway's
+    # mlflow route. Bucketed by an explicit allowlist (_OSS_MODEL_FAMILIES) so
+    # only families we've validated are offered; other OSS families discovered
+    # from model-services are dropped until we add them here.
+    oss_models = [m for m in ids if any(family in m for family in _OSS_MODEL_FAMILIES)]
 
     if not (claude_models or codex_models or gemini_models or oss_models):
         sample = ", ".join(ids[:5])

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1101,6 +1101,30 @@ _MODEL_SERVICE_REQUIRED_PREFIX = "system.ai."
 # can't back a chat agent.
 _NON_CHAT_MODEL_MARKERS = ("embed", "rerank", "bge", "gte")
 
+# Per-family token limits (context window + max output tokens). These are a
+# property of the model + its `/ai-gateway/mlflow/v1` route (the gateway rejects
+# requests whose output exceeds the cap), not of any one agent — so every agent
+# that serves OSS models reads this single table and translates it into its own
+# config dialect. Both fields are provided because agents like OpenCode require
+# context and output together. Keyed by family substring; add an entry to bound
+# a new model.
+_MODEL_TOKEN_LIMITS: dict[str, dict[str, int]] = {
+    # GLM-4.6: 200k context, but the gateway caps output well below the model's
+    # native 128k — pin 25k so requests aren't rejected.
+    "glm": {"context": 200_000, "output": 25_000},
+}
+
+
+def model_token_limits(model_id: str) -> dict[str, int] | None:
+    """Return ``{"context": ..., "output": ...}`` limits for ``model_id``, or None.
+
+    Matches by family substring (e.g. any ``*glm*`` id). None means the model
+    has no known limits and the agent should not pin any."""
+    for family, limits in _MODEL_TOKEN_LIMITS.items():
+        if family in model_id:
+            return dict(limits)
+    return None
+
 
 def _model_service_id(service: dict) -> str | None:
     """Extract the `system.ai.<model-name>` id from one model-service entry.

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1096,10 +1096,8 @@ _MODEL_SERVICE_NAME_PREFIX = "model-services/"
 # Databricks-managed foundation models under `system.ai`.
 _MODEL_SERVICE_REQUIRED_PREFIX = "system.ai."
 
-# OSS chat families we currently support. Bucketed by name substring; add an
-# entry here to surface a new OSS family in OpenCode. Kept as an allowlist
-# (rather than a catch-all) so untested families aren't offered before we're
-# ready to support them.
+# Supported OSS chat families, matched by name substring. Add an entry to
+# support a new family.
 _OSS_MODEL_FAMILIES = ("kimi-", "glm-")
 
 # Per-family token limits (context window + max output tokens). These are a
@@ -1232,8 +1230,7 @@ def discover_model_services(
       matching ``system.ai.claude-*`` id (mirrors ``discover_claude_models``).
     - ``codex_models`` is the list of ``system.ai.*gpt-*`` ids.
     - ``gemini_models`` is the list of ``system.ai.*gemini-*`` ids, newest first.
-    - ``oss_models`` is the list of supported OSS-model ``system.ai.*`` ids
-      (kimi, glm; see ``_OSS_MODEL_FAMILIES``).
+    - ``oss_models`` is the list of OSS-model ``system.ai.*`` ids.
 
     ``reason`` is None on success, else explains why nothing was found. Family
     bucketing is by name substring because the model-services API does not
@@ -1255,10 +1252,6 @@ def discover_model_services(
     codex_models = [m for m in ids if "gpt-" in m]
     gemini_models = sorted([m for m in ids if "gemini-" in m], key=model_version_sort_key)
 
-    # OSS models (kimi, glm) are served OpenAI-compatibly via the gateway's
-    # mlflow route. Bucketed by an explicit allowlist (_OSS_MODEL_FAMILIES) so
-    # only families we've validated are offered; other OSS families discovered
-    # from model-services are dropped until we add them here.
     oss_models = [m for m in ids if any(family in m for family in _OSS_MODEL_FAMILIES)]
 
     if not (claude_models or codex_models or gemini_models or oss_models):

--- a/tests/test_agent_opencode.py
+++ b/tests/test_agent_opencode.py
@@ -93,6 +93,21 @@ class TestRenderOverlay:
         options = overlay["provider"]["databricks-oss"]["options"]
         assert options["baseURL"] == f"{WS}/ai-gateway/mlflow/v1"
 
+    def test_glm_gets_token_limits(self):
+        models = {"oss": ["system.ai.glm-5-2"]}
+        overlay, _ = opencode.render_overlay("system.ai.glm-5-2", "tok", _base_urls(), models)
+        glm = overlay["provider"]["databricks-oss"]["models"]["system.ai.glm-5-2"]
+        # OpenCode's schema requires both context and output on `limit`.
+        assert glm["limit"] == {"context": 200000, "output": 25000}
+
+    def test_non_glm_oss_model_has_no_output_cap(self):
+        models = {"oss": ["system.ai.kimi-k2-7-code"]}
+        overlay, _ = opencode.render_overlay(
+            "system.ai.kimi-k2-7-code", "tok", _base_urls(), models
+        )
+        kimi = overlay["provider"]["databricks-oss"]["models"]["system.ai.kimi-k2-7-code"]
+        assert "limit" not in kimi
+
     def test_token_in_api_key(self):
         models = {"anthropic": ["claude-sonnet"]}
         overlay, _ = opencode.render_overlay("claude-sonnet", "mytoken", _base_urls(), models)

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -169,9 +169,35 @@ class TestDiscoverModelServices:
         assert codex == ["system.ai.gpt-5"]
         # Gemini ordered newest-first via the shared sort key.
         assert gemini[0] == "system.ai.gemini-3-5-flash"
-        assert oss == ["system.ai.kimi-k2-7-code"]
-        # llama is not bucketed into any of the four families.
-        assert "system.ai.llama-4-maverick" not in codex + gemini + oss
+        # OSS is the catch-all: kimi and llama (and any non-claude/gpt/gemini
+        # chat model) land here, sorted by their `system.ai.*` id.
+        assert oss == ["system.ai.kimi-k2-7-code", "system.ai.llama-4-maverick"]
+
+    def test_oss_catch_all_excludes_non_chat_models(self, monkeypatch):
+        # glm/qwen/deepseek are unknown chat families -> OSS; embedding and
+        # reranker services under system.ai.* must be filtered out.
+        payload = {
+            "model_services": [
+                _model_service("system.ai.glm-5-2"),
+                _model_service("system.ai.qwen-3-coder"),
+                _model_service("system.ai.deepseek-v3"),
+                _model_service("system.ai.gte-large-embed"),
+                _model_service("system.ai.bge-reranker-v2"),
+            ]
+        }
+        monkeypatch.setattr(
+            db_mod, "_http_get_json", lambda url, token, timeout=10: (payload, None)
+        )
+
+        claude, codex, gemini, oss, reason = db_mod.discover_model_services(WS, "token")
+
+        assert reason is None
+        assert (claude, codex, gemini) == ({}, [], [])
+        assert oss == [
+            "system.ai.deepseek-v3",
+            "system.ai.glm-5-2",
+            "system.ai.qwen-3-coder",
+        ]
 
     def test_paginates_via_next_page_token(self, monkeypatch):
         pages = {
@@ -209,7 +235,9 @@ class TestDiscoverModelServices:
         assert reason == "HTTP 500 Server Error"
 
     def test_no_matching_families_reports_sample(self, monkeypatch):
-        payload = {"model_services": [_model_service("system.ai.llama-4-maverick")]}
+        # Only non-chat model services (embeddings) are present, so no family —
+        # including the OSS catch-all — picks anything up.
+        payload = {"model_services": [_model_service("system.ai.bge-large-en-embed")]}
         monkeypatch.setattr(
             db_mod, "_http_get_json", lambda url, token, timeout=10: (payload, None)
         )
@@ -217,7 +245,7 @@ class TestDiscoverModelServices:
         claude, codex, gemini, oss, reason = db_mod.discover_model_services(WS, "token")
 
         assert (claude, codex, gemini, oss) == ({}, [], [], [])
-        assert reason is not None and "llama-4-maverick" in reason
+        assert reason is not None and "bge-large-en-embed" in reason
 
     def test_ignores_non_system_ai_schemas(self, monkeypatch):
         # The metastore listing returns services from every schema; only

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -250,9 +250,7 @@ class TestDiscoverModelServices:
         assert reason == "HTTP 500 Server Error"
 
     def test_no_matching_families_reports_sample(self, monkeypatch):
-        # Only an embedding service is present: no claude/gpt/gemini family
-        # matches, and it isn't in the OSS allowlist, so nothing is picked up.
-        payload = {"model_services": [_model_service("system.ai.bge-large-en-embed")]}
+        payload = {"model_services": [_model_service("system.ai.llama-4-maverick")]}
         monkeypatch.setattr(
             db_mod, "_http_get_json", lambda url, token, timeout=10: (payload, None)
         )
@@ -260,7 +258,7 @@ class TestDiscoverModelServices:
         claude, codex, gemini, oss, reason = db_mod.discover_model_services(WS, "token")
 
         assert (claude, codex, gemini, oss) == ({}, [], [], [])
-        assert reason is not None and "bge-large-en-embed" in reason
+        assert reason is not None and "llama-4-maverick" in reason
 
     def test_ignores_non_system_ai_schemas(self, monkeypatch):
         # The metastore listing returns services from every schema; only

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -140,6 +140,23 @@ def _model_service(model_id: str) -> dict:
     return {"name": f"model-services/{model_id}"}
 
 
+class TestModelTokenLimits:
+    def test_glm_is_capped(self):
+        assert db_mod.model_token_limits("system.ai.glm-5-2") == {
+            "context": 200_000,
+            "output": 25_000,
+        }
+
+    def test_glm_matches_any_version(self):
+        assert db_mod.model_token_limits("system.ai.glm-4-6-flash") == {
+            "context": 200_000,
+            "output": 25_000,
+        }
+
+    def test_uncapped_model_returns_none(self):
+        assert db_mod.model_token_limits("system.ai.kimi-k2-7-code") is None
+
+
 class TestDiscoverModelServices:
     def test_buckets_families_by_name(self, monkeypatch):
         payload = {

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -187,13 +187,11 @@ class TestDiscoverModelServices:
         assert codex == ["system.ai.gpt-5"]
         # Gemini ordered newest-first via the shared sort key.
         assert gemini[0] == "system.ai.gemini-3-5-flash"
-        # OSS is an allowlist: kimi and glm land here (alphabetized by the
-        # sorted listing); llama (unsupported) does not.
+        # kimi and glm are the allowlisted OSS families; llama is not.
         assert oss == ["system.ai.glm-5-2", "system.ai.kimi-k2-7-code"]
 
     def test_oss_allowlist_drops_unsupported_families(self, monkeypatch):
-        # Only kimi/glm are supported OSS families; other OSS families and
-        # non-chat services (embeddings, rerankers) under system.ai.* are dropped.
+        # Only kimi/glm are allowlisted; other families are dropped.
         payload = {
             "model_services": [
                 _model_service("system.ai.glm-5-2"),

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -168,6 +168,7 @@ class TestDiscoverModelServices:
                 _model_service("system.ai.gemini-2-5-flash"),
                 _model_service("system.ai.gemini-3-5-flash"),
                 _model_service("system.ai.kimi-k2-7-code"),
+                _model_service("system.ai.glm-5-2"),
                 _model_service("system.ai.llama-4-maverick"),
             ]
         }
@@ -186,16 +187,17 @@ class TestDiscoverModelServices:
         assert codex == ["system.ai.gpt-5"]
         # Gemini ordered newest-first via the shared sort key.
         assert gemini[0] == "system.ai.gemini-3-5-flash"
-        # OSS is the catch-all: kimi and llama (and any non-claude/gpt/gemini
-        # chat model) land here, sorted by their `system.ai.*` id.
-        assert oss == ["system.ai.kimi-k2-7-code", "system.ai.llama-4-maverick"]
+        # OSS is an allowlist: kimi and glm land here (alphabetized by the
+        # sorted listing); llama (unsupported) does not.
+        assert oss == ["system.ai.glm-5-2", "system.ai.kimi-k2-7-code"]
 
-    def test_oss_catch_all_excludes_non_chat_models(self, monkeypatch):
-        # glm/qwen/deepseek are unknown chat families -> OSS; embedding and
-        # reranker services under system.ai.* must be filtered out.
+    def test_oss_allowlist_drops_unsupported_families(self, monkeypatch):
+        # Only kimi/glm are supported OSS families; other OSS families and
+        # non-chat services (embeddings, rerankers) under system.ai.* are dropped.
         payload = {
             "model_services": [
                 _model_service("system.ai.glm-5-2"),
+                _model_service("system.ai.kimi-k2-7-code"),
                 _model_service("system.ai.qwen-3-coder"),
                 _model_service("system.ai.deepseek-v3"),
                 _model_service("system.ai.gte-large-embed"),
@@ -210,11 +212,7 @@ class TestDiscoverModelServices:
 
         assert reason is None
         assert (claude, codex, gemini) == ({}, [], [])
-        assert oss == [
-            "system.ai.deepseek-v3",
-            "system.ai.glm-5-2",
-            "system.ai.qwen-3-coder",
-        ]
+        assert oss == ["system.ai.glm-5-2", "system.ai.kimi-k2-7-code"]
 
     def test_paginates_via_next_page_token(self, monkeypatch):
         pages = {
@@ -252,8 +250,8 @@ class TestDiscoverModelServices:
         assert reason == "HTTP 500 Server Error"
 
     def test_no_matching_families_reports_sample(self, monkeypatch):
-        # Only non-chat model services (embeddings) are present, so no family —
-        # including the OSS catch-all — picks anything up.
+        # Only an embedding service is present: no claude/gpt/gemini family
+        # matches, and it isn't in the OSS allowlist, so nothing is picked up.
         payload = {"model_services": [_model_service("system.ai.bge-large-en-embed")]}
         monkeypatch.setattr(
             db_mod, "_http_get_json", lambda url, token, timeout=10: (payload, None)


### PR DESCRIPTION
1/ support kimi and glm. i use a hardcoded list instead of just fetching all oss models because not all of them work (ie qwen fails with some error about ints). i confirmed kimi and glm work 

2/ cap glm at an output token limit of 25k. otherwise it will fail. we see the same issue in the browser if we don't cap the output token limit. 

<img width="836" height="726" alt="Screenshot 2026-07-07 at 2 25 22 PM" src="https://github.com/user-attachments/assets/2f8e4358-30e7-4171-931d-4efb32cbf340" />