### PR TITLE
Fix multi-workspace host auth: append o=<workspace_id> to discovery calls

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -204,6 +204,52 @@ def _log_auth_diagnostics() -> None:
         _debug(f"databrickscfg ({cfg_path})", f"read error: {exc}")
 
 
+def _workspace_id_for_hostname(hostname: str) -> str | None:
+    """Return the ``workspace_id`` for the ~/.databrickscfg profile matching a host.
+
+    Databricks CLI writes a numeric ``workspace_id`` for workspace-scoped
+    profiles. It is absent (or the literal ``none``) for account-scoped
+    profiles, in which case there is nothing to disambiguate with."""
+    cfg_path = Path(os.environ.get("DATABRICKS_CONFIG_FILE") or "~/.databrickscfg").expanduser()
+    parser = configparser.ConfigParser(default_section="@ucode-no-defaults@", interpolation=None)
+    try:
+        if not parser.read(cfg_path, encoding="utf-8"):
+            return None
+    except (configparser.Error, OSError):
+        return None
+    for section in parser.sections():
+        host = (parser.get(section, "host", fallback="") or "").strip()
+        if not host:
+            continue
+        try:
+            if urlparse(normalize_workspace_url(host)).hostname != hostname:
+                continue
+        except RuntimeError:
+            continue
+        wid = (parser.get(section, "workspace_id", fallback="") or "").strip()
+        if wid and wid.lower() != "none":
+            return wid
+    return None
+
+
+def _with_workspace_disambiguator(url: str) -> str:
+    """Append ``o=<workspace_id>`` to a workspace API URL when needed.
+
+    A host that serves multiple workspaces rejects an account-audience OAuth
+    token unless the request carries the workspace disambiguator: without it
+    the gateway/UC APIs 303-redirect to ``/login`` and discovery reads the
+    login page as "response was not valid JSON". A single-workspace host
+    ignores the extra param, so this is always safe."""
+    parsed = urlparse(url)
+    if not parsed.hostname or "o=" in (parsed.query or ""):
+        return url
+    workspace_id = _workspace_id_for_hostname(parsed.hostname)
+    if not workspace_id:
+        return url
+    separator = "&" if parsed.query else "?"
+    return f"{url}{separator}o={workspace_id}"
+
+
 def _http_get_json(
     url: str, token: str, *, timeout: int = 10
 ) -> tuple[dict | list | None, str | None]:
@@ -211,6 +257,7 @@ def _http_get_json(
 
     Honors UCODE_DEBUG=1 to append status + truncated body to ~/.ucode/debug.log.
     """
+    url = _with_workspace_disambiguator(url)
     request = urllib_request.Request(
         url,
         headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
@@ -257,6 +304,7 @@ def _http_post_json(
 ) -> tuple[dict | list | None, str | None]:
     """POST a JSON body to an endpoint. Returns (payload, None) on success,
     (None, reason) on failure. Mirrors `_http_get_json`."""
+    url = _with_workspace_disambiguator(url)
     body_bytes = json.dumps(payload).encode("utf-8")
     request = urllib_request.Request(
         url,

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -16,6 +16,8 @@ from ucode.databricks import (
     _run_databricks_cli_installer,
     _scrub_databrickscfg,
     _scrub_json,
+    _with_workspace_disambiguator,
+    _workspace_id_for_hostname,
     build_auth_shell_command,
     build_auth_token_argv,
     build_databricks_cli_env,
@@ -1940,3 +1942,71 @@ class TestInstallAiTools:
         install_ai_tools(["copilot"])
         assert len(warnings) == 1
         assert "copilot: cli-not-on-path: could not resolve copilot" in warnings[0]
+
+
+DBCFG = """\
+[account-only]
+host = https://example.databricks.com
+workspace_id = none
+
+[workspace-scoped]
+host = https://example.databricks.com
+workspace_id = 1234567890123456
+
+[other]
+host = https://other.databricks.com
+workspace_id = 42
+"""
+
+
+class TestWorkspaceIdForHostname:
+    def _cfg(self, tmp_path, monkeypatch, contents=DBCFG):
+        cfg = tmp_path / "databrickscfg"
+        cfg.write_text(contents)
+        monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+        return cfg
+
+    def test_resolves_workspace_id_ignoring_account_only_profile(self, tmp_path, monkeypatch):
+        self._cfg(tmp_path, monkeypatch)
+        # The account-only profile (workspace_id = none) for the same host must
+        # be skipped in favor of the workspace-scoped one.
+        assert _workspace_id_for_hostname("example.databricks.com") == "1234567890123456"
+
+    def test_matches_other_host(self, tmp_path, monkeypatch):
+        self._cfg(tmp_path, monkeypatch)
+        assert _workspace_id_for_hostname("other.databricks.com") == "42"
+
+    def test_unknown_host_returns_none(self, tmp_path, monkeypatch):
+        self._cfg(tmp_path, monkeypatch)
+        assert _workspace_id_for_hostname("unknown.databricks.com") is None
+
+    def test_missing_config_returns_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(tmp_path / "does-not-exist"))
+        assert _workspace_id_for_hostname("example.databricks.com") is None
+
+
+class TestWithWorkspaceDisambiguator:
+    def _cfg(self, tmp_path, monkeypatch, contents=DBCFG):
+        cfg = tmp_path / "databrickscfg"
+        cfg.write_text(contents)
+        monkeypatch.setenv("DATABRICKS_CONFIG_FILE", str(cfg))
+
+    def test_appends_o_param_when_no_query(self, tmp_path, monkeypatch):
+        self._cfg(tmp_path, monkeypatch)
+        url = "https://example.databricks.com/api/ai-gateway/v2/endpoints"
+        assert _with_workspace_disambiguator(url) == url + "?o=1234567890123456"
+
+    def test_appends_o_param_preserving_existing_query(self, tmp_path, monkeypatch):
+        self._cfg(tmp_path, monkeypatch)
+        url = "https://example.databricks.com/api/ai-gateway/v2/endpoints?page_size=1"
+        assert _with_workspace_disambiguator(url) == url + "&o=1234567890123456"
+
+    def test_leaves_url_untouched_when_o_already_present(self, tmp_path, monkeypatch):
+        self._cfg(tmp_path, monkeypatch)
+        url = "https://example.databricks.com/api/ai-gateway/v2/endpoints?o=999"
+        assert _with_workspace_disambiguator(url) == url
+
+    def test_leaves_url_untouched_when_host_unknown(self, tmp_path, monkeypatch):
+        self._cfg(tmp_path, monkeypatch)
+        url = "https://unknown.databricks.com/api/ai-gateway/v2/endpoints"
+        assert _with_workspace_disambiguator(url) == url


### PR DESCRIPTION
## Problem

On a Databricks host that serves multiple workspaces, the CLI issues an **account-audience** OAuth token. The workspace APIs reject that token at the authz layer unless the request carries the workspace disambiguator `o=<workspace_id>`. Without it they respond `303` to `/login`, and ucode parses the returned sign-in HTML as JSON.

`ucode configure` therefore aborts before writing any agent config:

```
✔ Databricks authentication complete
ERROR Databricks Unity AI Gateway probe failed on this workspace
      (response was not valid JSON (Expecting value)).
      See https://docs.databricks.com/aws/en/ai-gateway/overview-beta
```

Patching only the probe moves the failure one step later, to model discovery:

```
✔ Unity AI Gateway detected
ERROR No coding agents are available on this workspace.
• Claude models (needed for: claude, opencode, copilot, pi): response was not valid JSON (Expecting value)
• Gemini models (needed for: gemini, opencode, pi): no models returned
```

The affected requests all flow through `_http_get_json` / `_http_post_json`:

- `GET /api/ai-gateway/v2/endpoints` — the `ensure_ai_gateway_v2` probe
- `GET /api/2.1/unity-catalog/model-services` — model discovery
- `GET /ai-gateway/anthropic/v1/models`
- `GET /api/2.0/sql/warehouses`, the UC catalog/schema/function listings, etc.

The workspace is fully gateway-enabled and the token is valid — the request just can't be attributed to a workspace.

Observed against a multi-workspace staging host:

```
$ curl -si -H "Authorization: Bearer $TOKEN" \
    "https://$HOST/api/ai-gateway/v2/endpoints?page_size=1"
HTTP/2 303
x-databricks-apiproxy-response-code-details: ext_authz_denied
location: /login?next_url=%2Fapi%2Fai-gateway%2Fv2%2Fendpoints%3Fpage_size%3D1

$ curl -so /dev/null -w '%{http_code}\n' -H "Authorization: Bearer $TOKEN" \
    "https://$HOST/api/ai-gateway/v2/endpoints?page_size=1&o=$WORKSPACE_ID"
200
```

An `X-Databricks-Org-Id: <workspace_id>` header works equivalently.

## Fix

Centralize it in the two HTTP helpers rather than at the ~30 individual call sites that each build `f"https://{hostname}/..."`.

- `_workspace_id_for_hostname(hostname)` reads `~/.databrickscfg` (honoring `DATABRICKS_CONFIG_FILE`), normalizes each profile's `host` to a hostname, and returns the `workspace_id` of the first match. Blank values and the literal `none` are skipped, so a workspace-scoped profile wins over an account-only profile on the same host — a common layout, since an account-level `databricks auth login` writes `workspace_id = none`.
- `_with_workspace_disambiguator(url)` appends `?o=<id>` or `&o=<id>` as appropriate.
- `_http_get_json` and `_http_post_json` each call it on entry.

It is a no-op wherever it isn't needed: a single-workspace host ignores the extra param, an account-only profile resolves to `None`, a URL already carrying `o=` is untouched, and a malformed or missing config degrades to current behavior instead of raising. No authentication logic changes — same token, same headers, same audience.

## Verification

After the change, against the same host:

```
✔ Databricks authentication complete
✔ Unity AI Gateway detected
✔ Databricks AI Tools installed
╭───────── Configuration Complete ─────────╮
│ Claude Code: configured (Provider: Databricks) │
╰──────────────────────────────────────────╯
✔ Claude Code is working
```

`ucode claude -p "..."` then runs headless against `system.ai.claude-opus-5` through the gateway.

## Tests

8 focused tests in `tests/test_databricks.py` (`TestWorkspaceIdForHostname`, `TestWithWorkspaceDisambiguator`): resolving past an account-only profile on the same host, a second distinct host, unknown host, missing config file, append with and without an existing query string, and the no-op when `o=` is already present.

```
uv run pytest -q                          # 1055 passed, 40 skipped
uv run ruff check .                       # All checks passed!
uv run ruff format --check src/ tests/    # 55 files already formatted
```

## Note for reviewers

`ci.yml` triggers on `pull_request`, and GitHub withholds repo secrets from fork-based PRs, so the steps needing `UCODE_TEST_WORKSPACE` / `DATABRICKS_BEARER` won't have credentials here. Unit tests and lint run normally; the e2e job may need a `workflow_dispatch` re-run from a branch in this repo.
