### PR TITLE
claude: allow disabling web_search MCP via web_search_model: false

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -51,9 +51,21 @@ def is_update_available() -> tuple[str, str] | None:
 def _resolve_web_search_model(state: dict) -> str | None:
     """Pick the model the web_search MCP server should call. Prefers an
     explicit override in state, otherwise the first endpoint discovered as
-    Responses-API-capable. Returns None if no GPT endpoint is available —
-    callers should skip the MCP wiring in that case."""
+    Responses-API-capable. Returns None if no GPT endpoint is available, or
+    if `web_search_model` is explicitly set to `False` to opt out — callers
+    should skip the MCP wiring in that case.
+
+    The `False` opt-out exists because Responses-API-shaped discovery
+    (`codex_models`) can only tell that an endpoint speaks the wire protocol,
+    not that it has real OpenAI backing for server-side tools like
+    `web_search`. A self-hosted model served through Databricks' Open
+    Responses API wrapper (e.g. gpt-oss) matches the wire-protocol filter but
+    has no such backing, so calling it 400s with "No OpenAI Response API
+    backing." When that's the only candidate, set `web_search_model: false`
+    in ucode's state to stop auto-discovery from picking it."""
     override = state.get("web_search_model")
+    if override is False:
+        return None
     if isinstance(override, str) and override.strip():
         return override.strip()
     codex_models = state.get("codex_models") or []
@@ -335,6 +347,11 @@ def write_tool_config(
 
     if web_search_model:
         _register_web_search_mcp(state["workspace"], web_search_model, state.get("profile"))
+    else:
+        # Clean up a stale registration from a prior run — e.g. the workspace's
+        # only codex model was removed, or `web_search_model` was just set to
+        # `False` to opt out of a previously-registered broken endpoint.
+        _unregister_web_search_mcp()
 
     state = mark_tool_managed(state, "claude", managed_keys)
     save_state(state)

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -258,6 +258,17 @@ class TestResolveWebSearchModel:
         state = {"web_search_model": "winner", "codex_models": ["loser"]}
         assert claude._resolve_web_search_model(state) == "winner"
 
+    def test_explicit_false_disables_regardless_of_codex_models(self):
+        # A self-hosted model (e.g. gpt-oss) can be the only discovered codex
+        # model yet have no real OpenAI backing for the web_search tool. An
+        # explicit `False` opts out instead of silently picking it.
+        state = {"web_search_model": False, "codex_models": ["mirion_ai_bronze"]}
+        assert claude._resolve_web_search_model(state) is None
+
+    def test_explicit_false_beats_string_codex_model(self):
+        state = {"web_search_model": False, "codex_models": ["m1"]}
+        assert claude._resolve_web_search_model(state) is None
+
 
 class TestClaudeDefaultModel:
     def test_prefers_opus(self):
@@ -308,6 +319,11 @@ class TestWriteToolConfigMcpRegistration:
             "_register_web_search_mcp",
             lambda ws, model, profile=None: calls.append(("register", ws, model)),
         )
+        monkeypatch.setattr(
+            claude,
+            "_unregister_web_search_mcp",
+            lambda: calls.append(("unregister",)),
+        )
 
     def test_registers_mcp_when_codex_model_available(self, monkeypatch):
         calls: list = []
@@ -321,7 +337,10 @@ class TestWriteToolConfigMcpRegistration:
         self._common_patches(monkeypatch, calls)
         state = {"workspace": WS, "codex_models": []}
         claude.write_tool_config(state, "databricks-claude-sonnet-4")
-        assert calls == []
+        # No candidate model exists, so any stale registration from a prior
+        # run (e.g. the workspace's only GPT endpoint was decommissioned)
+        # gets cleaned up rather than left dangling.
+        assert calls == [("unregister",)]
 
     def test_explicit_override_used_over_codex_models(self, monkeypatch):
         calls: list = []
@@ -333,6 +352,23 @@ class TestWriteToolConfigMcpRegistration:
         }
         claude.write_tool_config(state, "databricks-claude-sonnet-4")
         assert calls == [("register", WS, "explicit-model")]
+
+    def test_explicit_false_unregisters_instead_of_registering(self, monkeypatch):
+        # Regression: a workspace whose only Responses-API-shaped endpoint is
+        # a self-hosted model (e.g. gpt-oss served through Databricks' Open
+        # Responses API wrapper) has no real OpenAI backing for the
+        # web_search tool, so calling it 400s with "No OpenAI Response API
+        # backing." `web_search_model: false` opts out and any previously
+        # registered (broken) entry is removed.
+        calls: list = []
+        self._common_patches(monkeypatch, calls)
+        state = {
+            "workspace": WS,
+            "web_search_model": False,
+            "codex_models": ["mirion_ai_bronze"],
+        }
+        claude.write_tool_config(state, "databricks-claude-sonnet-4")
+        assert calls == [("unregister",)]
 
 
 class TestRegisterWebSearchMcp:


### PR DESCRIPTION
## Summary

`_resolve_web_search_model` picks the model backing the `web_search` MCP server by preferring an explicit `web_search_model` override, otherwise falling back to `codex_models[0]` (the first endpoint auto-discovered as Responses-API-shaped). That discovery only confirms an endpoint *speaks* the `openai/v1/responses` wire protocol — it doesn't confirm the endpoint has real OpenAI backing to execute server-side tools like `web_search`.

A self-hosted model served through Databricks' Open Responses API wrapper (e.g. a `gpt-oss-120b` custom serving endpoint) matches that wire-protocol filter but has no such backing. When it's the only discovered endpoint in a workspace, `ucode` silently wires it up as the `web_search` MCP's backing model, and every search call 400s with `No OpenAI Response API backing`. There was previously no way to opt out short of manually running `claude mcp remove web_search -s user` after every `ucode configure` (which re-registers it on the next run).

- `_resolve_web_search_model` now treats `web_search_model: False` as an explicit opt-out, short-circuiting before the `codex_models` fallback (existing string-override and no-override behavior is unchanged).
- `write_tool_config` now calls `_unregister_web_search_mcp()` when no model resolves, so a stale registration (from a prior run, or from just having set `web_search_model: false`) is actually cleaned up instead of only ever being added to.

## Test plan

- [x] `uv run pytest tests/test_agent_claude.py -q` — 69 passed
- [x] `uv run pytest -q` (excluding e2e, which need a live workspace) — 863 passed
- [x] `uv run ruff check .` — clean
- [x] Added regression tests: `test_explicit_false_disables_regardless_of_codex_models`, `test_explicit_false_beats_string_codex_model`, `test_explicit_false_unregisters_instead_of_registering`; updated `test_skips_registration_without_codex_model` for the new unregister-on-no-model behavior.

This pull request and its description were written by Isaac.
