### PR TITLE
Skip gemini flash-lite-image model in opencode per-model e2e test

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -711,7 +711,9 @@ class TestOpencodeLaunch:
     # no stderr beyond the initial `> build · <model>` line, while every
     # other configured model returns in ~3s. Backend-side latency we can't
     # influence from this repo; skip rather than block CI.
-    SKIP_MODELS: frozenset[str] = frozenset({"databricks-gemini-3-1-flash-lite"})
+    SKIP_MODELS: frozenset[str] = frozenset(
+        {"databricks-gemini-3-1-flash-lite", "databricks-gemini-3-1-flash-lite-image"}
+    )
 
     def _all_models(self, e2e_state: dict) -> list[tuple[str, str]]:
         """Return [(provider, model_id), ...] for all opencode models."""


### PR DESCRIPTION
`databricks-gemini-3-1-flash-lite-image` is an image-generation model that rejects function calling with a 400, so opencode can never launch it. Add it to SKIP_MODELS.

Co-authored-by: Isaac