### PR TITLE
ucode: add --version, tag-based install, and update-check nudge

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,106 @@
+name: Release tag
+
+# Manually cut a release: compute the next version (patch bump by default),
+# sync pyproject.toml, commit it to main, and push a matching vX.Y.Z tag.
+# The tag *is* the release — users install it with
+# `uv tool install "git+https://github.com/databricks/ucode@vX.Y.Z"`.
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Which part of the version to bump"
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          # Full history + tags so we can find the latest existing tag, and a
+          # token with write access so the bump commit + tag push are allowed.
+          fetch-depth: 0
+
+      - name: Compute next version
+        id: next
+        env:
+          BUMP: ${{ inputs.bump }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import os, re, subprocess
+
+          bump = os.environ.get("BUMP", "patch")
+
+          def parse(v):
+              m = re.match(r"v?(\d+)\.(\d+)\.(\d+)", v.strip())
+              return tuple(int(x) for x in m.groups()) if m else (0, 0, 0)
+
+          # Newest existing vX.Y.Z tag (empty repo -> 0.0.0).
+          tags = subprocess.run(
+              ["git", "tag", "--list", "v*.*.*"],
+              capture_output=True, text=True, check=True,
+          ).stdout.split()
+          latest_tag = max((parse(t) for t in tags), default=(0, 0, 0))
+
+          # Current pyproject.toml version.
+          text = open("pyproject.toml", encoding="utf-8").read()
+          proj = parse(re.search(r'(?m)^version = "([^"]+)"', text).group(1))
+
+          # Start from whichever is ahead, then bump the requested part. A
+          # hand-bumped pyproject (minor/major) above the latest tag wins as-is
+          # for that part; otherwise we just increment the patch.
+          base = max(latest_tag, proj)
+          major, minor, patch = base
+          if bump == "major":
+              major, minor, patch = major + 1, 0, 0
+          elif bump == "minor":
+              minor, patch = minor + 1, 0
+          else:
+              # If pyproject already jumped ahead of the tags, tag it as-is;
+              # otherwise increment the patch over the latest release.
+              if proj > latest_tag:
+                  major, minor, patch = proj
+              else:
+                  patch += 1
+
+          version = f"{major}.{minor}.{patch}"
+          tag = f"v{version}"
+          if tag in {f"v{p[0]}.{p[1]}.{p[2]}" for p in map(parse, tags)}:
+              raise SystemExit(f"Tag {tag} already exists — nothing to release.")
+          print(f"version={version}")
+          print(f"tag={tag}")
+          PY
+
+      - name: Sync pyproject.toml, commit, and tag
+        env:
+          VERSION: ${{ steps.next.outputs.version }}
+          TAG: ${{ steps.next.outputs.tag }}
+        run: |
+          python3 - <<'PY'
+          import os, re
+          version = os.environ["VERSION"]
+          path = "pyproject.toml"
+          text = open(path, encoding="utf-8").read()
+          text = re.sub(r'(?m)^version = "[^"]+"', f'version = "{version}"', text, count=1)
+          open(path, "w", encoding="utf-8").write(text)
+          PY
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Only commit when the version line actually changed (the first
+          # release may already match pyproject.toml). `[skip ci]` keeps the CI
+          # workflow from running on the bot's own bump.
+          if ! git diff --quiet -- pyproject.toml; then
+            git commit -am "ucode: release ${TAG} [skip ci]"
+            git push origin HEAD:main
+          fi
+          git tag "$TAG"
+          git push origin "$TAG"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,12 @@ Tests live in `tests/`.
 - Add or update focused tests for behavior changes.
 - Do not modify generated or lock files unless the dependency graph intentionally changes.
 
+## Versioning & releases
+
+- `ucode --version` prints `ucode <pyproject version> (<commit>)`. The commit comes from PEP 610 `direct_url.json` (`telemetry.ucode_commit()`): the short SHA for a git install, `editable` for a working checkout.
+- Releases are git tags, not PyPI. The **Release tag** workflow (`.github/workflows/release-tag.yml`, manual dispatch) computes the next `vX.Y.Z`, syncs `pyproject.toml`, commits to `main`, and pushes the tag. To force a minor/major, bump `version` in `pyproject.toml` first.
+- Users pin a version with `uv tool install "git+https://github.com/databricks/ucode@vX.Y.Z"`.
+
 ## Style
 
 - Keep user-facing CLI errors actionable.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,15 @@
 ## Installation
 
 ```bash
-uv tool install git+https://github.com/databricks/ucode
+uv tool install git+https://github.com/databricks/ucode            # latest (main)
+uv tool install "git+https://github.com/databricks/ucode@v0.2.0"   # a tagged release
+uv tool install "git+https://github.com/databricks/ucode@<sha>"    # an exact commit
 ```
+
+`ucode` is distributed straight from git, so you can pin any published release
+tag (`@vX.Y.Z`) or any commit (`@<sha>`). Check what you're running — and grab
+either handle to pin — with `ucode --version` (e.g. `ucode 0.2.0 (446a24a)`).
+`ucode upgrade` reinstalls the latest `main`.
 
 ---
 
@@ -98,6 +105,8 @@ Discovered external MCP connections are listed directly. MCP auth uses a Databri
 
 | Command | Description |
 |---------|-------------|
+| `ucode --version` | Show the installed version and commit (e.g. `ucode 0.2.0 (446a24a)`) |
+| `ucode upgrade` | Reinstall the latest `main` from GitHub |
 | `ucode status` | Show current workspace, base URLs, managed config files, and selected models |
 | `ucode usage` | Show AI Gateway usage summary |
 | `ucode revert` | Clear saved state and restore backed-up config files |
@@ -167,6 +176,17 @@ uv sync
 - Add `src/ucode/agents/<name>.py` with at least `write_tool_config`, `launch`, `default_model`, and `validate_cmd`.
 - Register it in `src/ucode/agents/__init__.py`.
 - Add focused tests under `tests/`.
+
+### Cutting a release
+
+Releases are git tags — there is no PyPI package. Trigger the **Release tag**
+workflow (Actions → Release tag → Run workflow); it patch-bumps by default, or
+pick `minor`/`major`. The workflow computes the next `vX.Y.Z`, writes it into
+`pyproject.toml`, commits that to `main`, and pushes the tag. Users then install
+it with `uv tool install "git+https://github.com/databricks/ucode@vX.Y.Z"`.
+
+To force a specific minor/major, bump `version` in `pyproject.toml` first — the
+workflow tags whatever is ahead of the latest existing tag.
 
 ## Security
 

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -66,6 +66,7 @@ from ucode.state import (
     save_state,
     set_provider_service,
 )
+from ucode.telemetry import ucode_version_string
 from ucode.tracing import configure_tracing_command
 from ucode.ui import (
     console,
@@ -84,6 +85,7 @@ from ucode.ui import (
     spinner,
     status_badge,
 )
+from ucode.update_check import maybe_warn_if_outdated
 from ucode.usage import usage as usage_report
 
 _DISCOVERY_CONSUMERS: dict[str, tuple[str, ...]] = {
@@ -763,6 +765,28 @@ mcp_app = typer.Typer(add_completion=False, no_args_is_help=True)
 app.add_typer(mcp_app, name="mcp", help="MCP servers exposed by ucode.")
 
 
+def _version_callback(value: bool) -> None:
+    if value:
+        console.print(ucode_version_string())
+        raise typer.Exit()
+
+
+@app.callback()
+def _root(
+    version: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            "-V",
+            callback=_version_callback,
+            is_eager=True,
+            help="Show the ucode version and exit.",
+        ),
+    ] = False,
+) -> None:
+    """Configure and launch coding agents through Databricks AI Gateway."""
+
+
 @mcp_app.command("web-search")
 def mcp_web_search_cmd() -> None:
     """Run the web_search MCP server over stdio. Invoked as a subprocess by Claude Code."""
@@ -865,6 +889,7 @@ def _launch_tool(
     skip_preflight: bool = False,
 ) -> None:
     try:
+        maybe_warn_if_outdated()
         tool = normalize_tool(tool_name)
         existing = load_state()
         # Workspaces configured with --use-pat export the profile's PAT as

--- a/src/ucode/telemetry.py
+++ b/src/ucode/telemetry.py
@@ -9,10 +9,11 @@ never block a launch.
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 from functools import cache
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import Distribution, PackageNotFoundError, version
 
 _SEMVER_RE = re.compile(r"\d+\.\d+\.\d+[-+0-9A-Za-z.]*")
 
@@ -23,6 +24,37 @@ def ucode_version() -> str:
         return version("ucode")
     except PackageNotFoundError:
         return "unknown"
+
+
+@cache
+def ucode_commit() -> str:
+    """Return an identifier for the exact installed build of ucode.
+
+    ucode is distributed straight from git (`uv tool install git+…`), so the
+    PEP 610 `direct_url.json` metadata records how this copy was installed:
+    a git install carries `vcs_info.commit_id` (the exact SHA), while a local
+    editable checkout carries `dir_info.editable`. We surface the short SHA for
+    git installs, "editable" for a working checkout, and "unknown" otherwise —
+    never raising, so `--version` and telemetry stay resilient.
+    """
+    try:
+        raw = Distribution.from_name("ucode").read_text("direct_url.json")
+        if not raw:
+            return "unknown"
+        info = json.loads(raw)
+    except (PackageNotFoundError, OSError, ValueError):
+        return "unknown"
+    commit = info.get("vcs_info", {}).get("commit_id")
+    if commit:
+        return commit[:7]
+    if info.get("dir_info", {}).get("editable"):
+        return "editable"
+    return "unknown"
+
+
+def ucode_version_string() -> str:
+    """Human-facing version line, e.g. `ucode 0.1.0 (446a24a)`."""
+    return f"ucode {ucode_version()} ({ucode_commit()})"
 
 
 @cache

--- a/src/ucode/update_check.py
+++ b/src/ucode/update_check.py
@@ -1,0 +1,91 @@
+"""Best-effort nudge when the installed ucode build is behind `main`.
+
+ucode is installed straight from git HEAD (`uv tool install git+…`), so "am I
+up to date?" means "does my commit match `main`?". We fetch `main`'s HEAD SHA
+from the GitHub API, compare it to the installed commit, and print a single
+warning when they differ.
+
+Everything here is best-effort: any failure (offline, rate-limited, editable
+checkout, unknown build) is swallowed silently. An update check must never
+block or break a launch — same principle as `telemetry`.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.request
+
+from ucode.config_io import APP_DIR, is_dry_run
+from ucode.telemetry import ucode_commit
+from ucode.ui import print_warning
+
+CACHE_PATH = APP_DIR / "update-check.json"
+# Only hit the network once a day — the nudge is a convenience, not a gate.
+CHECK_INTERVAL_S = 24 * 60 * 60
+_FETCH_TIMEOUT_S = 2
+_MAIN_COMMIT_URL = "https://api.github.com/repos/databricks/ucode/commits/main"
+
+
+def _fetch_remote_head() -> str | None:
+    """Return the short SHA of `main`'s HEAD, or None on any failure."""
+    req = urllib.request.Request(
+        _MAIN_COMMIT_URL,
+        headers={
+            "Accept": "application/vnd.github.sha",
+            "User-Agent": "ucode-update-check",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=_FETCH_TIMEOUT_S) as resp:
+            sha = resp.read().decode("utf-8").strip()
+    except Exception:
+        return None
+    return sha[:7] if sha else None
+
+
+def _read_cache() -> dict:
+    try:
+        return json.loads(CACHE_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+
+
+def _write_cache(payload: dict) -> None:
+    if is_dry_run():
+        return
+    try:
+        APP_DIR.mkdir(parents=True, exist_ok=True)
+        CACHE_PATH.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def maybe_warn_if_outdated() -> None:
+    """Warn once (per interval) if the installed commit is behind `main`.
+
+    No-ops for editable/unknown builds, when offline, or within the cache TTL.
+    Never raises.
+    """
+    try:
+        local = ucode_commit()
+        # Nothing to compare against for a working checkout or an install whose
+        # provenance we couldn't read.
+        if local in ("editable", "unknown"):
+            return
+
+        now = time.time()
+        cache = _read_cache()
+        remote = cache.get("remote_head")
+        if not remote or (now - cache.get("checked_at", 0)) >= CHECK_INTERVAL_S:
+            remote = _fetch_remote_head()
+            if remote:
+                _write_cache({"remote_head": remote, "checked_at": now})
+        if remote and remote != local:
+            print_warning(
+                f"A newer ucode is available (installed {local}, latest {remote}). "
+                "Run `ucode upgrade` to update."
+            )
+    except Exception:
+        # Telemetry-grade resilience: a broken update check must never surface.
+        return

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -15,6 +15,61 @@ class TestUcodeVersion:
         assert telemetry.ucode_version() != ""
 
 
+class TestUcodeCommit:
+    def setup_method(self):
+        telemetry.ucode_commit.cache_clear()
+
+    def _patch_direct_url(self, payload):
+        # Distribution.from_name(...).read_text("direct_url.json") is the PEP 610
+        # metadata source; stub it to exercise each install shape.
+        import json
+        from importlib.metadata import Distribution
+
+        class _Dist:
+            def read_text(self, name):
+                return json.dumps(payload) if payload is not None else None
+
+        return patch.object(Distribution, "from_name", return_value=_Dist())
+
+    def test_git_install_returns_short_sha(self):
+        payload = {
+            "url": "https://github.com/databricks/ucode",
+            "vcs_info": {"vcs": "git", "commit_id": "446a24a1077eac872fa5bd4c7fedc57666c51ad6"},
+        }
+        with self._patch_direct_url(payload):
+            assert telemetry.ucode_commit() == "446a24a"
+
+    def test_editable_checkout(self):
+        payload = {"url": "file:///home/x/ucode", "dir_info": {"editable": True}}
+        with self._patch_direct_url(payload):
+            assert telemetry.ucode_commit() == "editable"
+
+    def test_missing_direct_url_is_unknown(self):
+        with self._patch_direct_url(None):
+            assert telemetry.ucode_commit() == "unknown"
+
+    def test_non_editable_dir_install_is_unknown(self):
+        payload = {"url": "file:///home/x/ucode", "dir_info": {}}
+        with self._patch_direct_url(payload):
+            assert telemetry.ucode_commit() == "unknown"
+
+    def test_lookup_failure_is_unknown(self):
+        from importlib.metadata import Distribution, PackageNotFoundError
+
+        with patch.object(Distribution, "from_name", side_effect=PackageNotFoundError()):
+            telemetry.ucode_commit.cache_clear()
+            assert telemetry.ucode_commit() == "unknown"
+
+
+class TestUcodeVersionString:
+    def test_composes_version_and_commit(self):
+        with (
+            patch.object(telemetry, "ucode_version", return_value="0.2.0"),
+            patch.object(telemetry, "ucode_commit", return_value="446a24a"),
+        ):
+            assert telemetry.ucode_version_string() == "ucode 0.2.0 (446a24a)"
+
+
 class TestAgentVersion:
     def setup_method(self):
         # The helper is @cache'd; clear between tests so each gets a clean run.

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,0 +1,83 @@
+"""Tests for ucode.update_check."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from ucode import update_check
+
+
+def _configure(tmp_path, monkeypatch, *, local, remote, cache=None):
+    """Point the module at a temp cache and stub the local/remote commits.
+
+    Returns the cache path so tests can assert on what was persisted.
+    """
+    cache_path = tmp_path / "update-check.json"
+    if cache is not None:
+        cache_path.write_text(json.dumps(cache), encoding="utf-8")
+    monkeypatch.setattr(update_check, "CACHE_PATH", cache_path)
+    monkeypatch.setattr(update_check, "ucode_commit", lambda: local)
+    monkeypatch.setattr(update_check, "_fetch_remote_head", lambda: remote)
+    return cache_path
+
+
+class TestMaybeWarnIfOutdated:
+    def test_warns_when_behind(self, tmp_path, monkeypatch):
+        _configure(tmp_path, monkeypatch, local="aaaaaaa", remote="bbbbbbb")
+        with patch.object(update_check, "print_warning") as warn:
+            update_check.maybe_warn_if_outdated()
+        warn.assert_called_once()
+        assert "ucode upgrade" in warn.call_args.args[0]
+
+    def test_silent_when_up_to_date(self, tmp_path, monkeypatch):
+        _configure(tmp_path, monkeypatch, local="aaaaaaa", remote="aaaaaaa")
+        with patch.object(update_check, "print_warning") as warn:
+            update_check.maybe_warn_if_outdated()
+        warn.assert_not_called()
+
+    def test_silent_for_editable(self, tmp_path, monkeypatch):
+        # Editable checkout has no meaningful remote comparison — never fetch/warn.
+        _configure(tmp_path, monkeypatch, local="editable", remote="bbbbbbb")
+        with (
+            patch.object(update_check, "print_warning") as warn,
+            patch.object(update_check, "_fetch_remote_head") as fetch,
+        ):
+            update_check.maybe_warn_if_outdated()
+        warn.assert_not_called()
+        fetch.assert_not_called()
+
+    def test_silent_on_network_failure(self, tmp_path, monkeypatch):
+        _configure(tmp_path, monkeypatch, local="aaaaaaa", remote=None)
+        with patch.object(update_check, "print_warning") as warn:
+            update_check.maybe_warn_if_outdated()
+        warn.assert_not_called()
+
+    def test_writes_cache_after_fetch(self, tmp_path, monkeypatch):
+        cache_path = _configure(tmp_path, monkeypatch, local="aaaaaaa", remote="bbbbbbb")
+        update_check.maybe_warn_if_outdated()
+        saved = json.loads(cache_path.read_text(encoding="utf-8"))
+        assert saved["remote_head"] == "bbbbbbb"
+        assert "checked_at" in saved
+
+    def test_uses_cache_within_ttl(self, tmp_path, monkeypatch):
+        # A fresh cache entry means no network call this run.
+        import time
+
+        cache = {"remote_head": "bbbbbbb", "checked_at": time.time()}
+        _configure(tmp_path, monkeypatch, local="aaaaaaa", remote="ccccccc", cache=cache)
+        with (
+            patch.object(update_check, "_fetch_remote_head") as fetch,
+            patch.object(update_check, "print_warning") as warn,
+        ):
+            update_check.maybe_warn_if_outdated()
+        fetch.assert_not_called()
+        # Warns against the cached remote, not a fresh fetch.
+        warn.assert_called_once()
+
+    def test_refetches_after_ttl(self, tmp_path, monkeypatch):
+        stale = {"remote_head": "bbbbbbb", "checked_at": 0}
+        _configure(tmp_path, monkeypatch, local="aaaaaaa", remote="ccccccc", cache=stale)
+        with patch.object(update_check, "_fetch_remote_head", return_value="ccccccc") as fetch:
+            update_check.maybe_warn_if_outdated()
+        fetch.assert_called_once()


### PR DESCRIPTION
## What

Adds a user-facing version surface and a lightweight, git-tag-based release model for ucode.

Today `pyproject.toml` pins a static `0.1.0` that has never been bumped, there are no tags/releases, and everyone installs from `main` HEAD — so `importlib.metadata.version("ucode")` reports `0.1.0` for everyone regardless of which commit they actually run. This makes the version meaningful and gives users a way to install a specific one.

## Changes

- **`ucode --version` / `-V`** prints `ucode <version> (<commit>)`, e.g. `ucode 0.1.0 (446a24a)`. The commit is resolved from PEP 610 `direct_url.json` (`telemetry.ucode_commit()`): the short SHA for a git install, `editable` for a working checkout, `unknown` otherwise. Wired via a new top-level `@app.callback` with an eager option — bare `ucode` still shows help, and agent-launch passthrough (`ucode claude -V`) is unaffected.
- **Release tag workflow** (`.github/workflows/release-tag.yml`, manual dispatch): computes the next `vX.Y.Z` (patch bump by default; `minor`/`major` inputs), syncs `pyproject.toml`, commits to `main`, and pushes the tag. The tag *is* the release — no PyPI. Users pin with `uv tool install "git+https://github.com/databricks/ucode@vX.Y.Z"`.
- **Update-check nudge** (`update_check.py`): best-effort comparison of the installed commit to `main`'s HEAD via stdlib `urllib`, cached daily in `~/.ucode/update-check.json`, warns to run `ucode upgrade` when behind. No-ops for editable/unknown/offline installs and never raises (telemetry-grade resilience). Called from the launch path.
- **Docs**: install matrix (main / tag / sha) and release process in `README.md` and `AGENTS.md`.

No new dependencies — stdlib only, reusing existing helpers (`telemetry`, `config_io.APP_DIR`, `ui.print_warning`).

## Testing

- New unit tests: `ucode_commit()`/`ucode_version_string()` across all three metadata shapes; update-check behind/up-to-date/offline/editable + cache TTL (mocked fetch + clock, no network).
- Verified `ucode --version`, `-V`, bare help, and `ucode claude -V` passthrough manually.
- Verified `ucode_commit()` reads a real git-install `direct_url.json` (`446a24a`).
- Validated the workflow's next-version logic locally across scenarios.
- `uv run pytest` (unit) and `uv run ruff check .` pass. (The pre-existing `test_e2e_user_agent` failure needs a live gateway and is unrelated.)

**Note:** the full release workflow (bot commit + tag push) can only be exercised on GitHub after merge via Actions → Release tag → Run workflow.

This pull request and its description were written by Isaac.