### PR TITLE
Fix validate_tool hang: pass stdin=DEVNULL to the validation subprocess

### DIFF
--- a/src/ucode/agents/__init__.py
+++ b/src/ucode/agents/__init__.py
@@ -465,14 +465,6 @@ def validate_tool(tool: str) -> tuple[bool, str]:
         except RuntimeError:
             env = None
     try:
-        # stdin=DEVNULL: the validate command is a one-shot smoke test (e.g.
-        # `pi --print "say hi..."`) that never needs interactive input. Some
-        # agent CLIs still open stdin in print mode and block on it; without
-        # this, `subprocess.run` inherits our stdin, so when ucode itself is
-        # launched from a non-interactive parent whose stdin is an open pipe
-        # with no EOF (e.g. an agent harness spawning `ucode <tool>`), the
-        # validation subprocess hangs until the 60s timeout and reports a
-        # spurious "timed out" / "validation failed".
         result = subprocess.run(
             cmd,
             check=False,

--- a/src/ucode/agents/__init__.py
+++ b/src/ucode/agents/__init__.py
@@ -465,8 +465,22 @@ def validate_tool(tool: str) -> tuple[bool, str]:
         except RuntimeError:
             env = None
     try:
+        # stdin=DEVNULL: the validate command is a one-shot smoke test (e.g.
+        # `pi --print "say hi..."`) that never needs interactive input. Some
+        # agent CLIs still open stdin in print mode and block on it; without
+        # this, `subprocess.run` inherits our stdin, so when ucode itself is
+        # launched from a non-interactive parent whose stdin is an open pipe
+        # with no EOF (e.g. an agent harness spawning `ucode <tool>`), the
+        # validation subprocess hangs until the 60s timeout and reports a
+        # spurious "timed out" / "validation failed".
         result = subprocess.run(
-            cmd, check=False, capture_output=True, text=True, timeout=60, env=env
+            cmd,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            env=env,
+            stdin=subprocess.DEVNULL,
         )
         if result.returncode == 0:
             return True, ""

--- a/tests/test_agents_init.py
+++ b/tests/test_agents_init.py
@@ -567,3 +567,37 @@ class TestValidateAllToolsVerbosity:
         assert "Ready" not in out
         # Per-tool success line is still printed.
         assert "Codex is working" in out
+
+
+class TestValidateTool:
+    def test_runs_validate_command_with_stdin_devnull(self, monkeypatch):
+        # Regression guard: the validation smoke test must never inherit the
+        # caller's stdin, or it hangs to the timeout when ucode is launched
+        # from a non-interactive parent whose stdin is an open pipe.
+        captured: dict = {}
+
+        def fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr("ucode.agents.subprocess.run", fake_run)
+        monkeypatch.setattr(agents_mod, "load_state", lambda: {})
+
+        ok, err = agents_mod.validate_tool("codex")
+
+        assert ok is True
+        assert err == ""
+        assert captured["kwargs"].get("stdin") is subprocess.DEVNULL
+
+    def test_reports_timed_out_on_timeout(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd, 60)
+
+        monkeypatch.setattr("ucode.agents.subprocess.run", fake_run)
+        monkeypatch.setattr(agents_mod, "load_state", lambda: {})
+
+        ok, err = agents_mod.validate_tool("codex")
+
+        assert ok is False
+        assert err == "timed out"


### PR DESCRIPTION
## What

`validate_tool` runs each tool's smoke test (`pi --print …`, `codex exec …`) via `subprocess.run(..., timeout=60)` without setting `stdin`, so the child inherits ucode's stdin. pi and codex open stdin in print/exec mode and block on it. When ucode is launched from a non-interactive parent whose stdin is an open pipe with no EOF (e.g. an agent harness spawning `ucode <tool>`), validation hangs the full 60s and returns a spurious `timed out` → `<tool> validation failed — config reverted`, even though the tool is configured correctly.

## Fix

Pass `stdin=subprocess.DEVNULL` — the smoke test is one-shot and never needs input. Benign for every tool.

## Verified

Open-stdin-pipe condition, before (`main`) vs after:

| tool | before | after |
|---|---|---|
| pi (real `validate_tool`) | `timed out`, 60s | ok, 0s |
| codex (real `validate_tool`) | `timed out`, 60s | ok, 0s |
| real `pi --print` on sandbox | hang, 60s | reply, 2s |
| real `codex exec` on sandbox | hang, 60s | reply, 3s |

Added `TestValidateTool` (asserts `stdin=DEVNULL`; `TimeoutExpired` → `timed out`). Full suite: 875 passed, ruff clean.
