### PR TITLE
Install Databricks AI Tools as part of the configuration step

### DIFF
--- a/src/ucode/agents/__init__.py
+++ b/src/ucode/agents/__init__.py
@@ -20,6 +20,7 @@ from ucode.config_io import ToolSpec
 from ucode.databricks import (
     BEDROCK_PROVIDER_TYPES,
     get_databricks_token,
+    install_ai_tools,
     install_databricks_cli,
     map_bedrock_claude_models,
     resolve_provider_service,
@@ -64,6 +65,23 @@ TOOL_ALIASES = {
 
 DEFAULT_TOOL = "codex"
 BUNDLE_VERSION = 1
+
+# ucode tool -> `databricks aitools` agent id. gemini/pi aren't supported.
+AITOOLS_AGENT_TOKENS = {
+    "claude": "claude-code",
+    "codex": "codex",
+    "opencode": "opencode",
+    "copilot": "copilot",
+}
+
+
+def install_ai_tools_for_agents(tools: list[str], profile: str | None) -> None:
+    """Install Databricks AI Tools for the coding agents that support them.
+
+    ``tools`` are ucode tool keys (e.g. ``"claude"``); we map each to its
+    ``databricks aitools`` agent id and drop the unsupported ones (gemini, pi)."""
+    tokens = [AITOOLS_AGENT_TOKENS[tool] for tool in tools if tool in AITOOLS_AGENT_TOKENS]
+    install_ai_tools(tokens, profile)
 
 
 def normalize_tool(tool: str) -> str:
@@ -380,6 +398,7 @@ def configure_single_tool(tool: str, state: dict) -> dict:
     available_tools = list(set((state.get("available_tools") or []) + [tool]))
     state["available_tools"] = available_tools
     save_state(state)
+    install_ai_tools_for_agents([tool], state.get("profile"))
     return state
 
 
@@ -410,6 +429,7 @@ def configure_selected_tools(state: dict, tools: list[str]) -> dict:
     existing = state.get("available_tools") or []
     state["available_tools"] = sorted(set(existing) | set(tools))
     save_state(state)
+    install_ai_tools_for_agents(tools, state.get("profile"))
     return state
 
 

--- a/src/ucode/agents/__init__.py
+++ b/src/ucode/agents/__init__.py
@@ -75,13 +75,13 @@ AITOOLS_AGENT_TOKENS = {
 }
 
 
-def install_ai_tools_for_agents(tools: list[str], profile: str | None) -> None:
-    """Install Databricks AI Tools for the coding agents that support them.
-
-    ``tools`` are ucode tool keys (e.g. ``"claude"``); we map each to its
-    ``databricks aitools`` agent id and drop the unsupported ones (gemini, pi)."""
-    tokens = [AITOOLS_AGENT_TOKENS[tool] for tool in tools if tool in AITOOLS_AGENT_TOKENS]
-    install_ai_tools(tokens, profile)
+def install_ai_tools_for_agents(tools: list[str], state: dict) -> None:
+    """Install Databricks AI Tools for the coding agents that support them
+    (gemini/pi have no ``aitools`` support and are dropped)."""
+    if state.get("databricks_ai_tools_enabled", True) is False:
+        return
+    agents = [AITOOLS_AGENT_TOKENS[tool] for tool in tools if tool in AITOOLS_AGENT_TOKENS]
+    install_ai_tools(agents, state.get("profile"))
 
 
 def normalize_tool(tool: str) -> str:
@@ -398,7 +398,7 @@ def configure_single_tool(tool: str, state: dict) -> dict:
     available_tools = list(set((state.get("available_tools") or []) + [tool]))
     state["available_tools"] = available_tools
     save_state(state)
-    install_ai_tools_for_agents([tool], state.get("profile"))
+    install_ai_tools_for_agents([tool], state)
     return state
 
 
@@ -429,7 +429,7 @@ def configure_selected_tools(state: dict, tools: list[str]) -> dict:
     existing = state.get("available_tools") or []
     state["available_tools"] = sorted(set(existing) | set(tools))
     save_state(state)
-    install_ai_tools_for_agents(tools, state.get("profile"))
+    install_ai_tools_for_agents(tools, state)
     return state
 
 

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -648,6 +648,16 @@ def configure_workspace_command(
         for tool_name in picked:
             state = _maybe_select_provider_service(tool_name, state)
 
+    # Last question in the interactive flow: opt out of AI Tools. When a flag
+    # already decided it, configure_shared_state persisted that; skip the prompt.
+    # The default is the resolved prior choice, so Enter won't undo a past opt-out.
+    if databricks_ai_tools_enabled is None and offer_provider:
+        state["databricks_ai_tools_enabled"] = prompt_yes_no_default(
+            "Install Databricks AI Tools for your coding agents? "
+            "This adds Databricks skills and plugins.",
+            default=state.get("databricks_ai_tools_enabled", True),
+        )
+
     state = configure_selected_tools(state, picked)
 
     summary_lines = [f"[bold]Workspace:[/bold] [cyan]{state['workspace']}[/cyan]"]
@@ -1192,17 +1202,6 @@ def configure(
         # target claude instead of dropping into the interactive agent picker.
         if enable_fable is not None and agent is None and agents is None:
             agent = "claude"
-        # Bare `ucode configure`: nothing named on the command line, so there's
-        # a terminal to prompt in. Naming an agent or workspace/profile is a
-        # non-interactive run. (workspace_entries covers --workspaces/--profiles.)
-        interactive_configure = agent is None and agents is None and workspace_entries is None
-        if enable_databricks_ai_tools is None and interactive_configure:
-            # Default to prior choice so Enter doesn't undo a past opt-out.
-            prior_disabled = load_state().get("databricks_ai_tools_enabled") is False
-            enable_databricks_ai_tools = prompt_yes_no_default(
-                "Install Databricks AI Tools for your coding agents?",
-                default=not prior_disabled,
-            )
         if enable_databricks_ai_tools is not None:
             skip_kwargs["databricks_ai_tools_enabled"] = enable_databricks_ai_tools
         if agent is not None:

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -80,6 +80,7 @@ from ucode.ui import (
     prompt_for_selection,
     prompt_for_tools,
     prompt_for_workspace,
+    prompt_yes_no_default,
     set_verbosity,
     spinner,
     status_badge,
@@ -218,6 +219,7 @@ def configure_shared_state(
     skip_model_discovery: bool = False,
     skip_preflight: bool = False,
     fable_enabled: bool | None = None,
+    databricks_ai_tools_enabled: bool | None = None,
 ) -> dict:
     """Log into Databricks, enforce AI Gateway v2, fetch model lists, persist state.
 
@@ -249,6 +251,14 @@ def configure_shared_state(
         use_pat = bool(prior_state.get("use_pat")) and previous_workspace == workspace
     if fable_enabled is None:
         fable_enabled = bool(prior_state.get("fable_enabled")) and previous_workspace == workspace
+    if databricks_ai_tools_enabled is None:
+        # Opt-out: on by default. With no flag, keep this workspace's prior
+        # choice but don't inherit another workspace's opt-out.
+        disabled = (
+            prior_state.get("databricks_ai_tools_enabled") is False
+            and previous_workspace == workspace
+        )
+        databricks_ai_tools_enabled = not disabled
     fetch_all = tools is None
 
     # Assemble the shared workspace state that doesn't depend on model discovery:
@@ -278,6 +288,7 @@ def configure_shared_state(
         state["fable_enabled"] = True
     else:
         state.pop("fable_enabled", None)
+    state["databricks_ai_tools_enabled"] = databricks_ai_tools_enabled
     state["base_urls"] = build_shared_base_urls(workspace)
 
     if skip_preflight:
@@ -436,6 +447,7 @@ def _configure_shared_workspace_states(
     force_login: bool,
     use_pat: bool = False,
     fable_enabled: bool | None = None,
+    databricks_ai_tools_enabled: bool | None = None,
 ) -> list[dict]:
     if not workspaces:
         raise RuntimeError("At least one workspace must be provided.")
@@ -449,6 +461,7 @@ def _configure_shared_workspace_states(
                 force_login=force_login,
                 use_pat=use_pat,
                 fable_enabled=fable_enabled,
+                databricks_ai_tools_enabled=databricks_ai_tools_enabled,
             )
         )
     return states
@@ -529,6 +542,7 @@ def configure_workspace_command(
     use_pat: bool = False,
     skip_validate: bool = False,
     fable_enabled: bool | None = None,
+    databricks_ai_tools_enabled: bool | None = None,
 ) -> int:
     if tool is not None and selected_tools is not None:
         raise RuntimeError("Use either --agent or --agents, not both.")
@@ -547,6 +561,7 @@ def configure_workspace_command(
             force_login=True,
             use_pat=use_pat,
             fable_enabled=fable_enabled,
+            databricks_ai_tools_enabled=databricks_ai_tools_enabled,
         )
         state = states[0]
         state = configure_single_tool(tool, state)
@@ -584,6 +599,7 @@ def configure_workspace_command(
         force_login=True,
         use_pat=use_pat,
         fable_enabled=fable_enabled,
+        databricks_ai_tools_enabled=databricks_ai_tools_enabled,
     )
     state = states[0]
     save_state(state)
@@ -1102,6 +1118,15 @@ def configure(
             "it configures Claude Code directly since Fable is Claude-only.",
         ),
     ] = None,
+    enable_databricks_ai_tools: Annotated[
+        bool | None,
+        typer.Option(
+            "--enable-databricks-ai-tools/--disable-databricks-ai-tools",
+            help="Install Databricks AI Tools (skills + plugins that teach agents to use "
+            "Databricks) for the configured agents. Installed by default; pass "
+            "--disable-databricks-ai-tools to opt out.",
+        ),
+    ] = None,
     tracing: Annotated[
         bool,
         typer.Option(
@@ -1167,6 +1192,19 @@ def configure(
         # target claude instead of dropping into the interactive agent picker.
         if enable_fable is not None and agent is None and agents is None:
             agent = "claude"
+        # Bare `ucode configure`: nothing named on the command line, so there's
+        # a terminal to prompt in. Naming an agent or workspace/profile is a
+        # non-interactive run. (workspace_entries covers --workspaces/--profiles.)
+        interactive_configure = agent is None and agents is None and workspace_entries is None
+        if enable_databricks_ai_tools is None and interactive_configure:
+            # Default to prior choice so Enter doesn't undo a past opt-out.
+            prior_disabled = load_state().get("databricks_ai_tools_enabled") is False
+            enable_databricks_ai_tools = prompt_yes_no_default(
+                "Install Databricks AI Tools for your coding agents?",
+                default=not prior_disabled,
+            )
+        if enable_databricks_ai_tools is not None:
+            skip_kwargs["databricks_ai_tools_enabled"] = enable_databricks_ai_tools
         if agent is not None:
             tool = normalize_tool(agent)
             install_tool_binary(

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -49,9 +49,8 @@ WINDOWS_DATABRICKS_INSTALL_URL = (
     "https://raw.githubusercontent.com/databricks/setup-cli/main/install.ps1"
 )
 AI_GATEWAY_V2_DOCS_URL = "https://docs.databricks.com/aws/en/ai-gateway/overview-beta"
-MIN_DATABRICKS_CLI_VERSION = (0, 298, 0)
-# Minimum CLI version that ships `databricks aitools` (Databricks AI Tools).
-AITOOLS_MIN_CLI_VERSION = (1, 1, 0)
+# v1.0.0 is the release that ships `databricks aitools`.
+MIN_DATABRICKS_CLI_VERSION = (1, 0, 0)
 TOKEN_REFRESH_INTERVAL_SECONDS = 1800
 
 
@@ -572,18 +571,12 @@ def install_ai_tools(agent_tokens: list[str], profile: str | None = None) -> Non
                 timeout=300,
             )
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
-        # Surface the CLI's own error rather than assuming a version cause:
-        # `aitools` also fails when an agent binary isn't on PATH, etc. An old
-        # CLI (before `aitools` shipped) is only one possible reason, offered
-        # as a hint rather than asserted as the cause.
-        required = ".".join(str(n) for n in AITOOLS_MIN_CLI_VERSION)
+        # The CLI version is already guaranteed by ensure_databricks_cli_version,
+        # so any failure here is something else (e.g. an agent binary missing
+        # from PATH). Surface the CLI's own error rather than guessing a cause.
         detail = (getattr(exc, "stderr", None) or "").strip()
         reason = detail.splitlines()[-1] if detail else str(exc)
-        print_warning(
-            f"Could not install Databricks AI Tools: {reason}. "
-            f"This needs Databricks CLI v{required}+ (`databricks aitools`); "
-            "upgrade the CLI if needed, then re-run `ucode configure` to add them."
-        )
+        print_warning(f"Could not install Databricks AI Tools: {reason}")
     else:
         print_success("Databricks AI Tools installed")
 

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -574,7 +574,10 @@ def install_ai_tools(agent_tokens: list[str], profile: str | None = None) -> Non
         # The CLI version is already guaranteed by ensure_databricks_cli_version,
         # so any failure here is something else (e.g. an agent binary missing
         # from PATH). Surface the CLI's own error rather than guessing a cause.
-        detail = (getattr(exc, "stderr", None) or "").strip()
+        detail = getattr(exc, "stderr", None) or ""
+        if isinstance(detail, bytes):  # TimeoutExpired.stderr is bytes even with text=True
+            detail = detail.decode(errors="replace")
+        detail = detail.strip()
         reason = detail.splitlines()[-1] if detail else str(exc)
         print_warning(f"Could not install Databricks AI Tools: {reason}")
     else:

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -50,6 +50,8 @@ WINDOWS_DATABRICKS_INSTALL_URL = (
 )
 AI_GATEWAY_V2_DOCS_URL = "https://docs.databricks.com/aws/en/ai-gateway/overview-beta"
 MIN_DATABRICKS_CLI_VERSION = (0, 298, 0)
+# Minimum CLI version that ships `databricks aitools` (Databricks AI Tools).
+AITOOLS_MIN_CLI_VERSION = (1, 1, 0)
 TOKEN_REFRESH_INTERVAL_SECONDS = 1800
 
 
@@ -546,6 +548,44 @@ def install_databricks_cli() -> None:
             "Databricks CLI install completed, but `databricks` is still not on PATH."
         )
     ensure_databricks_cli_version()
+
+
+def install_ai_tools(agent_tokens: list[str], profile: str | None = None) -> None:
+    """Install Databricks AI Tools for the given agents (e.g. ``claude-code``).
+
+    Databricks AI Tools is the set of skills and plugins that teach coding
+    agents how to work with Databricks (installed via ``databricks aitools``).
+    Idempotent and best-effort: any failure only warns (surfacing the CLI's
+    own error), since AI Tools aren't required to launch an agent."""
+    if not agent_tokens:
+        return
+
+    agents_arg = ",".join(agent_tokens)
+    try:
+        with spinner(f"Installing Databricks AI Tools for {agents_arg}..."):
+            run(
+                ["databricks", "aitools", "install", "--agents", agents_arg, "--scope", "global"]
+                + _profile_args(profile),
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        # Surface the CLI's own error rather than assuming a version cause:
+        # `aitools` also fails when an agent binary isn't on PATH, etc. An old
+        # CLI (before `aitools` shipped) is only one possible reason, offered
+        # as a hint rather than asserted as the cause.
+        required = ".".join(str(n) for n in AITOOLS_MIN_CLI_VERSION)
+        detail = (getattr(exc, "stderr", None) or "").strip()
+        reason = detail.splitlines()[-1] if detail else str(exc)
+        print_warning(
+            f"Could not install Databricks AI Tools: {reason}. "
+            f"This needs Databricks CLI v{required}+ (`databricks aitools`); "
+            "upgrade the CLI if needed, then re-run `ucode configure` to add them."
+        )
+    else:
+        print_success("Databricks AI Tools installed")
 
 
 def _profile_args(profile: str | None) -> list[str]:

--- a/src/ucode/ui.py
+++ b/src/ucode/ui.py
@@ -302,6 +302,23 @@ def prompt_yes_no(prompt: str) -> bool:
         print_err("Please answer yes or no.")
 
 
+def prompt_yes_no_default(prompt: str, *, default: bool) -> bool:
+    """Empty answer or closed stdin (EOF) takes ``default`` (no abort on piped runs)."""
+    hint = "(Y/n)" if default else "(y/N)"
+    while True:
+        try:
+            response = console.input(f"{label(prompt)} {muted(hint)} {muted('›')} ").strip().lower()
+        except EOFError:
+            return default
+        if not response:
+            return default
+        if response in {"y", "yes"}:
+            return True
+        if response in {"n", "no"}:
+            return False
+        print_err("Please answer yes or no.")
+
+
 def prompt_for_choice(prompt: str, options: list[tuple[str, str]]) -> str:
     console.print()
     for index, (_, option_label) in enumerate(options, start=1):

--- a/tests/test_agents_init.py
+++ b/tests/test_agents_init.py
@@ -62,16 +62,34 @@ class TestToolSpecs:
 
 
 class TestInstallAiToolsForAgents:
-    def test_maps_supported_tools_and_drops_others(self, monkeypatch):
+    def _capture(self, monkeypatch):
         captured = {}
         monkeypatch.setattr(
             agents_mod,
             "install_ai_tools",
-            lambda tokens, profile: captured.update(tokens=tokens, profile=profile),
+            lambda agents, profile: captured.update(agents=agents, profile=profile),
         )
+        return captured
+
+    def test_maps_supported_tools_and_drops_others(self, monkeypatch):
+        captured = self._capture(monkeypatch)
         # gemini and pi aren't supported by `databricks aitools`, so they drop.
-        install_ai_tools_for_agents(["claude", "codex", "gemini", "pi"], "prof")
-        assert captured == {"tokens": ["claude-code", "codex"], "profile": "prof"}
+        install_ai_tools_for_agents(["claude", "codex", "gemini", "pi"], {"profile": "prof"})
+        assert captured == {"agents": ["claude-code", "codex"], "profile": "prof"}
+
+    def test_installed_by_default(self, monkeypatch):
+        # Opt-out: absent flag means install.
+        captured = self._capture(monkeypatch)
+        install_ai_tools_for_agents(["claude"], {"profile": "p"})
+        assert captured == {"agents": ["claude-code"], "profile": "p"}
+
+    def test_skipped_when_disabled(self, monkeypatch):
+        # `configure --disable-databricks-ai-tools` persists this False.
+        captured = self._capture(monkeypatch)
+        install_ai_tools_for_agents(
+            ["claude"], {"profile": "p", "databricks_ai_tools_enabled": False}
+        )
+        assert captured == {}  # install_ai_tools never called
 
 
 class TestConfigureWiresAiToolsInstall:
@@ -84,19 +102,27 @@ class TestConfigureWiresAiToolsInstall:
         monkeypatch.setattr(
             agents_mod,
             "install_ai_tools",
-            lambda tokens, profile: captured.update(tokens=tokens, profile=profile),
+            lambda agents, profile: captured.update(agents=agents, profile=profile),
         )
         return captured
 
     def test_configure_single_tool_triggers_install(self, monkeypatch):
         captured = self._stub_configure(monkeypatch)
         agents_mod.configure_single_tool("codex", {"codex_models": ["m"], "profile": "myprof"})
-        assert captured == {"tokens": ["codex"], "profile": "myprof"}
+        assert captured == {"agents": ["codex"], "profile": "myprof"}
 
     def test_configure_selected_tools_triggers_install(self, monkeypatch):
         captured = self._stub_configure(monkeypatch)
         agents_mod.configure_selected_tools({"profile": "myprof"}, ["codex"])
-        assert captured == {"tokens": ["codex"], "profile": "myprof"}
+        assert captured == {"agents": ["codex"], "profile": "myprof"}
+
+    def test_configure_single_tool_respects_disable(self, monkeypatch):
+        captured = self._stub_configure(monkeypatch)
+        agents_mod.configure_single_tool(
+            "codex",
+            {"codex_models": ["m"], "profile": "myprof", "databricks_ai_tools_enabled": False},
+        )
+        assert captured == {}
 
 
 class TestNormalizeTool:

--- a/tests/test_agents_init.py
+++ b/tests/test_agents_init.py
@@ -14,6 +14,7 @@ from ucode.agents import (
     configure_selected_tools,
     default_model_for_tool,
     ensure_tool_binary_available,
+    install_ai_tools_for_agents,
     install_tool_binary,
     normalize_tool,
     provider_permission_error,
@@ -58,6 +59,44 @@ class TestToolSpecs:
     def test_each_agent_exposes_update_check(self):
         for tool, module in agents_mod._MODULES.items():
             assert callable(module.is_update_available), f"{tool} missing is_update_available"
+
+
+class TestInstallAiToolsForAgents:
+    def test_maps_supported_tools_and_drops_others(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(
+            agents_mod,
+            "install_ai_tools",
+            lambda tokens, profile: captured.update(tokens=tokens, profile=profile),
+        )
+        # gemini and pi aren't supported by `databricks aitools`, so they drop.
+        install_ai_tools_for_agents(["claude", "codex", "gemini", "pi"], "prof")
+        assert captured == {"tokens": ["claude-code", "codex"], "profile": "prof"}
+
+
+class TestConfigureWiresAiToolsInstall:
+    """Both configure chokepoints must trigger AI Tools install."""
+
+    def _stub_configure(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(agents_mod, "configure_tool", lambda tool, state, model=None: state)
+        monkeypatch.setattr(agents_mod, "save_state", lambda state: None)
+        monkeypatch.setattr(
+            agents_mod,
+            "install_ai_tools",
+            lambda tokens, profile: captured.update(tokens=tokens, profile=profile),
+        )
+        return captured
+
+    def test_configure_single_tool_triggers_install(self, monkeypatch):
+        captured = self._stub_configure(monkeypatch)
+        agents_mod.configure_single_tool("codex", {"codex_models": ["m"], "profile": "myprof"})
+        assert captured == {"tokens": ["codex"], "profile": "myprof"}
+
+    def test_configure_selected_tools_triggers_install(self, monkeypatch):
+        captured = self._stub_configure(monkeypatch)
+        agents_mod.configure_selected_tools({"profile": "myprof"}, ["codex"])
+        assert captured == {"tokens": ["codex"], "profile": "myprof"}
 
 
 class TestNormalizeTool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,15 @@ def no_state_writes():
         yield
 
 
+@pytest.fixture(autouse=True)
+def no_blocking_ai_tools_prompt():
+    """The interactive configure flow prompts for AI Tools; default it to yes so
+    tests that drive that path don't block reading stdin. Tests that assert on the
+    prompt override this with their own patch."""
+    with patch("ucode.cli.prompt_yes_no_default", lambda msg, *, default: default):
+        yield
+
+
 MINIMAL_STATE = {
     "workspace": "https://example.databricks.com",
     "base_urls": {
@@ -494,12 +503,11 @@ class TestConfigureAgentFlag:
             patch("ucode.cli.install_tool_binary"),
             patch("ucode.cli.configure_workspace_command") as mock_cfg,
         ):
-            # No stdin -> the AI Tools prompt takes its default (yes).
+            # No flag: the AI Tools prompt happens later, inside
+            # configure_workspace_command, so nothing is forwarded here.
             result = runner.invoke(app, ["configure"])
         assert result.exit_code == 0, result.output
-        mock_cfg.assert_called_once_with(
-            prompt_optional_updates=True, databricks_ai_tools_enabled=True
-        )
+        mock_cfg.assert_called_once_with(prompt_optional_updates=True)
 
     def test_agents_flag_calls_configure_with_tools(self):
         with (
@@ -647,12 +655,9 @@ class TestConfigureAgentFlag:
             patch("ucode.cli.install_tool_binary"),
             patch("ucode.cli.configure_workspace_command") as mock_cfg,
         ):
-            # Interactive path -> AI Tools prompt takes its default (yes) with no stdin.
             result = runner.invoke(app, ["configure", "--skip-upgrade"])
         assert result.exit_code == 0, result.output
-        mock_cfg.assert_called_once_with(
-            prompt_optional_updates=False, databricks_ai_tools_enabled=True
-        )
+        mock_cfg.assert_called_once_with(prompt_optional_updates=False)
 
     def test_disable_databricks_ai_tools_forwards_false_and_skips_prompt(self):
         # An explicit flag suppresses the interactive prompt and forwards the choice.
@@ -685,37 +690,50 @@ class TestConfigureAgentFlag:
             databricks_ai_tools_enabled=True,
         )
 
-    def test_interactive_prompt_default_yes_when_no_prior_optout(self):
-        # No prior opt-out -> prompt defaults to yes; pressing Enter (no stdin) forwards True.
-        with (
-            patch("ucode.cli.install_databricks_cli"),
-            patch("ucode.cli.install_tool_binary"),
-            patch("ucode.cli.configure_workspace_command") as mock_cfg,
-            patch("ucode.cli.load_state", return_value={"workspace": "https://ws"}),
-        ):
-            result = runner.invoke(app, ["configure"])
-        assert result.exit_code == 0, result.output
-        mock_cfg.assert_called_once_with(
-            prompt_optional_updates=True, databricks_ai_tools_enabled=True
-        )
+    def _stub_interactive_configure(self, monkeypatch, shared_state):
+        """Wire configure_workspace_command's interactive path; return captured info."""
+        import ucode.cli as cli_mod
 
-    def test_interactive_prompt_defaults_to_prior_optout(self):
-        # A prior --disable persists databricks_ai_tools_enabled=False; pressing Enter on a
-        # re-configure must NOT silently re-enable it (prompt defaults to no -> forwards False).
-        with (
-            patch("ucode.cli.install_databricks_cli"),
-            patch("ucode.cli.install_tool_binary"),
-            patch("ucode.cli.configure_workspace_command") as mock_cfg,
-            patch(
-                "ucode.cli.load_state",
-                return_value={"workspace": "https://ws", "databricks_ai_tools_enabled": False},
-            ),
-        ):
-            result = runner.invoke(app, ["configure"])
-        assert result.exit_code == 0, result.output
-        mock_cfg.assert_called_once_with(
-            prompt_optional_updates=True, databricks_ai_tools_enabled=False
+        monkeypatch.setattr(cli_mod, "configure_shared_state", lambda *a, **k: shared_state)
+        monkeypatch.setattr(cli_mod, "check_gateway_endpoint", lambda s, t: t == "claude")
+        monkeypatch.setattr(cli_mod, "install_tool_binary", lambda *a, **k: True)
+        monkeypatch.setattr(cli_mod, "_maybe_select_provider_service", lambda tool, s: s)
+        monkeypatch.setattr(cli_mod, "validate_all_tools", lambda s: None)
+        monkeypatch.setattr(cli_mod, "validate_tool", lambda t: (True, None))
+        monkeypatch.setattr(
+            cli_mod, "_prompt_for_configuration", lambda tool=None: ("https://w", None)
         )
+        monkeypatch.setattr(cli_mod, "prompt_for_tools", lambda options: ["claude"])
+        captured = {}
+        monkeypatch.setattr(
+            cli_mod,
+            "configure_selected_tools",
+            lambda s, tools: captured.update(state=dict(s)) or s,
+        )
+        prompt_calls = []
+        monkeypatch.setattr(
+            cli_mod,
+            "prompt_yes_no_default",
+            lambda msg, *, default: prompt_calls.append(default) or default,
+        )
+        return cli_mod, captured, prompt_calls
+
+    def test_interactive_prompt_default_yes_when_no_prior_optout(self, monkeypatch):
+        # No prior opt-out -> prompt defaults to yes; state carries True into install.
+        state = {**MINIMAL_STATE, "available_tools": [], "databricks_ai_tools_enabled": True}
+        cli_mod, captured, prompt_calls = self._stub_interactive_configure(monkeypatch, state)
+        cli_mod.configure_workspace_command()
+        assert prompt_calls == [True]  # default derived from resolved prior choice
+        assert captured["state"]["databricks_ai_tools_enabled"] is True
+
+    def test_interactive_prompt_defaults_to_prior_optout(self, monkeypatch):
+        # configure_shared_state resolved a prior --disable to False; the prompt must
+        # default to no so Enter doesn't silently re-enable it.
+        state = {**MINIMAL_STATE, "available_tools": [], "databricks_ai_tools_enabled": False}
+        cli_mod, captured, prompt_calls = self._stub_interactive_configure(monkeypatch, state)
+        cli_mod.configure_workspace_command()
+        assert prompt_calls == [False]
+        assert captured["state"]["databricks_ai_tools_enabled"] is False
 
     def test_skip_upgrade_flag_with_agent_skips_optional_update(self):
         with (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -494,9 +494,12 @@ class TestConfigureAgentFlag:
             patch("ucode.cli.install_tool_binary"),
             patch("ucode.cli.configure_workspace_command") as mock_cfg,
         ):
+            # No stdin -> the AI Tools prompt takes its default (yes).
             result = runner.invoke(app, ["configure"])
         assert result.exit_code == 0, result.output
-        mock_cfg.assert_called_once_with(prompt_optional_updates=True)
+        mock_cfg.assert_called_once_with(
+            prompt_optional_updates=True, databricks_ai_tools_enabled=True
+        )
 
     def test_agents_flag_calls_configure_with_tools(self):
         with (
@@ -644,9 +647,75 @@ class TestConfigureAgentFlag:
             patch("ucode.cli.install_tool_binary"),
             patch("ucode.cli.configure_workspace_command") as mock_cfg,
         ):
+            # Interactive path -> AI Tools prompt takes its default (yes) with no stdin.
             result = runner.invoke(app, ["configure", "--skip-upgrade"])
         assert result.exit_code == 0, result.output
-        mock_cfg.assert_called_once_with(prompt_optional_updates=False)
+        mock_cfg.assert_called_once_with(
+            prompt_optional_updates=False, databricks_ai_tools_enabled=True
+        )
+
+    def test_disable_databricks_ai_tools_forwards_false_and_skips_prompt(self):
+        # An explicit flag suppresses the interactive prompt and forwards the choice.
+        with (
+            patch("ucode.cli.install_databricks_cli"),
+            patch("ucode.cli.install_tool_binary"),
+            patch("ucode.cli.configure_workspace_command") as mock_cfg,
+            patch("ucode.cli.prompt_yes_no_default") as mock_prompt,
+        ):
+            result = runner.invoke(app, ["configure", "--disable-databricks-ai-tools"])
+        assert result.exit_code == 0, result.output
+        mock_prompt.assert_not_called()
+        mock_cfg.assert_called_once_with(
+            prompt_optional_updates=True, databricks_ai_tools_enabled=False
+        )
+
+    def test_enable_databricks_ai_tools_with_agents_forwards_true(self):
+        with (
+            patch("ucode.cli.install_databricks_cli"),
+            patch("ucode.cli.install_tool_binary"),
+            patch("ucode.cli.configure_workspace_command") as mock_cfg,
+        ):
+            result = runner.invoke(
+                app, ["configure", "--enable-databricks-ai-tools", "--agents", "claude,codex"]
+            )
+        assert result.exit_code == 0, result.output
+        mock_cfg.assert_called_once_with(
+            selected_tools=["claude", "codex"],
+            prompt_optional_updates=True,
+            databricks_ai_tools_enabled=True,
+        )
+
+    def test_interactive_prompt_default_yes_when_no_prior_optout(self):
+        # No prior opt-out -> prompt defaults to yes; pressing Enter (no stdin) forwards True.
+        with (
+            patch("ucode.cli.install_databricks_cli"),
+            patch("ucode.cli.install_tool_binary"),
+            patch("ucode.cli.configure_workspace_command") as mock_cfg,
+            patch("ucode.cli.load_state", return_value={"workspace": "https://ws"}),
+        ):
+            result = runner.invoke(app, ["configure"])
+        assert result.exit_code == 0, result.output
+        mock_cfg.assert_called_once_with(
+            prompt_optional_updates=True, databricks_ai_tools_enabled=True
+        )
+
+    def test_interactive_prompt_defaults_to_prior_optout(self):
+        # A prior --disable persists databricks_ai_tools_enabled=False; pressing Enter on a
+        # re-configure must NOT silently re-enable it (prompt defaults to no -> forwards False).
+        with (
+            patch("ucode.cli.install_databricks_cli"),
+            patch("ucode.cli.install_tool_binary"),
+            patch("ucode.cli.configure_workspace_command") as mock_cfg,
+            patch(
+                "ucode.cli.load_state",
+                return_value={"workspace": "https://ws", "databricks_ai_tools_enabled": False},
+            ),
+        ):
+            result = runner.invoke(app, ["configure"])
+        assert result.exit_code == 0, result.output
+        mock_cfg.assert_called_once_with(
+            prompt_optional_updates=True, databricks_ai_tools_enabled=False
+        )
 
     def test_skip_upgrade_flag_with_agent_skips_optional_update(self):
         with (
@@ -860,6 +929,7 @@ class TestConfigureAgentsSelection:
             force_login=False,
             use_pat=False,
             fable_enabled=None,
+            databricks_ai_tools_enabled=None,
         ):
             configured_shared.append(
                 (workspace, profile, tuple(tools) if tools is not None else None, force_login)
@@ -1253,6 +1323,50 @@ class TestConfigureSharedStateUsePat:
 
         assert "fable_enabled" not in state
         assert "fable" not in state["claude_models"]
+
+    def test_ai_tools_disable_persists(self, monkeypatch):
+        cli_mod, *_ = self._stub_deps(monkeypatch, pat_token="dapi-pat")
+        state = cli_mod.configure_shared_state(
+            self.WS, profile="DEFAULT", databricks_ai_tools_enabled=False
+        )
+        assert state["databricks_ai_tools_enabled"] is False
+
+    def test_ai_tools_enable_persists_explicit_true(self, monkeypatch):
+        # We ask explicitly, so store the on choice too (not just absent-default).
+        cli_mod, *_ = self._stub_deps(monkeypatch, pat_token="dapi-pat")
+        state = cli_mod.configure_shared_state(
+            self.WS, profile="DEFAULT", databricks_ai_tools_enabled=True
+        )
+        assert state["databricks_ai_tools_enabled"] is True
+
+    def test_ai_tools_disable_inherited_same_workspace(self, monkeypatch):
+        # No flag on a re-configure of the same workspace keeps the prior opt-out.
+        cli_mod, *_ = self._stub_deps(
+            monkeypatch,
+            pat_token="dapi-pat",
+            existing_state={
+                "workspace": self.WS,
+                "profile": "DEFAULT",
+                "databricks_ai_tools_enabled": False,
+            },
+        )
+        state = cli_mod.configure_shared_state(self.WS, profile="DEFAULT")
+        assert state["databricks_ai_tools_enabled"] is False
+
+    def test_ai_tools_disable_does_not_leak_across_workspaces(self, monkeypatch):
+        # A different workspace's opt-out must NOT carry into this one; no flag
+        # here resolves to the default (install=True), matching use_pat/fable scoping.
+        cli_mod, *_ = self._stub_deps(
+            monkeypatch,
+            pat_token="dapi-pat",
+            existing_state={
+                "workspace": "https://other.databricks.com",
+                "profile": "DEFAULT",
+                "databricks_ai_tools_enabled": False,
+            },
+        )
+        state = cli_mod.configure_shared_state(self.WS, profile="DEFAULT")
+        assert state["databricks_ai_tools_enabled"] is True
 
     def test_falls_back_to_legacy_when_uc_empty(self, monkeypatch):
         # No UC model-services: each family falls back to the legacy listing.

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -1745,6 +1745,19 @@ class TestInstallAiTools:
         self._capture_run(monkeypatch, raises=subprocess.TimeoutExpired("databricks", 300))
         install_ai_tools(["claude-code"])
 
+    def test_timeout_stderr_bytes_decoded_in_warning(self, monkeypatch):
+        # TimeoutExpired.stderr is bytes even with text=True; the warning must
+        # decode it, not render a `b'...'` repr.
+        err = subprocess.TimeoutExpired("databricks", 300)
+        err.stderr = b"resolving agents...\ninstall timed out"
+        self._capture_run(monkeypatch, raises=err)
+        warnings = []
+        monkeypatch.setattr(db_mod, "print_warning", warnings.append)
+        install_ai_tools(["claude-code"])
+        assert len(warnings) == 1
+        assert "install timed out" in warnings[0]
+        assert "b'" not in warnings[0]
+
     def test_failure_surfaces_cli_stderr(self, monkeypatch):
         # A modern CLI can still fail (e.g. an agent binary missing from PATH);
         # the warning must show the CLI's real error, not blame the version.

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -1539,19 +1539,19 @@ class TestEnsureDatabricksCliVersion:
         return {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"}
 
     def test_passes_when_version_meets_minimum(self, tmp_path, monkeypatch):
-        env = self._fake_databricks(tmp_path, "Databricks CLI v0.298.0")
+        env = self._fake_databricks(tmp_path, "Databricks CLI v1.0.0")
         monkeypatch.setattr("os.environ", env)
         ensure_databricks_cli_version()  # should not raise
 
     def test_passes_when_version_exceeds_minimum(self, tmp_path, monkeypatch):
-        env = self._fake_databricks(tmp_path, "Databricks CLI v0.299.2")
+        env = self._fake_databricks(tmp_path, "Databricks CLI v1.8.0")
         monkeypatch.setattr("os.environ", env)
         ensure_databricks_cli_version()
 
     def test_auto_upgrades_when_version_too_old(self, tmp_path, monkeypatch):
         import ucode.databricks as db_mod
 
-        env = self._fake_databricks(tmp_path, "Databricks CLI v0.297.0")
+        env = self._fake_databricks(tmp_path, "Databricks CLI v0.299.2")
         monkeypatch.setattr("os.environ", env)
         upgraded = []
         monkeypatch.setattr(

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -25,6 +25,7 @@ from ucode.databricks import (
     ensure_databricks_cli_version,
     ensure_pat_bearer,
     get_databricks_token,
+    install_ai_tools,
     list_databricks_apps,
     list_databricks_connections,
     list_genie_spaces,
@@ -1699,3 +1700,59 @@ class TestRunUsageQuery:
             db_mod.run_usage_query(WS, "/sql/1.0/warehouses/abc", "tok", "SELECT 1")
         assert "Ask your workspace admin" not in str(exc_info.value)
         assert str(exc_info.value).startswith("Usage query failed:")
+
+
+class TestInstallAiTools:
+    def _capture_run(self, monkeypatch, *, raises=None):
+        calls = []
+
+        def fake_run(args, **kwargs):
+            calls.append(args)
+            if raises is not None:
+                raise raises
+            return subprocess.CompletedProcess(args, 0, "Installed 1 skill.", "")
+
+        monkeypatch.setattr(db_mod, "run", fake_run)
+        return calls
+
+    def test_no_tokens_skips_entirely(self, monkeypatch):
+        calls = self._capture_run(monkeypatch)
+        install_ai_tools([])
+        assert calls == []
+
+    def test_invokes_aitools_install(self, monkeypatch):
+        calls = self._capture_run(monkeypatch)
+        install_ai_tools(["claude-code", "codex"])
+        assert len(calls) == 1
+        cmd = calls[0]
+        assert cmd[:3] == ["databricks", "aitools", "install"]
+        assert "--agents" in cmd and cmd[cmd.index("--agents") + 1] == "claude-code,codex"
+        assert "--scope" in cmd and cmd[cmd.index("--scope") + 1] == "global"
+        assert "--profile" not in cmd
+
+    def test_passes_profile_when_set(self, monkeypatch):
+        calls = self._capture_run(monkeypatch)
+        install_ai_tools(["claude-code"], profile="myprofile")
+        cmd = calls[0]
+        assert "--profile" in cmd and cmd[cmd.index("--profile") + 1] == "myprofile"
+
+    def test_install_failure_is_non_fatal(self, monkeypatch):
+        self._capture_run(monkeypatch, raises=subprocess.CalledProcessError(1, "databricks"))
+        # Must not raise — AI Tools are best-effort.
+        install_ai_tools(["claude-code"])
+
+    def test_timeout_is_non_fatal(self, monkeypatch):
+        self._capture_run(monkeypatch, raises=subprocess.TimeoutExpired("databricks", 300))
+        install_ai_tools(["claude-code"])
+
+    def test_failure_surfaces_cli_stderr(self, monkeypatch):
+        # A modern CLI can still fail (e.g. an agent binary missing from PATH);
+        # the warning must show the CLI's real error, not blame the version.
+        err = subprocess.CalledProcessError(1, "databricks")
+        err.stderr = "resolving agents...\ncopilot: cli-not-on-path: could not resolve copilot"
+        self._capture_run(monkeypatch, raises=err)
+        warnings = []
+        monkeypatch.setattr(db_mod, "print_warning", warnings.append)
+        install_ai_tools(["copilot"])
+        assert len(warnings) == 1
+        assert "copilot: cli-not-on-path: could not resolve copilot" in warnings[0]

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -12,9 +12,42 @@ from ucode.ui import (
     format_token_count,
     normalize_workspace_url,
     prompt_for_workspace,
+    prompt_yes_no_default,
     render_box_table,
     status_badge,
 )
+
+
+class TestPromptYesNoDefault:
+    def _answer(self, monkeypatch, value):
+        # value: a string the user "types", or EOFError to simulate closed stdin.
+        def fake_input(_prompt):
+            if value is EOFError:
+                raise EOFError
+            return value
+
+        monkeypatch.setattr("ucode.ui.console.input", fake_input)
+
+    def test_empty_takes_default_true(self, monkeypatch):
+        self._answer(monkeypatch, "")
+        assert prompt_yes_no_default("go?", default=True) is True
+
+    def test_empty_takes_default_false(self, monkeypatch):
+        self._answer(monkeypatch, "")
+        assert prompt_yes_no_default("go?", default=False) is False
+
+    def test_eof_takes_default(self, monkeypatch):
+        # Non-interactive / closed stdin must not abort — it takes the default.
+        self._answer(monkeypatch, EOFError)
+        assert prompt_yes_no_default("go?", default=True) is True
+
+    def test_explicit_no_overrides_default_yes(self, monkeypatch):
+        self._answer(monkeypatch, "n")
+        assert prompt_yes_no_default("go?", default=True) is False
+
+    def test_explicit_yes_overrides_default_false(self, monkeypatch):
+        self._answer(monkeypatch, "yes")
+        assert prompt_yes_no_default("go?", default=False) is True
 
 
 class TestNormalizeWorkspaceUrl:


### PR DESCRIPTION
ucode configure now installs Databricks AI Tools for each coding agent it sets up, so agents can work with Databricks (bundles, jobs, SQL, Genie) out of the box instead of making low-level API calls.

Followup PR to be merged after this: https://github.com/databricks/ucode/pull/231

# Testing

- Unit tests cover the token mapping, both configure chokepoints, profile passthrough, and non-fatal failure with CLI-stderr surfacing (incl. the bytes-decoded timeout path).
- Manual end-to-end validation:

1. Baseline: claude-code + codex plugins installed.
2. databricks aitools uninstall --agents claude-code,codex.
3. Confirmed neither installed.
4. ucode configure --agent claude → "✔ Databricks AI Tools installed".
5. Verified claude-code installed, codex still absent (per-agent, not stale state).
6. ucode configure --agent codex → "✔ Databricks AI Tools installed".
7. Verified both installed.
8. Also verified the first-run launch path (ucode claude auto-configure) installs AI Tools, and that an already-configured launch skips it.