### PR TITLE
Enable 1h prompt caching and tool search for Claude client

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -174,7 +174,8 @@ def render_overlay(
         # Claude Code only sends when experimental betas are enabled — so we must
         # not set CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS (see CLAUDE_REMOVED_ENV_KEYS).
         "ENABLE_PROMPT_CACHING_1H": "1",
-        "ENABLE_TOOL_SEARCH": "true",
+        "ENABLE_TOOL_SEARCH": "1",
+        "CLAUDE_CODE_USE_GATEWAY": "1",
     }
     # Intentionally NOT setting ANTHROPIC_MODEL. Setting it produces a duplicate
     # catalog row in Claude Code's /model picker (e.g. "Opus 4.8 (1M context) ✓")

--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -91,6 +91,9 @@ CLAUDE_MANAGED_MODEL_ENV_KEYS = (
     "ANTHROPIC_DEFAULT_HAIKU_MODEL",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME",
 )
+# Env keys ucode used to write but no longer does; stripped from the managed
+# settings file on every launch so stale values never linger.
+CLAUDE_REMOVED_ENV_KEYS = ("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS",)
 CLAUDE_TRACING_STOP_HOOK_SUFFIX = " autolog claude stop-hook"
 # Tracing is driven by an `mlflow autolog claude stop-hook` Stop hook, run by
 # the `mlflow` CLI on each session end. Pin to 3.11.x: 3.12 dropped the Unity
@@ -163,8 +166,12 @@ def render_overlay(
     env: dict[str, str] = {
         "ANTHROPIC_BASE_URL": base_url,
         "ANTHROPIC_CUSTOM_HEADERS": custom_headers,
-        "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
         "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": "900000",
+        # 1h prompt caching needs the extended-cache-ttl beta header, which
+        # Claude Code only sends when experimental betas are enabled — so we must
+        # not set CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS (see CLAUDE_REMOVED_ENV_KEYS).
+        "ENABLE_PROMPT_CACHING_1H": "1",
+        "ENABLE_TOOL_SEARCH": "true",
     }
     # Intentionally NOT setting ANTHROPIC_MODEL. Setting it produces a duplicate
     # catalog row in Claude Code's /model picker (e.g. "Opus 4.8 (1M context) ✓")
@@ -331,6 +338,11 @@ def write_tool_config(
         for key in CLAUDE_MANAGED_MODEL_ENV_KEYS:
             if key not in overlay_env:
                 merged_env.pop(key, None)
+    # deep_merge_dict keeps keys already in the file, so drop the ones ucode no
+    # longer writes.
+    if isinstance(merged_env, dict):
+        for key in CLAUDE_REMOVED_ENV_KEYS:
+            merged_env.pop(key, None)
     write_json_file(CLAUDE_SETTINGS_PATH, merged)
 
     if web_search_model:

--- a/src/ucode/state.py
+++ b/src/ucode/state.py
@@ -155,7 +155,8 @@ def build_agent_state(state: dict) -> dict[str, dict]:
                 "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": str(AUTH_REFRESH_INTERVAL_MS),
                 # Kept in sync with agents/claude.py render_overlay.
                 "ENABLE_PROMPT_CACHING_1H": "1",
-                "ENABLE_TOOL_SEARCH": "true",
+                "ENABLE_TOOL_SEARCH": "1",
+                "CLAUDE_CODE_USE_GATEWAY": "1",
             },
         },
         "codex": {

--- a/src/ucode/state.py
+++ b/src/ucode/state.py
@@ -153,7 +153,9 @@ def build_agent_state(state: dict) -> dict[str, dict]:
             "env": {
                 "ANTHROPIC_BASE_URL": base_urls.get("claude"),
                 "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": str(AUTH_REFRESH_INTERVAL_MS),
-                "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
+                # Kept in sync with agents/claude.py render_overlay.
+                "ENABLE_PROMPT_CACHING_1H": "1",
+                "ENABLE_TOOL_SEARCH": "true",
             },
         },
         "codex": {

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -80,9 +80,18 @@ class TestRenderOverlay:
         overlay, _ = claude.render_overlay(WS, "s4")
         assert "x-databricks-use-coding-agent-mode" in overlay["env"]["ANTHROPIC_CUSTOM_HEADERS"]
 
-    def test_disables_experimental_betas(self):
+    def test_does_not_disable_experimental_betas(self):
+        # Would suppress the beta header 1h prompt caching needs.
         overlay, _ = claude.render_overlay(WS, "s4")
-        assert overlay["env"]["CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS"] == "1"
+        assert "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS" not in overlay["env"]
+
+    def test_enables_prompt_caching_1h(self):
+        overlay, _ = claude.render_overlay(WS, "s4")
+        assert overlay["env"]["ENABLE_PROMPT_CACHING_1H"] == "1"
+
+    def test_enables_tool_search(self):
+        overlay, _ = claude.render_overlay(WS, "s4")
+        assert overlay["env"]["ENABLE_TOOL_SEARCH"] == "true"
 
     def test_sets_api_key_helper(self):
         overlay, _ = claude.render_overlay(WS, "s4")
@@ -333,6 +342,29 @@ class TestWriteToolConfigMcpRegistration:
         }
         claude.write_tool_config(state, "databricks-claude-sonnet-4")
         assert calls == [("register", WS, "explicit-model")]
+
+
+class TestWriteToolConfigStripsRemovedEnvKeys:
+    """Stale keys ucode no longer writes are dropped from the merged settings."""
+
+    def _patch(self, monkeypatch, existing, written):
+        monkeypatch.setattr(claude, "backup_existing_file", lambda *a, **kw: True)
+        monkeypatch.setattr(claude, "read_json_safe", lambda path: existing)
+        monkeypatch.setattr(
+            claude, "write_json_file", lambda path, payload: written.append(payload)
+        )
+        monkeypatch.setattr(claude, "save_state", lambda state: None)
+        monkeypatch.setattr(claude, "_register_web_search_mcp", lambda *a, **kw: True)
+
+    def test_strips_stale_disable_experimental_betas(self, monkeypatch):
+        existing = {"env": {"CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1"}}
+        written: list = []
+        self._patch(monkeypatch, existing, written)
+        state = {"workspace": WS, "codex_models": []}
+        claude.write_tool_config(state, "databricks-claude-sonnet-4")
+        assert "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS" not in written[0]["env"]
+        assert written[0]["env"]["ENABLE_PROMPT_CACHING_1H"] == "1"
+        assert written[0]["env"]["ENABLE_TOOL_SEARCH"] == "true"
 
 
 class TestRegisterWebSearchMcp:

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -91,7 +91,11 @@ class TestRenderOverlay:
 
     def test_enables_tool_search(self):
         overlay, _ = claude.render_overlay(WS, "s4")
-        assert overlay["env"]["ENABLE_TOOL_SEARCH"] == "true"
+        assert overlay["env"]["ENABLE_TOOL_SEARCH"] == "1"
+
+    def test_enables_use_gateway(self):
+        overlay, _ = claude.render_overlay(WS, "s4")
+        assert overlay["env"]["CLAUDE_CODE_USE_GATEWAY"] == "1"
 
     def test_sets_api_key_helper(self):
         overlay, _ = claude.render_overlay(WS, "s4")
@@ -395,7 +399,8 @@ class TestWriteToolConfigStripsRemovedEnvKeys:
         claude.write_tool_config(state, "databricks-claude-sonnet-4")
         assert "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS" not in written[0]["env"]
         assert written[0]["env"]["ENABLE_PROMPT_CACHING_1H"] == "1"
-        assert written[0]["env"]["ENABLE_TOOL_SEARCH"] == "true"
+        assert written[0]["env"]["ENABLE_TOOL_SEARCH"] == "1"
+        assert written[0]["env"]["CLAUDE_CODE_USE_GATEWAY"] == "1"
 
 
 class TestRegisterWebSearchMcp:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -504,7 +504,6 @@ class TestClaudeLaunch:
                 "ANTHROPIC_MODEL": model_id,
                 "ANTHROPIC_BASE_URL": base_url,
                 "ANTHROPIC_API_KEY": e2e_token,
-                "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
             }
             cmd = claude.validate_cmd("claude")
             result = _run_agent(cmd, env=env, timeout=90)
@@ -571,7 +570,6 @@ class TestModelProviderLaunch:
             "CLAUDE_CONFIG_DIR": str(config_dir),
             "ANTHROPIC_BASE_URL": build_tool_base_url("claude", e2e_workspace),
             "ANTHROPIC_API_KEY": e2e_token,
-            "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS": "1",
         }
         result = _run_agent(claude.validate_cmd("claude"), env=env, timeout=90)
         combined = (result.stdout + result.stderr).strip()


### PR DESCRIPTION
## What

Sets two Claude Code env flags in the Claude settings `env` block, matching Isaac's config:

- `ENABLE_PROMPT_CACHING_1H=1` — opt into the 1-hour prompt-caching TTL.
- `ENABLE_TOOL_SEARCH=true` — enable Claude Code's deferred tool-search feature.

Before this can land, we need to ramp up `databricks.model.serving.allowAnthropicFirstPartyModelExtendedCacheTtl` to all workspaces. See [thread](https://databricks.slack.com/archives/C09MYH9BN5S/p1783969994794539)

## Why removing `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` is required

The 1h cache depends on the `extended-cache-ttl-2025-04-11` beta header. Verified against the `claude` 2.1.207 binary, that header is only attached when experimental betas are enabled:

```js
let D = PPe(querySource) ? "1h" : void 0;              // true when ENABLE_PROMPT_CACHING_1H set
if (D === "1h" && A1() && !b.includes(D_t)) b.push(D_t); // D_t = extended-cache-ttl beta header
// A1() = O0i() && !VUe();  VUe() = truthy(CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS) || hipaa
```

ucode previously set `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1`, which forced `A1()` false and suppressed the header — so `ENABLE_PROMPT_CACHING_1H` would have been silently ignored by the server. The flag is removed.

## Handling stale values

`deep_merge_dict` preserves keys already in `ucode-settings.json`, so simply not writing the key would leave it lingering in existing installs. A new `CLAUDE_REMOVED_ENV_KEYS` list is stripped from the managed settings file on every launch. This only touches ucode's own managed file — a user who wants experimental betas disabled can still set the flag in their own `~/.claude/settings.json` (strictly more permissive than the old behavior, which forced it on and blocked overrides).

`build_agent_state` (the reusable agent-config export) is kept in sync with the same flag change.

`CLAUDE_CODE_USE_GATEWAY` was considered but left out of scope: it selects an auth mode requiring `ANTHROPIC_AUTH_TOKEN`, which ucode doesn't set (it uses `apiKeyHelper`), so it would be ignored today.

## Testing

LL: I tested this locally and confirmed the 2 headers are set: extended-cache-ttl-2025-04-11 and advanced-tool-use-2025-11-20

```
anthropic-beta: claude-code-20250219,context-1m-2025-08-07,interleaved-thinking-2025-05-14,redact-thinking-2026-02-12,thinking-token-count-2026-05-13,context-management-2025-06-27,prompt-caching-scope-2026-01-05,mid-conversation-system-2026-04-07,advisor-tool-2026-03-01,advanced-tool-use-2025-11-20,effort-2025-11-24,**extended-cache-ttl-2025-04-11**
```

- `uv run pytest` — 863 passed, 6 skipped.
- `uv run ruff check .` — clean.
- Added tests: the beta key is absent from the overlay, both new flags are set, and a stale `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS` in an existing settings file is stripped.



This pull request and its description were written by Isaac.