### PR TITLE
Force token refresh in the auth-token apiKeyHelper

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -776,7 +776,15 @@ def auth_token_cmd(
             )
             raise typer.Exit(1)
     try:
-        token = get_databricks_token(workspace, profile)
+        # force_refresh: this helper is re-invoked by Claude Code's apiKeyHelper
+        # (and Codex's auth command) on the CLAUDE_CODE_API_KEY_HELPER_TTL_MS
+        # interval (15 min). Forcing a refresh each cycle hands back a token with
+        # a full fresh lifetime, so a long session never dies at the original
+        # token's ~1h expiry. Without it, `databricks auth token` only refreshes
+        # when it independently judges the cached token "close to expiry", which
+        # can lapse between invocations. Mirrors the force_refresh=True used by
+        # the gemini/opencode/copilot/pi background refreshers.
+        token = get_databricks_token(workspace, profile, force_refresh=True)
     except RuntimeError as exc:
         print_err(str(exc))
         raise typer.Exit(1) from None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -215,7 +215,7 @@ class TestAuthTokenCommand:
             patch("ucode.cli.load_state", return_value={"workspace": "https://ws"}),
             patch(
                 "ucode.cli.get_databricks_token",
-                side_effect=lambda w, p, force_refresh=False: os.environ.get(
+                side_effect=lambda w, p, *, force_refresh=False: os.environ.get(
                     "DATABRICKS_BEARER", ""
                 ),
             ),
@@ -233,7 +233,7 @@ class TestAuthTokenCommand:
             patch("ucode.cli.load_state", return_value={"workspace": "https://ws"}),
             patch(
                 "ucode.cli.get_databricks_token",
-                side_effect=lambda w, p, force_refresh=False: os.environ.get(
+                side_effect=lambda w, p, *, force_refresh=False: os.environ.get(
                     "DATABRICKS_BEARER", ""
                 ),
             ),
@@ -265,7 +265,7 @@ class TestAuthTokenCommand:
             patch("ucode.cli.load_state", return_value={"workspace": "https://ws"}),
             patch(
                 "ucode.cli.get_databricks_token",
-                side_effect=lambda w, p, force_refresh=False: os.environ.get(
+                side_effect=lambda w, p, *, force_refresh=False: os.environ.get(
                     "DATABRICKS_BEARER", ""
                 ),
             ),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -180,7 +180,9 @@ class TestAuthTokenCommand:
         # Nothing but the bare token (plus trailing newline) may reach stdout,
         # or the consuming agent will treat the noise as part of the token.
         assert result.stdout == "tok-123\n"
-        fetch.assert_called_once_with("https://ws", None)
+        # force_refresh=True so each 15-min apiKeyHelper cycle yields a token with
+        # a full fresh lifetime (long sessions otherwise die at ~1h expiry).
+        fetch.assert_called_once_with("https://ws", None, force_refresh=True)
 
     def test_host_and_profile_override_state(self):
         with (
@@ -191,7 +193,7 @@ class TestAuthTokenCommand:
                 app, ["auth-token", "--host", "https://override", "--profile", "prod"]
             )
         assert result.exit_code == 0
-        fetch.assert_called_once_with("https://override", "prod")
+        fetch.assert_called_once_with("https://override", "prod", force_refresh=True)
 
     def test_errors_without_workspace(self):
         with patch("ucode.cli.load_state", return_value={}):
@@ -213,7 +215,9 @@ class TestAuthTokenCommand:
             patch("ucode.cli.load_state", return_value={"workspace": "https://ws"}),
             patch(
                 "ucode.cli.get_databricks_token",
-                side_effect=lambda w, p: os.environ.get("DATABRICKS_BEARER", ""),
+                side_effect=lambda w, p, force_refresh=False: os.environ.get(
+                    "DATABRICKS_BEARER", ""
+                ),
             ),
         ):
             result = runner.invoke(app, ["auth-token", "--use-pat", "--profile", "p"])
@@ -229,7 +233,9 @@ class TestAuthTokenCommand:
             patch("ucode.cli.load_state", return_value={"workspace": "https://ws"}),
             patch(
                 "ucode.cli.get_databricks_token",
-                side_effect=lambda w, p: os.environ.get("DATABRICKS_BEARER", ""),
+                side_effect=lambda w, p, force_refresh=False: os.environ.get(
+                    "DATABRICKS_BEARER", ""
+                ),
             ),
         ):
             result = runner.invoke(app, ["auth-token", "--use-pat", "--profile", "p"])
@@ -259,7 +265,9 @@ class TestAuthTokenCommand:
             patch("ucode.cli.load_state", return_value={"workspace": "https://ws"}),
             patch(
                 "ucode.cli.get_databricks_token",
-                side_effect=lambda w, p: os.environ.get("DATABRICKS_BEARER", ""),
+                side_effect=lambda w, p, force_refresh=False: os.environ.get(
+                    "DATABRICKS_BEARER", ""
+                ),
             ),
         ):
             result = runner.invoke(app, ["auth-token", "--use-pat", "--profile", "p"])

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -1141,6 +1141,32 @@ class TestGetDatabricksToken:
         assert "--profile" in argv
         assert argv[argv.index("--profile") + 1] == "stablebox"
 
+    def test_force_refresh_appends_flag(self, tmp_path, monkeypatch):
+        # The apiKeyHelper (`ucode auth-token`) passes force_refresh=True so each
+        # refresh cycle bypasses `databricks auth token`'s "close to expiry"
+        # heuristic and hands back a token with a full fresh lifetime.
+        argv_log = tmp_path / "argv"
+        env = self._fake_databricks(
+            tmp_path,
+            f'printf "%s\\n" "$@" >> {argv_log}\n'
+            'echo \'{"access_token": "good-token", "token_type": "Bearer"}\'',
+        )
+        monkeypatch.setattr("os.environ", env)
+        token = get_databricks_token(WS, force_refresh=True)
+        assert token == "good-token"
+        assert "--force-refresh" in argv_log.read_text().splitlines()
+
+    def test_omits_force_refresh_flag_by_default(self, tmp_path, monkeypatch):
+        argv_log = tmp_path / "argv"
+        env = self._fake_databricks(
+            tmp_path,
+            f'printf "%s\\n" "$@" >> {argv_log}\n'
+            'echo \'{"access_token": "good-token", "token_type": "Bearer"}\'',
+        )
+        monkeypatch.setattr("os.environ", env)
+        get_databricks_token(WS)
+        assert "--force-refresh" not in argv_log.read_text().splitlines()
+
     def test_error_suggests_logout_when_matching_profile_exists(self, tmp_path, monkeypatch):
         env = self._fake_databricks(
             tmp_path,

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -1055,7 +1055,12 @@ class TestGetDatabricksToken:
         fake = tmp_path / "databricks"
         fake.write_text(f"#!/bin/sh\n{script}\n")
         fake.chmod(0o755)
-        return {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"}
+        env = {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"}
+        # Drop any ambient DATABRICKS_BEARER: get_databricks_token short-circuits
+        # on it and would never invoke the fake CLI, so these tests must exercise
+        # the shim, not a leaked CI/developer bearer.
+        env.pop("DATABRICKS_BEARER", None)
+        return env
 
     def test_returns_token_on_success(self, tmp_path, monkeypatch):
         env = self._fake_databricks(
@@ -1131,7 +1136,7 @@ class TestGetDatabricksToken:
         argv_log = tmp_path / "argv"
         env = self._fake_databricks(
             tmp_path,
-            f'printf "%s\\n" "$@" >> {argv_log}\n'
+            f'printf "%s\\n" "$@" >> "{argv_log}"\n'
             'echo \'{"access_token": "good-token", "token_type": "Bearer"}\'',
         )
         monkeypatch.setattr("os.environ", env)

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -1148,7 +1148,7 @@ class TestGetDatabricksToken:
         argv_log = tmp_path / "argv"
         env = self._fake_databricks(
             tmp_path,
-            f'printf "%s\\n" "$@" >> {argv_log}\n'
+            f'printf "%s\\n" "$@" >> "{argv_log}"\n'
             'echo \'{"access_token": "good-token", "token_type": "Bearer"}\'',
         )
         monkeypatch.setattr("os.environ", env)
@@ -1160,7 +1160,7 @@ class TestGetDatabricksToken:
         argv_log = tmp_path / "argv"
         env = self._fake_databricks(
             tmp_path,
-            f'printf "%s\\n" "$@" >> {argv_log}\n'
+            f'printf "%s\\n" "$@" >> "{argv_log}"\n'
             'echo \'{"access_token": "good-token", "token_type": "Bearer"}\'',
         )
         monkeypatch.setattr("os.environ", env)


### PR DESCRIPTION
## Problem

Long-running Claude Code / Codex sessions die when the original Databricks OAuth token expires (~1h), even though the `apiKeyHelper` is configured to refresh every 15 min via `CLAUDE_CODE_API_KEY_HELPER_TTL_MS: 900000`.

## Root cause

`ucode auth-token` is the command Claude Code's `apiKeyHelper` (and Codex's auth command) re-invokes on that 15-min interval. It called `get_databricks_token(...)` **without** `force_refresh`, so the underlying `databricks auth token` only renewed the token when the CLI *independently* judged the cached token "close to expiry":

> Get authentication token from the local cache… Refresh the access token if it is expired or close to expiry. Use `--force-refresh` to bypass expiry checks.

That heuristic can lapse between helper invocations, so the session dies at the original token's expiry. Notably, this is inconsistent with the gemini/opencode/copilot/pi agents, whose background refreshers already pass `force_refresh=True`.

## Fix

Pass `force_refresh=True` from the `auth-token` helper so each refresh cycle bypasses the expiry heuristic and hands back a token with a full fresh lifetime.

## Tests

- `tests/test_cli.py` — the `auth-token` command forwards `force_refresh=True`.
- `tests/test_databricks.py` — `--force-refresh` is (and by default isn't) forwarded to the real `databricks auth token` argv.

Full suite passes (`853 passed`); the only failures are two pre-existing network-dependent e2e tests that also fail on clean `main`.

## Note for reviewers

PR #137 (Windows support) touches this same auth code and is stale against #177 — the two will conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)