### PR TITLE
Make debug log rotation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ you to run `ucode <agent>` (existing agent sessions need a restart before the MC
 | `ucode configure skills --location main.default [--path <dir>]` | Download a schema's skills to disk (under `<dir>`, or your home dir) and register a schema-less skills MCP connection |
 | `ucode configure skills --location main.default --mcp` | Expose a schema's skills as MCP tools (override-only) instead of downloading |
 
+### Debug logging
+
+Set `UCODE_DEBUG=1` to write diagnostic output to `~/.ucode/debug.log`. The log rotates at
+1,000,000 bytes and retains three backups by default. Long-running sessions can override those
+limits with `UCODE_DEBUG_MAX_BYTES` and `UCODE_DEBUG_BACKUP_COUNT`:
+
+```bash
+UCODE_DEBUG=1 UCODE_DEBUG_MAX_BYTES=25000000 UCODE_DEBUG_BACKUP_COUNT=10 ucode claude
+```
+
+Both rotation settings must be non-negative integers; unset or invalid values use the defaults.
+
 ## Managed Local Files
 
 `ucode` manages these files:

--- a/README.md
+++ b/README.md
@@ -162,18 +162,6 @@ you to run `ucode <agent>` (existing agent sessions need a restart before the MC
 | `ucode configure skills --location main.default [--path <dir>]` | Download a schema's skills to disk (under `<dir>`, or your home dir) and register a schema-less skills MCP connection |
 | `ucode configure skills --location main.default --mcp` | Expose a schema's skills as MCP tools (override-only) instead of downloading |
 
-### Debug logging
-
-Set `UCODE_DEBUG=1` to write diagnostic output to `~/.ucode/debug.log`. The log rotates at
-1,000,000 bytes and retains three backups by default. Long-running sessions can override those
-limits with `UCODE_DEBUG_MAX_BYTES` and `UCODE_DEBUG_BACKUP_COUNT`:
-
-```bash
-UCODE_DEBUG=1 UCODE_DEBUG_MAX_BYTES=25000000 UCODE_DEBUG_BACKUP_COUNT=10 ucode claude
-```
-
-Both rotation settings must be non-negative integers; unset or invalid values use the defaults.
-
 ## Managed Local Files
 
 `ucode` manages these files:

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -53,10 +53,28 @@ AI_GATEWAY_V2_DOCS_URL = "https://docs.databricks.com/aws/en/ai-gateway/overview
 # v1.0.0 is the release that ships `databricks aitools`.
 MIN_DATABRICKS_CLI_VERSION = (1, 0, 0)
 TOKEN_REFRESH_INTERVAL_SECONDS = 1800
+DEFAULT_DEBUG_LOG_MAX_BYTES = 1_000_000
+DEFAULT_DEBUG_LOG_BACKUP_COUNT = 3
 
 
 def _debug_enabled() -> bool:
     return os.environ.get("UCODE_DEBUG") == "1"
+
+
+def _debug_log_rotation_config() -> tuple[int, int]:
+    """Return debug log rotation settings, falling back for invalid values."""
+
+    def non_negative_int(name: str, default: int) -> int:
+        try:
+            value = int(os.environ.get(name, ""))
+        except ValueError:
+            return default
+        return value if value >= 0 else default
+
+    return (
+        non_negative_int("UCODE_DEBUG_MAX_BYTES", DEFAULT_DEBUG_LOG_MAX_BYTES),
+        non_negative_int("UCODE_DEBUG_BACKUP_COUNT", DEFAULT_DEBUG_LOG_BACKUP_COUNT),
+    )
 
 
 _DEBUG_LOGGER: logging.Logger | None = None
@@ -73,12 +91,13 @@ def _get_debug_logger() -> logging.Logger | None:
         return _DEBUG_LOGGER
 
     log_path = APP_DIR / "debug.log"
+    max_bytes, backup_count = _debug_log_rotation_config()
     try:
         log_path.parent.mkdir(parents=True, exist_ok=True)
         handler = logging.handlers.RotatingFileHandler(
             log_path,
-            maxBytes=1_000_000,
-            backupCount=3,
+            maxBytes=max_bytes,
+            backupCount=backup_count,
             encoding="utf-8",
         )
         handler.setFormatter(

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -36,6 +36,27 @@ from ucode.databricks import (
 WS = "https://example.databricks.com"
 
 
+class TestDebugLogRotationConfig:
+    def test_uses_defaults_when_environment_is_unset(self, monkeypatch):
+        monkeypatch.delenv("UCODE_DEBUG_MAX_BYTES", raising=False)
+        monkeypatch.delenv("UCODE_DEBUG_BACKUP_COUNT", raising=False)
+
+        assert db_mod._debug_log_rotation_config() == (1_000_000, 3)
+
+    def test_reads_values_from_environment(self, monkeypatch):
+        monkeypatch.setenv("UCODE_DEBUG_MAX_BYTES", "25000000")
+        monkeypatch.setenv("UCODE_DEBUG_BACKUP_COUNT", "10")
+
+        assert db_mod._debug_log_rotation_config() == (25_000_000, 10)
+
+    @pytest.mark.parametrize("value", ["", "invalid", "-1"])
+    def test_invalid_values_fall_back_independently(self, monkeypatch, value):
+        monkeypatch.setenv("UCODE_DEBUG_MAX_BYTES", value)
+        monkeypatch.setenv("UCODE_DEBUG_BACKUP_COUNT", "8")
+
+        assert db_mod._debug_log_rotation_config() == (1_000_000, 8)
+
+
 class TestWorkspaceHostname:
     def test_extracts_hostname(self):
         assert workspace_hostname(WS) == "example.databricks.com"


### PR DESCRIPTION
## Summary
- Add `UCODE_DEBUG_MAX_BYTES` and `UCODE_DEBUG_BACKUP_COUNT` so long-running sessions can keep more `~/.ucode/debug.log` history
- Preserve the existing defaults (`1_000_000` bytes, `3` backups) when unset or invalid
- Cover the parser with focused unit tests

## Test plan
- [x] `uv run pytest tests/test_databricks.py`
- [x] `uv run ruff check .`
- [x] Manually verify with:
  ```bash
  UCODE_DEBUG=1 UCODE_DEBUG_MAX_BYTES=25000000 UCODE_DEBUG_BACKUP_COUNT=10 ucode status
  ```
  and confirm `~/.ucode/debug.log` rotation uses the overrides