### PR TITLE
Show budget spend and threshold in `ucode usage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ skipped in a re-run is dropped.
 | Command | Description |
 |---------|-------------|
 | `ucode status` | Show current workspace, base URLs, managed config files, and selected models |
-| `ucode usage` | Show AI Gateway usage summary |
+| `ucode usage` | Show AI Gateway usage summary, plus your budget spend against its alert threshold when the workspace reports one |
 | `ucode revert` | Clear saved state and restore backed-up config files |
 | `ucode configure --dry-run` | Preview config files without writing them |
 | `ucode configure --agents claude,codex` | Configure specific agents without the interactive picker |

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -23,6 +23,7 @@ from concurrent.futures import (
 from concurrent.futures import (
     TimeoutError as FutureTimeoutError,
 )
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Literal, cast, overload
 from urllib import error as urllib_error
@@ -2527,6 +2528,48 @@ def _looks_like_auth_failure(reason: str) -> bool:
     if "HTTP 400" in reason and "invalid token" in reason.lower():
         return True
     return False
+
+
+CODING_AGENT_BUDGET_SPEND_PATH = "/api/ai-gateway/v2/coding-agent-configs:resolveCurrentBudgetSpend"
+
+
+def resolve_current_budget_spend(
+    workspace: str,
+    token: str,
+    *,
+    timeout: int = 10,
+) -> tuple[tuple[Decimal, Decimal] | None, str | None]:
+    """Fetch the caller's coding-agent budget spend and alert threshold.
+
+    Returns `((spend, threshold), None)` or `(None, reason)`. Absence is
+    routine — the endpoint needs a per-org SAFE flag (default off) and a
+    coding-agent config — so it never raises.
+    """
+    url = f"https://{workspace_hostname(workspace)}{CODING_AGENT_BUDGET_SPEND_PATH}"
+    payload, reason = _http_post_json(url, token, {}, timeout=timeout)
+    if payload is None:
+        return None, reason or "unknown error"
+    if not isinstance(payload, dict):
+        return None, "response was not a JSON object"
+
+    # Per the server's BudgetSpend.fromProto, a spend with no threshold to
+    # measure against counts as no spend.
+    spend = _parse_decimal(payload.get("current_spend"))
+    threshold = _parse_decimal(payload.get("effective_threshold"))
+    if spend is None or threshold is None:
+        return None, "workspace reported no coding-agent budget spend"
+    return (spend, threshold), None
+
+
+def _parse_decimal(value: object) -> Decimal | None:
+    if isinstance(value, str) and value.strip():
+        try:
+            return Decimal(value.strip())
+        except InvalidOperation:
+            return None
+    if isinstance(value, int):
+        return Decimal(value)
+    return None
 
 
 def discover_sql_warehouse_http_path(

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -2530,7 +2530,7 @@ def _looks_like_auth_failure(reason: str) -> bool:
     return False
 
 
-CODING_AGENT_BUDGET_SPEND_PATH = "/api/ai-gateway/v2/coding-agent-configs:resolveCurrentBudgetSpend"
+CODING_AGENT_RECOMMEND_MODEL_PATH = "/api/ai-gateway/v2/coding-agent-configs:recommendModel"
 
 
 def resolve_current_budget_spend(
@@ -2541,12 +2541,16 @@ def resolve_current_budget_spend(
 ) -> tuple[tuple[Decimal, Decimal] | None, str | None]:
     """Fetch the caller's coding-agent budget spend and alert threshold.
 
+    Reads them off `recommendModel`, which returns the spend its model
+    recommendation was based on. `available_models` is empty since we want the
+    spend, not the recommendation.
+
     Returns `((spend, threshold), None)` or `(None, reason)`. Absence is
     routine — the endpoint needs a per-org SAFE flag (default off) and a
     coding-agent config — so it never raises.
     """
-    url = f"https://{workspace_hostname(workspace)}{CODING_AGENT_BUDGET_SPEND_PATH}"
-    payload, reason = _http_post_json(url, token, {}, timeout=timeout)
+    url = f"https://{workspace_hostname(workspace)}{CODING_AGENT_RECOMMEND_MODEL_PATH}"
+    payload, reason = _http_post_json(url, token, {"available_models": []}, timeout=timeout)
     if payload is None:
         return None, reason or "unknown error"
     if not isinstance(payload, dict):

--- a/src/ucode/ui.py
+++ b/src/ucode/ui.py
@@ -10,6 +10,7 @@ import time
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import timedelta
+from decimal import ROUND_HALF_UP, Decimal
 
 import questionary
 from rich.console import Console
@@ -225,6 +226,20 @@ def format_token_count(token_count: int) -> str:
     if token_count >= 1_000:
         return f"{value_float / 1_000:.1f}K"
     return str(token_count)
+
+
+def format_usd(amount: Decimal) -> str:
+    return f"${amount.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP):,}"
+
+
+def format_meter(fraction: float, width: int = 30) -> str:
+    """Text meter for `fraction` of a whole, clamped to [0, 1]."""
+    clamped = min(max(fraction, 0.0), 1.0)
+    filled = int(clamped * width)
+    # A small-but-real fraction shouldn't read as empty.
+    if clamped > 0:
+        filled = max(filled, 1)
+    return "[" + "█" * filled + "░" * (width - filled) + "]"
 
 
 def format_duration(duration_value: timedelta | None) -> str:

--- a/src/ucode/usage.py
+++ b/src/ucode/usage.py
@@ -489,7 +489,8 @@ def usage() -> int:
     requester_name = find_requester_name(workspace, resolved_http_path, token, records)
 
     # Opt-in per workspace: omit the lines rather than fail the report.
-    budget_spend, _ = resolve_current_budget_spend(workspace, token)
+    with spinner("Checking budget spend..."):
+        budget_spend, _ = resolve_current_budget_spend(workspace, token)
 
     tool_displays = {tool: spec["display"] for tool, spec in TOOL_SPECS.items()}
     configured_tools = configured_usage_tools(state, tool_displays)

--- a/src/ucode/usage.py
+++ b/src/ucode/usage.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 from datetime import date, datetime, timedelta
+from decimal import Decimal
 from typing import cast
 
 from ucode.databricks import (
@@ -15,15 +16,19 @@ from ucode.databricks import (
     discover_sql_warehouse_http_path,
     ensure_databricks_auth,
     get_databricks_token,
+    resolve_current_budget_spend,
     run_usage_query,
 )
 from ucode.state import load_state
 from ucode.ui import (
     console,
     format_duration,
+    format_meter,
     format_token_count,
+    format_usd,
     heading,
     label,
+    muted,
     print_heading,
     print_note,
     render_box_table,
@@ -370,10 +375,27 @@ def find_requester_name(
     return "current user"
 
 
+def render_budget_lines(budget_spend: tuple[Decimal, Decimal] | None) -> list[str]:
+    """Spend-against-threshold lines, or nothing when unavailable."""
+    if budget_spend is None:
+        return []
+    spend, threshold = budget_spend
+    # No whole to be a fraction of; dividing would raise.
+    if threshold <= 0:
+        return [f"{label('Budget spend:')} {value(format_usd(spend))}"]
+    fraction = float(spend / threshold)
+    summary = f"{format_usd(spend)} of {format_usd(threshold)} ({fraction:.0%})"
+    return [
+        f"{label('Budget spend:')} {value(summary)}",
+        muted(format_meter(fraction)),
+    ]
+
+
 def render_usage_summary(
     records: list[dict[str, object]],
     requester_name: str,
     tool_displays: dict[str, str],
+    budget_spend: tuple[Decimal, Decimal] | None = None,
 ) -> str:
     today = date.today()
     week_start = today - timedelta(days=USAGE_BREAKDOWN_DAYS - 1)
@@ -434,6 +456,7 @@ def render_usage_summary(
             for model_name, token_total in top_models
         )
         lines.append(f"{label('Top models this week:')} {value(models_text)}")
+    lines.extend(render_budget_lines(budget_spend))
     return "\n".join(lines)
 
 
@@ -465,12 +488,22 @@ def usage() -> int:
     records = parse_usage_rows(columns, rows)
     requester_name = find_requester_name(workspace, resolved_http_path, token, records)
 
+    # Opt-in per workspace: omit the lines rather than fail the report.
+    budget_spend, _ = resolve_current_budget_spend(workspace, token)
+
     tool_displays = {tool: spec["display"] for tool, spec in TOOL_SPECS.items()}
     configured_tools = configured_usage_tools(state, tool_displays)
     configured_tool_displays = {tool: tool_displays[tool] for tool in configured_tools}
     records = filter_records_for_tools(records, configured_tools)
 
-    console.print(render_usage_summary(records, requester_name, configured_tool_displays))
+    console.print(
+        render_usage_summary(
+            records,
+            requester_name,
+            configured_tool_displays,
+            budget_spend=budget_spend,
+        )
+    )
 
     table_headers = ["Date", "Day", "Tokens", "Sessions", "Duration", "Models"]
     table_widths = [8, 5, 10, 8, 8, 24]

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+from decimal import Decimal
 
 import pytest
 
 import ucode.databricks as db_mod
 from ucode.databricks import (
     AI_GATEWAY_V2_DOCS_URL,
+    CODING_AGENT_BUDGET_SPEND_PATH,
     _format_subprocess_result,
     _parse_databricks_cli_version,
     _run_databricks_cli_installer,
@@ -31,6 +33,7 @@ from ucode.databricks import (
     list_databricks_apps,
     list_databricks_connections,
     list_genie_spaces,
+    resolve_current_budget_spend,
     workspace_hostname,
 )
 
@@ -2286,3 +2289,81 @@ class TestIsWorkspaceAdmin:
         # A well-formed `Me` for a user in no groups omits `groups` entirely.
         self._stub(monkeypatch, payload)
         assert db_mod.is_workspace_admin("https://w", "tok") is False
+
+
+class TestResolveCurrentBudgetSpend:
+    def test_parses_spend_and_threshold(self, monkeypatch):
+        monkeypatch.setattr(
+            db_mod,
+            "_http_post_json",
+            lambda url, token, payload, timeout=10: (
+                {"current_spend": "12.34", "effective_threshold": "100"},
+                None,
+            ),
+        )
+        spend, reason = resolve_current_budget_spend("https://ws", "token")
+        assert spend == (Decimal("12.34"), Decimal("100"))
+        assert reason is None
+
+    def test_posts_empty_body_to_coding_agent_path(self, monkeypatch):
+        captured = {}
+
+        def fake_post(url, token, payload, timeout=10):
+            captured["url"] = url
+            captured["payload"] = payload
+            return {"current_spend": "1", "effective_threshold": "2"}, None
+
+        monkeypatch.setattr(db_mod, "_http_post_json", fake_post)
+        resolve_current_budget_spend("https://ws.example.com", "token")
+        assert captured["url"] == (f"https://ws.example.com{CODING_AGENT_BUDGET_SPEND_PATH}")
+        assert captured["payload"] == {}
+
+    def test_feature_disabled_returns_reason(self, monkeypatch):
+        monkeypatch.setattr(
+            db_mod,
+            "_http_post_json",
+            lambda url, token, payload, timeout=10: (
+                None,
+                "HTTP 400 Bad Request: FEATURE_DISABLED",
+            ),
+        )
+        spend, reason = resolve_current_budget_spend("https://ws", "token")
+        assert spend is None
+        assert "FEATURE_DISABLED" in reason
+
+    def test_unset_fields_treated_as_no_spend(self, monkeypatch):
+        monkeypatch.setattr(
+            db_mod, "_http_post_json", lambda url, token, payload, timeout=10: ({}, None)
+        )
+        spend, reason = resolve_current_budget_spend("https://ws", "token")
+        assert spend is None
+        assert "no coding-agent budget spend" in reason
+
+    def test_spend_without_threshold_is_no_spend(self, monkeypatch):
+        monkeypatch.setattr(
+            db_mod,
+            "_http_post_json",
+            lambda url, token, payload, timeout=10: ({"current_spend": "12.34"}, None),
+        )
+        spend, _ = resolve_current_budget_spend("https://ws", "token")
+        assert spend is None
+
+    def test_malformed_decimal_is_no_spend(self, monkeypatch):
+        monkeypatch.setattr(
+            db_mod,
+            "_http_post_json",
+            lambda url, token, payload, timeout=10: (
+                {"current_spend": "not-a-number", "effective_threshold": "100"},
+                None,
+            ),
+        )
+        spend, _ = resolve_current_budget_spend("https://ws", "token")
+        assert spend is None
+
+    def test_non_object_payload_is_no_spend(self, monkeypatch):
+        monkeypatch.setattr(
+            db_mod, "_http_post_json", lambda url, token, payload, timeout=10: ([], None)
+        )
+        spend, reason = resolve_current_budget_spend("https://ws", "token")
+        assert spend is None
+        assert "not a JSON object" in reason

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -12,7 +12,7 @@ import pytest
 import ucode.databricks as db_mod
 from ucode.databricks import (
     AI_GATEWAY_V2_DOCS_URL,
-    CODING_AGENT_BUDGET_SPEND_PATH,
+    CODING_AGENT_RECOMMEND_MODEL_PATH,
     _format_subprocess_result,
     _parse_databricks_cli_version,
     _run_databricks_cli_installer,
@@ -2305,7 +2305,7 @@ class TestResolveCurrentBudgetSpend:
         assert spend == (Decimal("12.34"), Decimal("100"))
         assert reason is None
 
-    def test_posts_empty_body_to_coding_agent_path(self, monkeypatch):
+    def test_posts_to_recommend_model_with_no_available_models(self, monkeypatch):
         captured = {}
 
         def fake_post(url, token, payload, timeout=10):
@@ -2315,8 +2315,41 @@ class TestResolveCurrentBudgetSpend:
 
         monkeypatch.setattr(db_mod, "_http_post_json", fake_post)
         resolve_current_budget_spend("https://ws.example.com", "token")
-        assert captured["url"] == (f"https://ws.example.com{CODING_AGENT_BUDGET_SPEND_PATH}")
-        assert captured["payload"] == {}
+        assert captured["url"] == (f"https://ws.example.com{CODING_AGENT_RECOMMEND_MODEL_PATH}")
+        # Empty list applies no availability filter; we want the spend only.
+        assert captured["payload"] == {"available_models": []}
+
+    def test_ignores_recommended_models(self, monkeypatch):
+        monkeypatch.setattr(
+            db_mod,
+            "_http_post_json",
+            lambda url, token, payload, timeout=10: (
+                {
+                    "recommended_models": ["system.ai.claude-sonnet-4-5"],
+                    "current_spend": "12.34",
+                    "effective_threshold": "100",
+                },
+                None,
+            ),
+        )
+        spend, reason = resolve_current_budget_spend("https://ws", "token")
+        assert spend == (Decimal("12.34"), Decimal("100"))
+        assert reason is None
+
+    def test_recommendation_without_spend_is_no_spend(self, monkeypatch):
+        # A config with no matching budget still recommends models, but both
+        # spend fields come back unset.
+        monkeypatch.setattr(
+            db_mod,
+            "_http_post_json",
+            lambda url, token, payload, timeout=10: (
+                {"recommended_models": ["system.ai.claude-sonnet-4-5"]},
+                None,
+            ),
+        )
+        spend, reason = resolve_current_budget_spend("https://ws", "token")
+        assert spend is None
+        assert "no coding-agent budget spend" in reason
 
     def test_feature_disabled_returns_reason(self, monkeypatch):
         monkeypatch.setattr(

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 from datetime import timedelta
+from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
@@ -11,7 +12,9 @@ from rich.console import Console
 
 from ucode.ui import (
     format_duration,
+    format_meter,
     format_token_count,
+    format_usd,
     normalize_workspace_url,
     prompt_for_percentage,
     prompt_for_text,
@@ -296,3 +299,42 @@ class TestPromptForWorkspace:
             url, profile = prompt_for_workspace("desc", profiles=None)
         assert url == "https://example.databricks.com"
         assert profile is None
+
+
+class TestFormatUsd:
+    def test_rounds_to_cents(self):
+        assert format_usd(Decimal("12.345")) == "$12.35"
+        assert format_usd(Decimal("12.344")) == "$12.34"
+
+    def test_pads_to_two_decimals(self):
+        assert format_usd(Decimal("5")) == "$5.00"
+
+    def test_thousands_separator(self):
+        assert format_usd(Decimal("1234567.5")) == "$1,234,567.50"
+
+    def test_zero(self):
+        assert format_usd(Decimal("0")) == "$0.00"
+
+
+class TestFormatMeter:
+    def test_empty(self):
+        assert format_meter(0.0, width=10) == "[" + "\u2591" * 10 + "]"
+
+    def test_full(self):
+        assert format_meter(1.0, width=10) == "[" + "\u2588" * 10 + "]"
+
+    def test_half(self):
+        assert format_meter(0.5, width=10) == "[" + "\u2588" * 5 + "\u2591" * 5 + "]"
+
+    def test_tiny_nonzero_fills_one_cell(self):
+        assert format_meter(0.001, width=10) == "[\u2588" + "\u2591" * 9 + "]"
+
+    def test_clamps_above_one(self):
+        assert format_meter(2.5, width=10) == "[" + "\u2588" * 10 + "]"
+
+    def test_clamps_below_zero(self):
+        assert format_meter(-1.0, width=10) == "[" + "\u2591" * 10 + "]"
+
+    def test_width_is_constant(self):
+        for fraction in (0.0, 0.13, 0.5, 0.99, 1.0):
+            assert len(format_meter(fraction)) == 32

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta
+from decimal import Decimal
 
 import ucode.usage as usage_mod
+from ucode.ui import label, value
 from ucode.usage import (
     USAGE_BREAKDOWN_DAYS,
     USAGE_SUMMARY_DAYS,
@@ -20,6 +22,7 @@ from ucode.usage import (
     filter_records_for_tools,
     has_tool_usage_last_week,
     parse_usage_rows,
+    render_budget_lines,
     render_usage_summary,
     simplify_model_name,
     summarize_model_tokens,
@@ -301,6 +304,37 @@ class TestEmptyToolDay:
         assert row["models"] == "-"
 
 
+class TestRenderBudgetLines:
+    def test_no_lines_when_unavailable(self):
+        assert render_budget_lines(None) == []
+
+    def test_shows_spend_threshold_and_percent(self):
+        lines = render_budget_lines((Decimal("12.34"), Decimal("100")))
+        assert "$12.34" in lines[0]
+        assert "$100.00" in lines[0]
+        assert "12%" in lines[0]
+
+    def test_renders_meter(self):
+        lines = render_budget_lines((Decimal("50"), Decimal("100")))
+        assert len(lines) == 2
+        assert "█" in lines[1]
+        assert "░" in lines[1]
+
+    def test_zero_threshold_omits_percent_and_meter(self):
+        lines = render_budget_lines((Decimal("5"), Decimal("0")))
+        assert lines == [f"{label('Budget spend:')} {value('$5.00')}"]
+
+    def test_spend_over_threshold_clamps_meter(self):
+        lines = render_budget_lines((Decimal("250"), Decimal("100")))
+        assert "250%" in lines[0]
+        assert "░" not in lines[1]
+
+    def test_thousands_separator(self):
+        lines = render_budget_lines((Decimal("1234.5"), Decimal("10000")))
+        assert "$1,234.50" in lines[0]
+        assert "$10,000.00" in lines[0]
+
+
 class TestRenderUsageSummary:
     def _make_record(self, days_ago: int, tool: str, tokens: int, model: str = "") -> dict:
         d = date.today() - timedelta(days=days_ago)
@@ -340,6 +374,21 @@ class TestRenderUsageSummary:
         records = [self._make_record(0, "claude", 5000, "databricks-claude-sonnet-4")]
         result = render_usage_summary(records, "user", {"claude": "Claude Code"})
         assert "sonnet-4" in result
+
+    def test_includes_budget_spend_when_available(self):
+        records = [self._make_record(0, "claude", 1000)]
+        result = render_usage_summary(
+            records,
+            "user",
+            {"claude": "Claude Code"},
+            budget_spend=(Decimal("12.34"), Decimal("100")),
+        )
+        assert "$12.34 of $100.00" in result
+
+    def test_omits_budget_spend_by_default(self):
+        records = [self._make_record(0, "claude", 1000)]
+        result = render_usage_summary(records, "user", {"claude": "Claude Code"})
+        assert "Budget spend" not in result
 
     def test_top_models_uses_per_model_token_totals(self):
         records = [
@@ -470,6 +519,9 @@ class TestUsageCommand:
             lambda *args, **kwargs: "/sql/1.0/warehouses/abc",
         )
         monkeypatch.setattr(usage_mod, "run_usage_query", lambda *args, **kwargs: (columns, rows))
+        monkeypatch.setattr(
+            usage_mod, "resolve_current_budget_spend", lambda *args, **kwargs: (None, "disabled")
+        )
         monkeypatch.setattr(usage_mod, "console", DummyConsole())
         monkeypatch.setattr(usage_mod, "print_heading", headings.append)
         monkeypatch.setattr(usage_mod, "print_note", notes.append)


### PR DESCRIPTION
## Problem

`ucode usage` shows tokens only — no dollar spend or budget context.

## Change

Add the caller's coding-agent budget spend and alert threshold to the `ucode usage` summary, read off AI Gateway's `coding-agent-configs:recommendModel` (posted with an empty `available_models`, since we want the spend the recommendation was based on, not the recommendation — `recommended_models` is ignored):

```
Budget spend: $2.34 of $5,000.00 (0%)
[█░░░░░░░░░░░░░░░░░░░░░░░░░░░░░]
```

Amounts are parsed as `Decimal`. The endpoint is off by default per org, so absence returns a reason string rather than raising — the lines are simply omitted and the rest of the report is unchanged.

## Testing

29 new unit tests; 1167 passed, ruff clean.

Verified against the live endpoint on a workspace with the flag on: `current_spend` `2.3441188` / `effective_threshold` `5000` renders as `$2.34 of $5,000.00 (0%)`. A workspace with the flag off returns `FEATURE_DISABLED` and correctly renders no lines.