### PR TITLE
Add `ucode configure skills --location` to register the UC Skills MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ location repoints skills at that schema.
 | `ucode configure --profiles DEFAULT` | Configure using existing Databricks CLI profiles (hosts come from `~/.databrickscfg`) |
 | `ucode configure --profiles DEFAULT --use-pat` | Authenticate with the profile's personal access token — no browser login |
 | `ucode configure --skip-validate` | Write configs without sending a test message through each agent |
-| `ucode configure skills --location <catalog>.<schema>` | Add the Unity Catalog Skills MCP server to configured tools |
 
 ## Managed Local Files
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ Options are shown in this order:
 Discovered external MCP connections are listed directly. MCP auth uses a Databricks token that
 `ucode` sets when launching each tool.
 
+### Skills (optional)
+
+```bash
+ucode configure skills --location <catalog>.<schema>
+```
+
+Add the Unity Catalog Skills MCP server for a `<catalog>.<schema>` to every configured
+MCP-capable tool. Claude Code additionally loads it eagerly (`alwaysLoad`) so the skills in that
+schema are discoverable; other agents get the same endpoint without eager loading. Uses the same
+Databricks token as `configure mcp`. Skills and other MCP servers coexist; re-running with a new
+location repoints skills at that schema.
+
 ---
 
 ## Other Commands
@@ -107,6 +119,7 @@ Discovered external MCP connections are listed directly. MCP auth uses a Databri
 | `ucode configure --profiles DEFAULT` | Configure using existing Databricks CLI profiles (hosts come from `~/.databrickscfg`) |
 | `ucode configure --profiles DEFAULT --use-pat` | Authenticate with the profile's personal access token — no browser login |
 | `ucode configure --skip-validate` | Write configs without sending a test message through each agent |
+| `ucode configure skills --location <catalog>.<schema>` | Add the Unity Catalog Skills MCP server to configured tools |
 
 ## Managed Local Files
 

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -54,6 +54,7 @@ from ucode.databricks import (
 from ucode.mcp import (
     MCP_CLIENTS,
     configure_mcp_command,
+    configure_skills_command,
     purge_cross_workspace_mcp_residue,
     revert_mcp_configs,
 )
@@ -671,7 +672,7 @@ def status() -> int:
         print_kv("Base URL", base_url)
         if configured and tool in MCP_CLIENTS:
             tool_mcp_servers = [
-                str(server.get("name"))
+                str(server.get("name")) + (" (skills)" if server.get("kind") == "skills" else "")
                 for server in mcp_servers
                 if tool in (server.get("clients") or []) and server.get("name")
             ]
@@ -706,6 +707,9 @@ def status() -> int:
     print_note("Use `ucode configure` to update workspace settings or configure new tools.")
     print_note(
         "Use `ucode configure mcp` to add Databricks MCP servers to configured coding tools."
+    )
+    print_note(
+        "Use `ucode configure skills --location <catalog>.<schema>` to add the UC Skills MCP."
     )
     print_note("Use `ucode configure tracing` to log coding sessions to an MLflow experiment.")
     print_note("Use `ucode revert` to clear managed configs and restore prior files.")
@@ -1214,6 +1218,29 @@ def configure_mcp(
     selected = None if services is None else {s.strip() for s in services.split(",") if s.strip()}
     try:
         configure_mcp_command(location=location, services=selected)
+    except RuntimeError as exc:
+        print_err(str(exc))
+        raise typer.Exit(1) from None
+    except KeyboardInterrupt:
+        print_err("Interrupted.")
+        raise typer.Exit(130) from None
+
+
+@configure_app.command("skills")
+def configure_skills(
+    location: Annotated[
+        str,
+        typer.Option(
+            "--location",
+            help="Unity Catalog `<catalog>.<schema>` whose UC Skills to expose (e.g. "
+            "`main.default`). The skills MCP is added to every configured agent; Claude "
+            "additionally loads it eagerly so skills are discoverable.",
+        ),
+    ],
+) -> None:
+    """Add the Unity Catalog Skills MCP server to installed coding tools."""
+    try:
+        configure_skills_command(location=location)
     except RuntimeError as exc:
         print_err(str(exc))
         raise typer.Exit(1) from None

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1323,8 +1323,6 @@ def build_mcp_service_url(workspace: str, full_name: str) -> str:
 
 
 def build_skills_mcp_url(workspace: str, catalog: str, schema: str) -> str:
-    """MCP endpoint that serves the UC Skills in ``catalog.schema``. Unlike the
-    mcp-services route this takes the schema as path segments, not a dotted name."""
     return f"{workspace}/ai-gateway/skills/{catalog}/{schema}"
 
 

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1322,6 +1322,12 @@ def build_mcp_service_url(workspace: str, full_name: str) -> str:
     return f"{workspace}/ai-gateway/mcp-services/{full_name}"
 
 
+def build_skills_mcp_url(workspace: str, catalog: str, schema: str) -> str:
+    """MCP endpoint that serves the UC Skills in ``catalog.schema``. Unlike the
+    mcp-services route this takes the schema as path segments, not a dotted name."""
+    return f"{workspace}/ai-gateway/skills/{catalog}/{schema}"
+
+
 # Maps the gateway routing dialect a coding tool speaks to the Model Provider
 # Service `provider_type`s it can be backed by. claude speaks Anthropic's API,
 # which both the `anthropic` and `amazon_bedrock` provider types serve (Bedrock

--- a/src/ucode/mcp.py
+++ b/src/ucode/mcp.py
@@ -29,6 +29,7 @@ from ucode.config_io import restore_file
 from ucode.databricks import (
     apply_pat_environment,
     build_mcp_service_url,
+    build_skills_mcp_url,
     ensure_databricks_auth,
     get_databricks_token,
     list_databricks_apps,
@@ -49,6 +50,10 @@ from ucode.ui import (
 )
 
 MCP_AUTH_TOKEN_ENV_VAR = "OAUTH_TOKEN"
+# `kind` tag on a saved MCP entry marking it as a UC Skills server. Skills
+# entries are eagerly loaded in Claude (see `apply_mcp_server_changes`); every
+# other entry is untagged and treated as a plain mcp-service.
+SKILLS_MCP_KIND = "skills"
 MCP_USER_SCOPE = "user"
 MCP_CLEANUP_SCOPES = ("local", "project", MCP_USER_SCOPE)
 MCP_PICKER_VISIBLE_ROWS = 10
@@ -96,14 +101,20 @@ MCP_CONNECTION_MARKERS = (
 )
 
 
-def build_mcp_http_entry(url: str) -> dict:
-    return {
+def build_mcp_http_entry(url: str, *, always_load: bool = False) -> dict:
+    entry: dict = {
         "type": "http",
         "url": url,
         "headers": {
             "Authorization": f"Bearer ${{{MCP_AUTH_TOKEN_ENV_VAR}}}",
         },
     }
+    # `alwaysLoad` makes Claude Code eagerly load the server's tool names and
+    # descriptions, which skills rely on to be discoverable. It is Claude-only;
+    # other agents receive just the URL and never see this field.
+    if always_load:
+        entry["alwaysLoad"] = True
+    return entry
 
 
 def add_claude_mcp_server(name: str, entry: dict, scope: str = MCP_USER_SCOPE) -> None:
@@ -1037,7 +1048,7 @@ def apply_mcp_server_changes(
         url = server.get("url")
         if not isinstance(url, str) or not url:
             continue
-        entry = build_mcp_http_entry(url)
+        entry = build_mcp_http_entry(url, always_load=server.get("kind") == SKILLS_MCP_KIND)
         for client in clients:
             configure_client_mcp_server(client, name, url, entry)
         changed = True
@@ -1125,8 +1136,7 @@ def _resolve_location_mcp_servers(
     since-removed service still configures the rest. An empty set selects
     nothing (every previously-registered service in the location is removed).
     ``None`` keeps the whole schema."""
-    if location.count(".") != 1 or not all(part.strip() for part in location.split(".")):
-        raise RuntimeError(f"--location must be `<catalog>.<schema>`, got `{location}`.")
+    _split_catalog_schema(location, "--location")
 
     token = get_databricks_token(workspace, profile)
     with spinner(f"Discovering MCP services in {location}..."):
@@ -1177,25 +1187,20 @@ def _resolve_location_mcp_servers(
     return working_servers
 
 
-def configure_mcp_command(location: str | None = None, services: set[str] | None = None) -> int:
-    if services is not None and location is None:
-        # `--services` works standalone with full names (`system.ai.github`): the
-        # `<catalog>.<schema>` to configure is derived from them. Bare short names
-        # (`github`) can't be located without `--location`.
-        schemas = {".".join(s.split(".")[:2]) for s in services if s.count(".") >= 2}
-        bare = sorted(s for s in services if s.count(".") < 2)
-        if bare:
-            raise RuntimeError(
-                "--services short names need --location (or pass full names like "
-                f"`system.ai.<name>`): {', '.join(bare)}"
-            )
-        if len(schemas) != 1:
-            raise RuntimeError(
-                "--services without --location must all share one `<catalog>.<schema>` "
-                f"(got: {', '.join(sorted(schemas)) or 'none'}); pass --location instead."
-            )
-        location = next(iter(schemas))
-    state = load_state()
+def _split_catalog_schema(location: str, flag: str) -> tuple[str, str]:
+    """Validate and split a ``<catalog>.<schema>`` location. ``flag`` names the
+    option being parsed so the error points at the right one."""
+    if location.count(".") != 1 or not all(part.strip() for part in location.split(".")):
+        raise RuntimeError(f"{flag} must be `<catalog>.<schema>`, got `{location}`.")
+    catalog, schema = (part.strip() for part in location.split("."))
+    return catalog, schema
+
+
+def _setup_mcp_clients(state: dict, section: str) -> tuple[str, str | None, list[str]]:
+    """Shared setup for the non-interactive MCP commands: validate the workspace,
+    drop cross-workspace residue, resolve the configured-and-installed clients,
+    authenticate, and announce the target agents. Returns
+    ``(workspace, profile, clients)``."""
     workspace = state.get("workspace")
     if not workspace:
         raise RuntimeError("Workspace is not configured. Run `ucode configure` first.")
@@ -1223,7 +1228,7 @@ def configure_mcp_command(location: str | None = None, services: set[str] | None
     apply_pat_environment(state)
     ensure_databricks_auth(workspace, profile)
 
-    print_section("MCP Servers")
+    print_section(section)
     client_names = ", ".join(str(MCP_CLIENTS[client]["display"]) for client in clients)
     print_note(f"Configuring for: {client_names}")
     for client in missing_clients:
@@ -1231,6 +1236,29 @@ def configure_mcp_command(location: str | None = None, services: set[str] | None
             f"{MCP_CLIENTS[client]['display']} is configured in ucode but not installed; "
             "skipping MCP config."
         )
+    return workspace, profile, clients
+
+
+def configure_mcp_command(location: str | None = None, services: set[str] | None = None) -> int:
+    if services is not None and location is None:
+        # `--services` works standalone with full names (`system.ai.github`): the
+        # `<catalog>.<schema>` to configure is derived from them. Bare short names
+        # (`github`) can't be located without `--location`.
+        schemas = {".".join(s.split(".")[:2]) for s in services if s.count(".") >= 2}
+        bare = sorted(s for s in services if s.count(".") < 2)
+        if bare:
+            raise RuntimeError(
+                "--services short names need --location (or pass full names like "
+                f"`system.ai.<name>`): {', '.join(bare)}"
+            )
+        if len(schemas) != 1:
+            raise RuntimeError(
+                "--services without --location must all share one `<catalog>.<schema>` "
+                f"(got: {', '.join(sorted(schemas)) or 'none'}); pass --location instead."
+            )
+        location = next(iter(schemas))
+    state = load_state()
+    workspace, profile, clients = _setup_mcp_clients(state, "MCP Servers")
 
     original_mcp_servers_for_location: list[dict] = list(state.get("mcp_servers") or [])
     if location is not None:
@@ -1334,4 +1362,59 @@ def configure_mcp_command(location: str | None = None, services: set[str] | None
     elif not selections and not original_mcp_servers:
         # User submitted the picker without toggling anything --> make it clear nothing was selected
         print_note("No MCP servers selected. Press space to toggle an item, then enter to save.")
+    return 0
+
+
+def _resolve_skills_mcp_servers(
+    workspace: str,
+    clients: list[str],
+    location: str,
+    original_servers: list[dict],
+) -> list[dict]:
+    """Build the desired MCP server list for ``ucode configure skills``.
+
+    Registers exactly one skills entry for ``location`` (a ``<catalog>.<schema>``)
+    and drops any previously-registered skills entry, so a re-run repoints skills
+    at the new schema. Non-skills entries (plain mcp-services) are preserved:
+    skills and mcp-services can coexist."""
+    catalog, schema = _split_catalog_schema(location, "--location")
+    entry_name = _catalog_schema_server_name("databricks-skills", catalog, schema, set())
+
+    original = _servers_by_name(original_servers).get(entry_name)
+    original_clients = list((original or {}).get("clients") or [])
+    merged_clients = original_clients + [c for c in clients if c not in original_clients]
+    skills_entry = {
+        "name": entry_name,
+        "url": build_skills_mcp_url(workspace, catalog, schema),
+        "auth": f"env:{MCP_AUTH_TOKEN_ENV_VAR}",
+        "clients": merged_clients,
+        "kind": SKILLS_MCP_KIND,
+    }
+    # `apply_mcp_server_changes` compares by value, so re-emitting an unchanged
+    # entry is a no-op; only a genuinely repointed skills entry re-registers.
+    kept = [
+        s
+        for s in original_servers
+        if s.get("kind") != SKILLS_MCP_KIND and _server_name(s) != entry_name
+    ]
+    return [*kept, skills_entry]
+
+
+def configure_skills_command(location: str) -> int:
+    """Register the UC Skills MCP for ``location`` across configured agents.
+
+    Skills are eagerly loaded in Claude (via ``alwaysLoad``); other agents get
+    the same endpoint without eager loading, which their CLIs cannot express."""
+    state = load_state()
+    workspace, _profile, clients = _setup_mcp_clients(state, "Skills MCP")
+
+    original_mcp_servers: list[dict] = list(state.get("mcp_servers") or [])
+    working_mcp_servers = _resolve_skills_mcp_servers(
+        workspace, clients, location, original_mcp_servers
+    )
+    changed = apply_mcp_server_changes(original_mcp_servers, working_mcp_servers, clients)
+    if changed or original_mcp_servers != working_mcp_servers:
+        state["mcp_servers"] = working_mcp_servers
+        save_state(state)
+        print_success("Saved")
     return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,6 +157,30 @@ class TestMcpSubcommands:
         assert "web-search" in result.output
 
 
+class TestConfigureSkillsCommand:
+    def test_dispatches_location_to_command(self, monkeypatch):
+        calls: list[str] = []
+        monkeypatch.setattr(
+            "ucode.cli.configure_skills_command", lambda location: calls.append(location) or 0
+        )
+        result = runner.invoke(app, ["configure", "skills", "--location", "main.default"])
+        assert result.exit_code == 0
+        assert calls == ["main.default"]
+
+    def test_requires_location(self):
+        result = runner.invoke(app, ["configure", "skills"])
+        assert result.exit_code != 0
+
+    def test_runtime_error_exits_nonzero(self, monkeypatch):
+        def boom(location):
+            raise RuntimeError("Workspace is not configured.")
+
+        monkeypatch.setattr("ucode.cli.configure_skills_command", boom)
+        result = runner.invoke(app, ["configure", "skills", "--location", "main.default"])
+        assert result.exit_code == 1
+        assert "Workspace is not configured." in result.output
+
+
 class TestAuthTokenCommand:
     """`ucode auth-token` is the cross-platform apiKeyHelper (#116)."""
 

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -512,6 +512,20 @@ class TestModelProviderFeatureUnavailable:
         assert db_mod.is_model_provider_feature_unavailable(None) is False
 
 
+class TestBuildMcpUrls:
+    def test_mcp_service_url_keeps_dotted_name(self):
+        assert (
+            db_mod.build_mcp_service_url(WS, "system.ai.github")
+            == f"{WS}/ai-gateway/mcp-services/system.ai.github"
+        )
+
+    def test_skills_url_uses_path_segments(self):
+        assert (
+            db_mod.build_skills_mcp_url(WS, "main", "default")
+            == f"{WS}/ai-gateway/skills/main/default"
+        )
+
+
 class TestListMcpServices:
     def test_accepts_entries_without_connection_status(self, monkeypatch):
         payload = {

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -25,6 +25,13 @@ class TestBuildMcpHttpEntry:
         assert "oauth" not in entry
         assert "headersHelper" not in entry
 
+    def test_omits_always_load_by_default(self):
+        assert "alwaysLoad" not in mcp.build_mcp_http_entry(f"{WS}/api/2.0/mcp/external/github")
+
+    def test_sets_always_load_when_requested(self):
+        entry = mcp.build_mcp_http_entry(f"{WS}/ai-gateway/skills/main/default", always_load=True)
+        assert entry["alwaysLoad"] is True
+
 
 class TestAddClaudeMcpServer:
     def test_adds_user_scoped_json(self, monkeypatch):
@@ -221,6 +228,36 @@ class TestConfigureClientMcpServer:
 
         assert removed_scopes == []
         assert calls == [("github", f"{WS}/api/2.0/mcp/external/github")]
+
+    def test_claude_receives_entry_with_always_load(self, monkeypatch):
+        added: dict = {}
+        url = f"{WS}/ai-gateway/skills/main/default"
+        entry = mcp.build_mcp_http_entry(url, always_load=True)
+        monkeypatch.setattr(mcp, "remove_claude_mcp_server", lambda name, scope: False)
+        monkeypatch.setattr(
+            mcp,
+            "add_claude_mcp_server",
+            lambda name, entry, scope: added.update(name=name, entry=entry),
+        )
+
+        mcp.configure_client_mcp_server("claude", "databricks-skills-main-default", url, entry)
+
+        assert added["entry"]["alwaysLoad"] is True
+
+    def test_codex_receives_only_the_url(self, monkeypatch):
+        added: dict = {}
+        url = f"{WS}/ai-gateway/skills/main/default"
+        entry = mcp.build_mcp_http_entry(url, always_load=True)
+        monkeypatch.setattr(mcp, "remove_codex_mcp_server", lambda name: False)
+        monkeypatch.setattr(
+            mcp, "add_codex_mcp_server", lambda name, url: added.update(name=name, url=url)
+        )
+
+        mcp.configure_client_mcp_server("codex", "databricks-skills-main-default", url, entry)
+
+        # codex's add signature takes no entry, so alwaysLoad structurally cannot
+        # reach it -- it is registered from the URL alone.
+        assert added == {"name": "databricks-skills-main-default", "url": url}
 
 
 class TestMcpPicker:
@@ -1640,6 +1677,93 @@ class TestConfigureMcpServicesSubset:
             raise AssertionError(
                 "expected RuntimeError for multi-schema services without --location"
             )
+
+
+class TestConfigureSkills:
+    def test_rejects_malformed_location(self, monkeypatch):
+        _stub_location_base(monkeypatch, {**CLAUDE_STATE})
+        for bad in ("main", "cat.sch.extra", ".sch", "cat.", ""):
+            try:
+                mcp.configure_skills_command(location=bad)
+            except RuntimeError as exc:
+                assert "--location" in str(exc)
+            else:
+                raise AssertionError(f"expected RuntimeError for `{bad}`")
+
+    def test_registers_skills_entry_for_every_agent(self, monkeypatch):
+        saved_states: list[dict] = []
+        configured: list[tuple[str, str, str, dict]] = []
+        state = {"workspace": WS, "available_tools": ALL_MCP_CLIENTS}
+        _stub_location_base(monkeypatch, state)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: list(ALL_MCP_CLIENTS))
+        monkeypatch.setattr(
+            mcp,
+            "configure_client_mcp_server",
+            lambda client, name, url, entry: configured.append((client, name, url, entry)) or [],
+        )
+        monkeypatch.setattr(mcp, "save_state", lambda state: saved_states.append(state.copy()))
+
+        assert mcp.configure_skills_command(location="main.default") == 0
+
+        assert {c[0] for c in configured} == set(ALL_MCP_CLIENTS)
+        assert {c[1] for c in configured} == {"databricks-skills-main-default"}
+        assert {c[2] for c in configured} == {f"{WS}/ai-gateway/skills/main/default"}
+        # The skills entry carries alwaysLoad; only Claude's CLI consumes it (see
+        # TestConfigureClientMcpServerAlwaysLoad for the per-agent dispatch).
+        assert all(c[3].get("alwaysLoad") is True for c in configured)
+        assert saved_states[-1]["mcp_servers"] == [
+            {
+                "name": "databricks-skills-main-default",
+                "url": f"{WS}/ai-gateway/skills/main/default",
+                "auth": "env:OAUTH_TOKEN",
+                "clients": ALL_MCP_CLIENTS,
+                "kind": "skills",
+            }
+        ]
+
+    def test_repoints_prior_skills_entry_but_keeps_mcp_services(self, monkeypatch):
+        saved_states: list[dict] = []
+        removed: list[tuple[str, str]] = []
+        service_entry = {
+            "name": "system-ai-github",
+            "url": f"{WS}/ai-gateway/mcp-services/system.ai.github",
+            "auth": "env:OAUTH_TOKEN",
+            "clients": ["claude"],
+        }
+        stale_skills = {
+            "name": "databricks-skills-main-old",
+            "url": f"{WS}/ai-gateway/skills/main/old",
+            "auth": "env:OAUTH_TOKEN",
+            "clients": ["claude"],
+            "kind": "skills",
+        }
+        _stub_location_base(
+            monkeypatch,
+            {**CLAUDE_STATE, "mcp_servers": [service_entry, stale_skills]},
+        )
+        monkeypatch.setattr(mcp, "configure_client_mcp_server", lambda client, name, url, entry: [])
+        monkeypatch.setattr(
+            mcp,
+            "remove_client_mcp_server",
+            lambda client, name: removed.append((client, name)) or [],
+        )
+        monkeypatch.setattr(mcp, "save_state", lambda state: saved_states.append(state.copy()))
+
+        assert mcp.configure_skills_command(location="main.default") == 0
+
+        # The stale skills entry is removed; the mcp-service is untouched.
+        assert removed == [("claude", "databricks-skills-main-old")]
+        saved = saved_states[-1]["mcp_servers"]
+        assert service_entry in saved
+        assert [s for s in saved if s.get("kind") == "skills"] == [
+            {
+                "name": "databricks-skills-main-default",
+                "url": f"{WS}/ai-gateway/skills/main/default",
+                "auth": "env:OAUTH_TOKEN",
+                "clients": ["claude"],
+                "kind": "skills",
+            }
+        ]
 
 
 class TestRevertMcpConfigs:


### PR DESCRIPTION
## What & why

Adds a non-interactive command that registers the Unity Catalog **Skills** MCP endpoint for a `<catalog>.<schema>`, replacing the manual `~/.claude.json` edit used during the skills bug bash:

```bash
ucode configure skills --location <catalog>.<schema>
```

The endpoint (`/ai-gateway/skills/<cat>/<sch>`) is added to **every configured MCP-capable agent** (Claude, Codex, Gemini, OpenCode, Copilot). Claude Code additionally receives `alwaysLoad: true` so the schema's skills are eagerly loaded and discoverable; the other agents get the same endpoint from the URL alone, which their CLIs cannot express.

## Implementation

- **`databricks.py`** — `build_skills_mcp_url()` builds `{ws}/ai-gateway/skills/{cat}/{sch}` (path segments, unlike the dotted mcp-services route).
- **`mcp.py`**
  - `build_mcp_http_entry(url, *, always_load=False)` adds `alwaysLoad` when requested.
  - Skills entries are tagged `kind: "skills"` in saved state; `apply_mcp_server_changes` derives `always_load` from that tag. The field rides in the shared entry dict but only Claude's `mcp add-json` path consumes it — other agents are registered from the URL alone.
  - `_resolve_skills_mcp_servers` registers exactly one skills entry, **preserving** coexisting mcp-services and dropping any stale skills entry so re-runs repoint cleanly.
  - `configure_skills_command()` fans out to all configured agents via the existing apply path.
- **`cli.py`** — `configure skills` subcommand with a required `--location`; `ucode status` labels skills entries `(skills)`.
- **Refactor (no behavior change):** the non-interactive preamble shared by the mcp and skills commands is extracted into `_setup_mcp_clients`, and the `<catalog>.<schema>` validation into `_split_catalog_schema`.

## Out of scope

- Skills-schema discovery / interactive picker (one `--location` per invocation for now).
- Eager loading for non-Claude agents (their CLIs can't express it).

## Testing

### Unit tests

- 882 unit tests pass (`uv run pytest`, excluding e2e); `ruff check`, `ruff format --check`, and `ty` all clean.
- New coverage: URL builder, `alwaysLoad` on/off, per-agent dispatch (Claude gets the entry, Codex gets URL-only), skills registration across all agents, stale-skills replacement while preserving mcp-services, malformed `--location`, and CLI wiring (dispatch, required flag, error exit code).

### Manual end-to-end (against a real workspace)

Ran against staging workspace `eng-ml-inference.staging.cloud.databricks.com` with a real skills schema `xsh.xsh_oncall_skills`, configuring both Claude Code and Codex:

```bash
ucode configure --profiles eng-ml-inference-staging --agents claude,codex
ucode configure skills --location xsh.xsh_oncall_skills
```

**Config written correctly:**

| Check | Result |
|---|---|
| Registered for every configured agent | ✅ Claude + Codex |
| Claude entry (`~/.claude.json`) has `alwaysLoad: true` | ✅ |
| Codex entry (`~/.codex/config.toml`) is URL-only, **no** `alwaysLoad` | ✅ (`bearer_token_env_var = "OAUTH_TOKEN"`, no alwaysLoad key) |
| URL preserves the real schema; server name is agent-safe | ✅ URL `…/skills/xsh/xsh_oncall_skills`; name `databricks-skills-xsh-xsh-oncall-skills` (dots/underscores slugified since agent CLIs reject them) |
| `ucode status` labels the entry `(skills)` | ✅ under both agents |
| Coexists with other MCP servers; re-running repoints cleanly | ✅ |

**Auth + live connection verified.** The entry authenticates with `Bearer ${OAUTH_TOKEN}`, which ucode injects into the agent's environment at launch (`claude.py`), so a directly-launched agent returns 401 while an agent launched via `ucode claude` gets a fresh token. Confirmed both cases against the endpoint's MCP `initialize`:

- empty token (direct launch) → **HTTP 401** (expected)
- real ucode-injected token → **HTTP 200**

**Skills actually load.** Launched Claude via `ucode claude`; `/mcp` shows the server connected, and `tools/list` returns **11 tools** — the 5 skills from `xsh.xsh_oncall_skills` exposed as `skill_<leaf>` plus the 6 static utility tools (`load_skill`, `get_skill_files`, `list_skills`, `create_skill`, `update_skill`, `delete_skill`). `tools/call` verified working on the loaded skills.

<img width="1265" height="546" alt="Screenshot 2026-07-15 at 4 37 01 PM" src="https://github.com/user-attachments/assets/2e228057-c791-4270-a7de-d371f28c679b" />

<img width="1264" height="655" alt="Screenshot 2026-07-15 at 4 42 07 PM" src="https://github.com/user-attachments/assets/51d876ba-39e5-4013-935f-f0cbb55f9328" />


### Note on auth UX

Like all ucode-managed Databricks MCP servers, the skills entry relies on `OAUTH_TOKEN` being present in the agent's environment, which only happens when the agent is launched **through ucode** (`ucode claude`, `ucode codex`, …). Opening the agent directly yields a 401. This matches existing ucode MCP behavior and is more secure than baking a static PAT into the config (as the manual bug-bash setup did), but it's a sharp edge worth documenting for users.