### PR TITLE
Support x-databricks-traffic-id header for codex

### DIFF
--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -107,6 +107,7 @@ def _provider_block(
     databricks_profile: str | None,
     use_pat: bool = False,
     provider: str | None = None,
+    traffic_id: str | None = None,
 ) -> dict:
     auth_argv = build_auth_token_argv(workspace, databricks_profile, use_pat=use_pat)
     base_url = build_tool_base_url("codex", workspace)
@@ -117,6 +118,9 @@ def _provider_block(
     # provider from this header on every request.
     if provider:
         http_headers["Databricks-Model-Provider-Service"] = provider
+    # Tag outbound requests so the gateway can attribute this traffic.
+    if traffic_id:
+        http_headers["x-databricks-traffic-id"] = traffic_id
     return {
         "name": "Databricks AI Gateway",
         "base_url": base_url,
@@ -139,13 +143,14 @@ def render_overlay(
     databricks_profile: str | None = None,
     use_pat: bool = False,
     provider: str | None = None,
+    traffic_id: str | None = None,
 ) -> dict:
     overlay: dict = {"model_provider": CODEX_MODEL_PROVIDER_NAME}
     if model:
         overlay["model"] = model
     overlay["model_providers"] = {
         CODEX_MODEL_PROVIDER_NAME: _provider_block(
-            workspace, databricks_profile, use_pat, provider
+            workspace, databricks_profile, use_pat, provider, traffic_id
         ),
     }
     return overlay

--- a/tests/test_agent_codex.py
+++ b/tests/test_agent_codex.py
@@ -91,6 +91,16 @@ class TestRenderOverlayUserAgent:
         # Revert must clean up the new key.
         assert ["model_providers", "ucode-databricks", "http_headers"] in codex.MANAGED_KEYS
 
+    def test_traffic_id_adds_header(self):
+        overlay = codex.render_overlay(WS, traffic_id="team-42")
+        headers = overlay["model_providers"]["ucode-databricks"]["http_headers"]
+        assert headers["x-databricks-traffic-id"] == "team-42"
+
+    def test_no_traffic_id_header_without_value(self):
+        overlay = codex.render_overlay(WS)
+        headers = overlay["model_providers"]["ucode-databricks"]["http_headers"]
+        assert "x-databricks-traffic-id" not in headers
+
 
 class TestCodexWriteConfig:
     def test_writes_ucode_profile_config_file(self, tmp_path, monkeypatch):


### PR DESCRIPTION
Thread an optional traffic_id through render_overlay/_provider_block that writes x-databricks-traffic-id into the codex provider's http_headers when set (mirroring the existing Databricks-Model-Provider-Service header). The header lands under the already-managed http_headers key, so it reaches every gateway request and survives reconfigures via deep-merge.

mitm capture confirms my liteswap header is there 
```
[REQ] POST eng-ml-inference.staging.cloud.databricks.com/ai-gateway/codex/v1/responses
      x-databricks-traffic-id: testenv://liteswap/lilly-codex
      Databricks-Model-Provider-Service: <none>
      Databricks-Ai-Gateway-Request-Tags: <none>
``` 

Co-authored-by: Isaac