### PR TITLE
claude: disable built-in WebSearch via permissions.deny (not the no-op disabledTools key)

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -202,12 +202,20 @@ def render_overlay(
     }
     keys: list[list[str]] = [["apiKeyHelper"]] + [["env", k] for k in env]
 
-    # Disable Claude Code's built-in WebSearch (it routes through Anthropic's
-    # hosted infra and fails through the Databricks gateway). The replacement
-    # `web_search` MCP server is registered separately via the claude CLI.
+    # Disable Claude Code's built-in WebSearch: it declares Anthropic's hosted
+    # `web_search_20250305` server tool, which the Databricks gateway rejects
+    # (HTTP 400: "Input tag 'web_search_20250305' ... does not match"), so the
+    # model wastes a turn on it before falling back. A *bare* `permissions.deny`
+    # entry removes the tool from Claude's context entirely, so it is never
+    # advertised to the model nor sent to the gateway. (Claude Code has no
+    # `disabledTools` setting — the `permissions` block is the only settings.json
+    # mechanism for built-in tools; a bare tool name in `deny` drops it, whereas
+    # a scoped rule like `WebSearch(*)` would leave it advertised.) The
+    # replacement `web_search` MCP server is registered separately via the
+    # claude CLI.
     if disable_web_search:
-        overlay["disabledTools"] = ["WebSearch"]
-        keys.append(["disabledTools"])
+        overlay["permissions"] = {"deny": ["WebSearch"]}
+        keys.append(["permissions", "deny"])
 
     return overlay, keys
 

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -211,20 +211,22 @@ class TestRenderOverlayWebSearchDisable:
         assert "mcpServers" not in overlay
 
     def test_disables_builtin_websearch_when_requested(self):
+        # A bare `permissions.deny` entry removes the built-in WebSearch tool
+        # from Claude's context (Claude Code has no `disabledTools` setting).
         overlay, _ = claude.render_overlay(WS, "s4", disable_web_search=True)
-        assert overlay["disabledTools"] == ["WebSearch"]
+        assert overlay["permissions"] == {"deny": ["WebSearch"]}
 
     def test_no_disable_when_not_requested(self):
         overlay, _ = claude.render_overlay(WS, "s4", disable_web_search=False)
-        assert "disabledTools" not in overlay
+        assert "permissions" not in overlay
 
     def test_managed_keys_include_disabled_tools_when_set(self):
         _, keys = claude.render_overlay(WS, "s4", disable_web_search=True)
-        assert ["disabledTools"] in keys
+        assert ["permissions", "deny"] in keys
 
     def test_managed_keys_omit_disabled_tools_when_not_set(self):
         _, keys = claude.render_overlay(WS, "s4", disable_web_search=False)
-        assert ["disabledTools"] not in keys
+        assert ["permissions", "deny"] not in keys
 
 
 class TestWebSearchMcpEntry:


### PR DESCRIPTION
## What

`ucode claude` intends to disable Claude Code's built-in `WebSearch` tool and route web search through the `web_search` MCP server instead. WebSearch declares Anthropic's hosted `web_search_20250305` server tool, which the Databricks gateway rejects with a `400`, so it can't work through the gateway.

It disables the tool by writing `"disabledTools": ["WebSearch"]` into the Claude settings overlay — but **`disabledTools` is not a Claude Code settings key.** Claude Code silently ignores unknown keys, so WebSearch stays advertised to the model: the model calls it, hits the gateway 400, and only *then* falls back to the MCP tool — a wasted turn plus a 400 in the transcript on every web-search request.

## Fix

Use the real mechanism: a **bare `permissions.deny`** entry. Per the Claude Code docs, a bare tool name in `deny` removes the tool from Claude's context entirely (unlike a scoped rule such as `WebSearch(*)`, which leaves it advertised and only blocks matching calls). So `web_search_20250305` is never advertised to the model nor sent to the gateway — no wasted turn, no 400. The `web_search` MCP replacement is unchanged.

```python
# before  (silently ignored — not a real settings key)
overlay["disabledTools"] = ["WebSearch"]
# after
overlay["permissions"] = {"deny": ["WebSearch"]}
```

## Evidence

Confirmed on a staging managed Claude session: `"disabledTools":["WebSearch"]` was present in the launched claude's merged `--settings`, yet the model still called native `WebSearch`, which returned:

```
API Error: 400 tools.0: Input tag 'web_search_20250305' ... does not match any of the expected tags
```

and only then fell back to `mcp__web_search__web_search` (which works). Also verified Claude Code exposes no `disabledTools` (settings) or `--disabledTools` (flag) — the `permissions` block is the only settings.json mechanism for built-in tools.

## Test

Updated `TestRenderOverlayWebSearchDisable` to assert the `permissions.deny` overlay + `["permissions", "deny"]` managed key. Full non-e2e suite green (854 passed, 8 skipped).

This pull request and its description were written by Isaac.
