### PR TITLE
Remove the GLM restriction for Codex subagents

### DIFF
--- a/src/ucode/smart_routing/codex_routing.py
+++ b/src/ucode/smart_routing/codex_routing.py
@@ -31,11 +31,6 @@ CANARY_PATH = APP_DIR / "codex-smart-routing-canary.json"
 AUDIT_PATH = APP_DIR / "codex-smart-routing-audit.jsonl"
 DECISIONS_PATH = APP_DIR / "codex-smart-routing-decisions.jsonl"
 
-GLM_SUBAGENT_SKIP_MESSAGE = (
-    "Smart Routing selected GLM 5.2, which is not enabled for Codex "
-    "subagents. Keeping the original subagent model."
-)
-
 _GPT_RE = re.compile(r"gpt-(\d+)(?:[.-](\d+))?(?:[.-](\d+))?(-.+|[a-z].*)?")
 
 _normalize_model = routing.normalize_model
@@ -158,7 +153,6 @@ def route_pre_tool_use(
         ),
         default_task_label="Codex subagent task",
         model_id_mapper=_codex_model_id,
-        skip_arms={GLM_ROUTE_ARM: GLM_SUBAGENT_SKIP_MESSAGE},
         record_decision=record,
     )
 

--- a/tests/test_codex_routing.py
+++ b/tests/test_codex_routing.py
@@ -187,7 +187,9 @@ def test_spawn_rewrite_uses_codex_model_id_for_uc_endpoint(monkeypatch):
     assert output["hookSpecificOutput"]["updatedInput"]["model"] == "gpt-5.6-luna"
 
 
-def test_spawn_glm_decision_keeps_original_model(monkeypatch):
+def test_spawn_glm_decision_applies_glm_model(monkeypatch):
+    # GLM is no longer skipped for Codex subagents: a GLM routing decision is
+    # applied like any other arm.
     monkeypatch.setattr(
         codex_routing,
         "request_routing_decision",
@@ -210,12 +212,8 @@ def test_spawn_glm_decision_keeps_original_model(monkeypatch):
         available_models=["system.ai.gpt-5-6-luna", "system.ai.gpt-5-6-sol"],
     )
 
-    assert output == {
-        "systemMessage": (
-            "Smart Routing selected GLM 5.2, which is not enabled for Codex "
-            "subagents. Keeping the original subagent model."
-        )
-    }
+    assert output["hookSpecificOutput"]["updatedInput"]["model"] == "system.ai.glm-5-2"
+    assert "Using Smart Routing. Routing to system.ai.glm-5-2." in output["systemMessage"]
 
 
 def test_non_spawn_tool_has_no_opinion():


### PR DESCRIPTION
## What & why

Drops the `skip_arms` guard in `codex_routing.route_pre_tool_use` that prevented a GLM routing decision from being applied to Codex subagent spawns. With it removed, GLM is routed like any other arm — the subagent's `model` is rewritten to `system.ai.glm-5-2`.

Scope is deliberately minimal: only the guard, the now-unused `GLM_SUBAGENT_SKIP_MESSAGE` constant, and the one test that asserted the skip.

## Caveat worth flagging

The guard existed because Codex constrains a spawned subagent's model to its own model catalog, and GLM isn't in it — so a GLM-routed subagent may be rejected at spawn until GLM is present in the catalog (either via the gateway's model-list endpoint or a client-side catalog file). This PR removes the restriction on its own; the catalog side is tracked separately.

## How do you know it works

- `test_spawn_glm_decision_applies_glm_model` replaces the old skip test and asserts the GLM model is injected into `updatedInput`.
- Full suite: 1192 passed; ruff clean.

This pull request and its description were written by Isaac.