### PR TITLE
fix(pi): point pi at config dir via PI_CODING_AGENT_DIR instead of redirecting HOME

### DIFF
--- a/src/ucode/agents/pi.py
+++ b/src/ucode/agents/pi.py
@@ -1,4 +1,4 @@
-"""Pi coding agent: writes ~/.pi/agent/models.json with Databricks-backed providers.
+"""Pi coding agent: writes a ucode-private models.json with Databricks-backed providers.
 
 Pi (https://pi.dev) is a multi-provider coding agent. We register three
 providers in its `models.json`, each speaking the API dialect best suited to
@@ -110,7 +110,7 @@ def render_overlay(
     codex_models: list[str],
     gemini_models: list[str],
 ) -> tuple[dict, list[list[str]]]:
-    """Return (overlay, managed_key_paths) for ~/.pi/agent/models.json."""
+    """Return (overlay, managed_key_paths) for Pi's private agent config."""
     providers: dict = {}
     keys: list[list[str]] = [["model"]]
     # Pi expands header values that match an env var name. Our UA contains
@@ -282,7 +282,7 @@ def _refresh_forever(state: dict, stop_event: threading.Event) -> None:
 def build_runtime_env(token: str) -> dict[str, str]:
     env = os.environ.copy()
     env["OAUTH_TOKEN"] = token
-    env["HOME"] = str(PI_UCODE_HOME)
+    env["PI_CODING_AGENT_DIR"] = str(PI_CONFIG_DIR)
     return env
 
 

--- a/tests/test_agent_pi.py
+++ b/tests/test_agent_pi.py
@@ -240,9 +240,13 @@ class TestBuildRuntimeEnv:
         env = pi.build_runtime_env("tok")
         assert env["OAUTH_TOKEN"] == "tok"
 
-    def test_sets_ucode_home(self):
+    def test_sets_private_agent_dir_without_replacing_home(self, monkeypatch):
+        monkeypatch.setenv("HOME", "/real-user-home")
+
         env = pi.build_runtime_env("tok")
-        assert env["HOME"] == str(pi.PI_UCODE_HOME)
+
+        assert env["PI_CODING_AGENT_DIR"] == str(pi.PI_CONFIG_DIR)
+        assert env["HOME"] == "/real-user-home"
 
 
 class TestPiValidateCmd:

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -948,14 +948,17 @@ class TestPiLaunch:
             pytest.skip("No Pi-compatible models available on this workspace")
 
         monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
-        # Pi reads models.json below HOME/.pi/agent. Point both pi's runtime
-        # HOME and our writer at the same isolated tmp home.
+        # Point PI_CODING_AGENT_DIR and ucode's config writer at the same
+        # isolated directory without changing the process HOME.
         pi_home = tmp_path / "pi-home"
         pi_dir = pi_home / ".pi" / "agent"
         config_path = pi_dir / "models.json"
         backup_path = tmp_path / "pi-models.backup.json"
         monkeypatch.setattr(pi, "PI_UCODE_HOME", pi_home)
+        monkeypatch.setattr(pi, "PI_CONFIG_DIR", pi_dir)
         monkeypatch.setattr(pi, "PI_CONFIG_PATH", config_path)
+        monkeypatch.setattr(pi, "PI_SETTINGS_PATH", pi_dir / "settings.json")
+        monkeypatch.setattr(pi, "PI_SETTINGS_BACKUP_PATH", tmp_path / "pi-settings.backup.json")
         monkeypatch.setattr(pi, "PI_BACKUP_PATH", backup_path)
 
         failures = []

--- a/tests/test_e2e_user_agent.py
+++ b/tests/test_e2e_user_agent.py
@@ -325,7 +325,10 @@ class TestPiUserAgent:
 
         monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
         monkeypatch.setattr(pi, "PI_UCODE_HOME", pi_home)
+        monkeypatch.setattr(pi, "PI_CONFIG_DIR", pi_dir)
         monkeypatch.setattr(pi, "PI_CONFIG_PATH", config_path)
+        monkeypatch.setattr(pi, "PI_SETTINGS_PATH", pi_dir / "settings.json")
+        monkeypatch.setattr(pi, "PI_SETTINGS_BACKUP_PATH", tmp_path / "pi-settings.backup.json")
         monkeypatch.setattr(pi, "PI_BACKUP_PATH", tmp_path / "pi.backup.json")
 
         state = {


### PR DESCRIPTION
## Issue

Closes #291.

This PR's current head (`45db26a`) and the current-`origin/main` validation candidate (`88d759c`) have the same stable patch ID (`eaa6fe487b9f968de6ff0da5fb1abc83b962bdcf`). The focused/full evidence below was rerun from the rebased candidate without rewriting this existing PR branch.

---
# Unit 01 — Pi config-dir/keychain fix

## Objective and user-visible behavior

Keep Pi models, settings, sessions, MCP, and skills under ucode's private Pi directory without changing the process `HOME`. On macOS, subprocesses therefore keep login-keychain and credential-helper resolution.

Candidate: `review/pi-config-keychain` (`88d759c`), existing PR #243, compared with current `origin/main`.

## Exact scope

Production: `src/ucode/agents/pi.py`.
Tests: `tests/test_agent_pi.py`, `tests/test_e2e.py`, `tests/test_e2e_user_agent.py`.
Non-goals: model routing, context metadata, MLflow proxying, cache retention, managed config, MCP/skills behavior changes.

## Before / after reproduction

```bash
git show origin/main:src/ucode/agents/pi.py | rg 'env\["(HOME|PI_CODING_AGENT_DIR)"\]'
# env["HOME"] = str(PI_UCODE_HOME)

git show review/pi-config-keychain:src/ucode/agents/pi.py | rg 'env\["(HOME|PI_CODING_AGENT_DIR)"\]'
# env["PI_CODING_AGENT_DIR"] = str(PI_CONFIG_DIR)
```

Focused validation:

```bash
uv run --frozen pytest tests/test_agent_pi.py tests/test_e2e_user_agent.py::TestPiUserAgent tests/test_e2e.py -q
# 50 passed, 29 skipped
uv run --frozen ruff check .
# All checks passed
```

Full suite:

```bash
uv run --frozen pytest -q
# 1 failed, 1658 passed, 36 skipped
```

Only `TestClaudeUserAgent::test_user_agent_arrives_at_gateway` failed; integrated `dev` reproduces that installed-Claude capture failure. Pi's capture test passes here, providing direct regression evidence for home isolation.

## Live evidence

No Databricks serving behavior changes. The focused Pi installed-agent capture test validates the launched environment locally without logging credentials.

## Impact map

- Agent: Pi only.
- Provider: all Pi providers inherit the corrected process environment; endpoint payloads are unchanged.
- Config: `PI_CODING_AGENT_DIR` points at the existing private config root; real `HOME` is preserved.
- Compatibility risks: requires Pi's supported config-dir variable; tests cover models/settings/session path patching and installed Pi launch.
- MCP/skills/managed config: paths remain under the same private Pi root; no registration or state schema changes.

## Rollback and residual risk

Rollback by reverting `88d759c`; this restores HOME redirection and its macOS keychain breakage. Residual risk is limited to older Pi releases that might ignore `PI_CODING_AGENT_DIR`; current installed Pi behavior is covered by the focused launch test.

## Hygiene

`git diff --check origin/main..88d759c` passes. Four-file range; no `uv.lock`, generated files, credentials, `.pi-subagents/`, or `goal.md`; no merge markers or unresolved index entries.
