### PR TITLE
e2e: fix the codex model exclusions, and stop truncating away the cause

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -426,11 +426,12 @@ class TestCodexLaunch:
     CODEX_INCOMPATIBLE_MODEL_FRAGMENTS = (
         # nano endpoint is unreliably slow and times out past the 60s budget.
         "gpt-5-4-nano",
-        # These endpoints are discoverable as responses-capable, but the
-        # backing OpenAI endpoint returns ENDPOINT_NOT_FOUND in the CI region.
-        "gpt-5-6-luna",
-        "gpt-5-6-sol",
-        "gpt-5-6-terra",
+        # Discoverable and correctly configured, but the gateway's upstream OpenAI project can't
+        # serve this snapshot from the CI region: "The requested model snapshot is not available
+        # for your project's geography." The gateway relays that as a bare INTERNAL_ERROR
+        # ("invalid response from an upstream server"), so the launch fails after codex-cli
+        # exhausts its five reconnects. Nothing ucode writes can fix it.
+        "gpt-5-3-codex",
     )
 
     def _codex_models(self, e2e_state: dict) -> list[str]:
@@ -479,9 +480,12 @@ class TestCodexLaunch:
                 continue
 
             if result.returncode != 0 or not (result.stdout or result.stderr).strip():
+                # Keep a generous tail of stderr. codex-cli logs a non-fatal model-listing error
+                # first and the actual cause last, so a short prefix reports the wrong problem —
+                # at 200 chars the geography failure above read as a `/v1/models` routing error.
                 failures.append(
                     f"model={model} rc={result.returncode} "
-                    f"stdout={result.stdout[:200]!r} stderr={result.stderr[:200]!r}"
+                    f"stdout={result.stdout[-500:]!r} stderr={result.stderr[-1500:]!r}"
                 )
 
         assert not failures, "Codex launch failures:\n" + "\n".join(failures)


### PR DESCRIPTION
### Changes

`TestCodexLaunch::test_launch_codex_per_model` has been red on `main` for at least five consecutive runs. The exclusion list had drifted in **both** directions.

**Dropped `gpt-5-6-luna` / `sol` / `terra`.** Their comment says the backing OpenAI endpoint returns `ENDPOINT_NOT_FOUND` in the CI region. That is no longer true — all three answer a `/ai-gateway/codex/v1/responses` request there now:

```
databricks-gpt-5-6-luna    OK -> gpt-5.6-luna
databricks-gpt-5-6-sol     OK -> gpt-5.6-sol
databricks-gpt-5-6-terra   OK -> gpt-5.6-terra
databricks-gpt-5-3-codex   INTERNAL_ERROR
```

So the list was excluding the model ucode actually defaults to (`gpt-5.6-sol` is the launcher's pick) while still testing one that cannot run.

**Added `gpt-5-3-codex`**, which is what fails today. It is discoverable, in the workspace catalog, and configured correctly by ucode — the gateway's upstream OpenAI project just can't serve that snapshot from the CI region:

```
ERROR: stream disconnected before completion: The requested model snapshot is not
available for your project's geography.
```

The gateway relays that as a bare `INTERNAL_ERROR` ("invalid response from an upstream server"), so the launch dies after codex-cli exhausts its five reconnects. No ucode change can fix it, which is what makes it an exclusion rather than a bug.

Net effect is **more** coverage, not less: 13 models tested before, 15 now.

**Stopped truncating away the cause.** The failure report used the *first* 200 characters of stdout/stderr; it now uses the *last* 1500. Direction matters more than length: codex-cli logs a non-fatal model-listing error **first** and the real cause **last**, so a prefix reliably reported the wrong problem. The geography failure above presented as a `/v1/models` routing error — the message died mid-word at `Request path '/ai-gat` — and cost two rounds of misdiagnosis before the tail was visible.

### Testing

Verified against a workspace in the CI region:

- each of the three re-enabled models returns a response
- `gpt-5-3-codex` returns `INTERNAL_ERROR`
- `tests/test_e2e.py::TestCodexLaunch::test_launch_codex_per_model` **passes** across all 15 remaining models (73s)

### Note for reviewers

The exclusion list is keyed to whatever workspace `UCODE_TEST_WORKSPACE` points at, and regional availability has now shifted twice. I verified against a workspace in the CI region, but that secret is masked, so I can't confirm it is the same one — if it isn't, the `5-6` removals could re-introduce failures.

Treating a gateway-side availability error as a **skip** rather than a failure would remove this maintenance burden entirely, since a model ucode configured correctly that the gateway can't serve isn't a ucode regression. That's a larger change than this fix, so it's left as a follow-up.

This pull request and its description were written by Isaac.
