### PR TITLE
Apply managed agent config per-agent and honor default model

### DIFF
--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -385,15 +385,17 @@ def write_tool_config(state: dict, model: str | None = None, provider: str | Non
 def default_model(state: dict) -> str | None:
     """Pick the newest GPT model when multiple are available.
 
-    The discovery list is alphabetically sorted, which can put
-    "databricks-gpt-5" ahead of "databricks-gpt-5-5". Prefer the
-    highest semantic version instead.
+    A managed config's ``codex_default_model`` takes priority. The discovery list
+    is alphabetically sorted, which can put "databricks-gpt-5" ahead of
+    "databricks-gpt-5-5". Prefer the highest semantic version instead.
 
     Only GPT-parseable ids are considered. Codex routes the chosen ``model``
     through the gateway as-is, so a non-GPT entry (e.g. ``moonshotai/kimi-k2.5``)
     would be rejected with a Unity Catalog endpoint-name error. When no
     candidate parses as GPT we return None rather than pinning an unroutable id.
     """
+    if isinstance(state.get("codex_default_model"), str):
+        return state.get("codex_default_model")
     codex_models = state.get("codex_models") or []
     parsed: list[tuple[str, tuple[int, int | None, int | None, str]]] = [
         (mid, gpt) for mid in codex_models if (gpt := _parse_gpt(mid)) is not None

--- a/src/ucode/agents/copilot.py
+++ b/src/ucode/agents/copilot.py
@@ -71,7 +71,16 @@ def is_update_available() -> tuple[str, str] | None:
 
 
 def default_model(state: dict) -> str | None:
-    """Prefer Claude sonnet, then opus/haiku, then codex."""
+    """Prefer Claude sonnet, then opus/haiku, then codex.
+
+    A managed config's ``copilot_default_model`` and ``copilot_models`` both win outright: the former is
+    the admin's chosen session start, the latter their allowlist. Workspace-wide discovery falls back.
+    """
+    if isinstance(state.get("copilot_default_model"), str):
+        return state.get("copilot_default_model")
+    copilot_models = state.get("copilot_models") or []
+    if isinstance(copilot_models, list) and copilot_models:
+        return copilot_models[0]
     claude_models = state.get("claude_models") or {}
     for family in ("sonnet", "opus", "haiku"):
         if claude_models.get(family):

--- a/src/ucode/agents/gemini.py
+++ b/src/ucode/agents/gemini.py
@@ -184,6 +184,8 @@ def write_tool_config(
 
 
 def default_model(state: dict) -> str | None:
+    if isinstance(state.get("gemini_default_model"), str):
+        return state.get("gemini_default_model")
     gemini_models = state.get("gemini_models") or []
     return gemini_models[0] if gemini_models else None
 

--- a/src/ucode/agents/opencode.py
+++ b/src/ucode/agents/opencode.py
@@ -228,6 +228,8 @@ def remove_mcp_server_config(name: str) -> bool:
 
 
 def default_model(state: dict) -> str | None:
+    if isinstance(state.get("opencode_default_model"), str):
+        return state.get("opencode_default_model")
     opencode_models = state.get("opencode_models") or {}
     anthropic = opencode_models.get("anthropic") or []
     if anthropic:

--- a/src/ucode/agents/pi.py
+++ b/src/ucode/agents/pi.py
@@ -42,8 +42,10 @@ from ucode.config_io import (
     write_json_file,
 )
 from ucode.databricks import (
+    ANTHROPIC_FAMILIES,
     TOKEN_REFRESH_INTERVAL_SECONDS,
     build_pi_base_urls,
+    classify_model_family,
     get_databricks_token,
 )
 from ucode.state import mark_tool_managed, save_state
@@ -171,13 +173,19 @@ def write_tool_config(
             state["workspace"], state.get("profile"), force_refresh=force_refresh
         )
     pi_base_urls = state.get("base_urls", {}).get("pi") or build_pi_base_urls(state["workspace"])
+    managed_families = _managed_model_families(state)
+    claude_models, codex_models, gemini_models = managed_families or (
+        state.get("claude_models") or {},
+        state.get("codex_models") or [],
+        state.get("gemini_models") or [],
+    )
     overlay, managed_keys = render_overlay(
         model,
         token,
         pi_base_urls,
-        state.get("claude_models") or {},
-        state.get("codex_models") or [],
-        state.get("gemini_models") or [],
+        claude_models,
+        codex_models,
+        gemini_models,
     )
     existing = read_json_safe(PI_CONFIG_PATH)
     providers = existing.get("providers")
@@ -205,8 +213,42 @@ def _write_settings(model_selector: str) -> None:
     write_json_file(PI_SETTINGS_PATH, merged)
 
 
+def _managed_model_families(state: dict) -> tuple[dict[str, str], list[str], list[str]] | None:
+    """Split a managed config's ``pi_models`` into the per-family inputs Pi's providers need.
+
+    Pi builds one provider block per family, so a flat list has to be classified back out. Returns
+    None when no managed models are set, leaving the workspace-wide discovery lists in play.
+    """
+    managed = state.get("pi_models")
+    if not isinstance(managed, list) or not managed:
+        return None
+    claude: dict[str, str] = {}
+    codex: list[str] = []
+    gemini: list[str] = []
+    for model in managed:
+        if not isinstance(model, str) or not model.strip():
+            continue
+        family = classify_model_family(model)
+        if family in ANTHROPIC_FAMILIES:
+            claude.setdefault(family, model)
+        elif family == "codex":
+            codex.append(model)
+        elif family == "gemini":
+            gemini.append(model)
+    return claude, codex, gemini
+
+
 def default_model(state: dict) -> str | None:
-    """Prefer Claude opus → sonnet → haiku; fall back to codex, gemini."""
+    """Prefer Claude opus → sonnet → haiku; fall back to codex, gemini.
+
+    A managed config's ``pi_default_model`` and ``pi_models`` both win outright: the former is
+    the admin's chosen session start, the latter their allowlist. Workspace-wide discovery falls back.
+    """
+    if isinstance(state.get("pi_default_model"), str):
+        return state.get("pi_default_model")
+    managed = state.get("pi_models")
+    if isinstance(managed, list) and managed:
+        return managed[0]
     claude_models = state.get("claude_models") or {}
     for family in ("opus", "sonnet", "haiku"):
         if claude_models.get(family):

--- a/src/ucode/agents/pi.py
+++ b/src/ucode/agents/pi.py
@@ -217,7 +217,8 @@ def _managed_model_families(state: dict) -> tuple[dict[str, str], list[str], lis
     """Split a managed config's ``pi_models`` into the per-family inputs Pi's providers need.
 
     Pi builds one provider block per family, so a flat list has to be classified back out. Returns
-    None when no managed models are set, leaving the workspace-wide discovery lists in play.
+    None when the managed models yield no family Pi can serve, leaving the workspace-wide discovery
+    lists in play rather than writing a config with no usable provider.
     """
     managed = state.get("pi_models")
     if not isinstance(managed, list) or not managed:
@@ -235,6 +236,8 @@ def _managed_model_families(state: dict) -> tuple[dict[str, str], list[str], lis
             codex.append(model)
         elif family == "gemini":
             gemini.append(model)
+    if not (claude or codex or gemini):
+        return None
     return claude, codex, gemini
 
 

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -58,12 +58,14 @@ from ucode.databricks import (
 from ucode.managed_config import (
     load_managed_state,
     managed_agent_config_enabled,
-    managed_launch_state,
+    refresh_managed_config,
 )
 from ucode.managed_resolve import (
     managed_default_model,
+    managed_enabled_tools,
     managed_provider_service,
     managed_supplies_models,
+    resolve_state,
 )
 from ucode.mcp import (
     MCP_CLIENTS,
@@ -1153,6 +1155,36 @@ _ROUTING_AGENTS = {"codex": codex_agent, "claude": claude_agent}
 _ROUTING_MODULES = {"codex": codex_routing, "claude": claude_routing}
 
 
+def _reject_disabled_agent(managed: dict | None, tool: str) -> None:
+    """Refuse to launch ``tool`` when the managed config enables other agents but not this one.
+
+    ``enabled_agents`` is an allowlist: launching an agent the admin didn't enable would run
+    unmanaged, with none of their models or provider applied. A config that names no agents at all
+    expresses no opinion, so it blocks nothing.
+    """
+    enabled = managed_enabled_tools(managed or {})
+    if enabled and tool not in enabled:
+        names = ", ".join(TOOL_SPECS[name]["display"] for name in enabled)
+        raise RuntimeError(
+            f"Your workspace's managed config doesn't enable {TOOL_SPECS[tool]['display']}. "
+            f"Enabled: {names}."
+        )
+
+
+def _fetch_managed_config(state: dict, *, skip_preflight: bool) -> dict | None:
+    """The workspace's managed config for this launch, or None when there is none.
+
+    ``skip_preflight`` mirrors the launch flag: it reads the last persisted copy instead of
+    re-fetching, so the config can be stale until a normal launch refreshes it.
+    """
+    if not managed_agent_config_enabled():
+        return None
+    if skip_preflight:
+        return load_managed_state(state.get("workspace")) or None
+    with spinner("Checking for a managed coding agent config..."):
+        return refresh_managed_config(state)
+
+
 def _launch_tool(
     tool_name: str,
     ctx: typer.Context,
@@ -1187,10 +1219,13 @@ def _launch_tool(
         # back to whatever `ucode configure` saved for this tool.
         provider = provider or get_provider_service(state, tool)
         routing_agent = _ROUTING_AGENTS.get(tool)
+        # Fetched before `configure_shared_state` because it decides whether this agent may launch
+        # at all and whether the model discovery below can be skipped.
+        managed = _fetch_managed_config(state, skip_preflight=skip_preflight)
+        # Checked before discovery, which can take tens of seconds, so a blocked launch fails fast.
+        _reject_disabled_agent(managed, tool)
         # Discovery exists to find models and isn't needed for managed config that already names them.
-        managed_models_known = managed_agent_config_enabled() and managed_supplies_models(
-            load_managed_state(state.get("workspace")), tool
-        )
+        managed_models_known = managed_supplies_models(managed, tool)
         # Re-fetch model lists on every launch so newly-added Databricks
         # endpoints show up without a manual `ucode configure` (and so that
         # tools like pi which read multiple model bundles never run on
@@ -1203,29 +1238,24 @@ def _launch_tool(
             skip_model_discovery=bool(provider) or managed_models_known,
             skip_preflight=skip_preflight,
         )
-        # An admin-published managed config wins over the developer's own settings. Resolved before
-        # the provider and model are settled below, so each is decided once against the values that
-        # will actually be written — the two state files are never merged on disk.
-        managed = None
-        if managed_agent_config_enabled():
-            # The spinner covers the read; the outcome is printed after it so the line survives
-            # (a spinner erases itself, leaving nothing to explain which settings won).
-            with spinner("Checking for a managed coding agent config..."):
-                state, managed = managed_launch_state(state, tool, skip_preflight=skip_preflight)
-            if managed is not None:
-                print_success("Applied your workspace's managed coding agent config")
-                # The enterprise scope outranks the --settings file ucode writes, so a model pinned
-                # there quietly beats the admin's — point at the file rather than let the mismatch
-                # look like a ucode bug.
-                if tool == "claude":
-                    overrides = claude_agent.managed_settings_model_overrides()
-                    if overrides is not None:
-                        print_warning(
-                            f"Default models are set in your enterprise managed settings at "
-                            f"{overrides}, which may override your admin's managed config."
-                        )
-            else:
-                print_note("No managed coding agent config found; using your own settings")
+        # An admin-published managed config wins over the developer's own settings. Layered on after
+        # `configure_shared_state`, whose returned state it overrides, and before the provider and
+        # model are settled below — the two state files are never merged on disk.
+        if managed is not None:
+            state = resolve_state(managed, state, tool)
+            print_success("Applied your workspace's managed coding agent config")
+            # The enterprise scope outranks the --settings file ucode writes, so a model pinned
+            # there quietly beats the admin's — point at the file rather than let the mismatch
+            # look like a ucode bug.
+            if tool == "claude":
+                overrides = claude_agent.managed_settings_model_overrides()
+                if overrides is not None:
+                    print_warning(
+                        f"Default models are set in your enterprise managed settings at "
+                        f"{overrides}, which may override your admin's managed config."
+                    )
+        elif managed_agent_config_enabled():
+            print_note("No managed coding agent config found; using your own settings")
         if managed is not None:
             managed_provider = managed_provider_service(managed, tool)
             if explicit_provider and managed_provider and managed_provider != explicit_provider:

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -65,6 +65,7 @@ from ucode.managed_resolve import (
     managed_enabled_tools,
     managed_provider_service,
     managed_supplies_models,
+    managed_unservable_models,
     resolve_state,
 )
 from ucode.mcp import (
@@ -1244,6 +1245,12 @@ def _launch_tool(
         if managed is not None:
             state = resolve_state(managed, state, tool)
             print_success("Applied your workspace's managed coding agent config")
+            unservable = managed_unservable_models(managed, tool)
+            if unservable:
+                print_warning(
+                    f"Your workspace's managed config lists no {TOOL_SPECS[tool]['display']}-servable "
+                    f"models ({', '.join(unservable)}); using your discovered models instead."
+                )
             # The enterprise scope outranks the --settings file ucode writes, so a model pinned
             # there quietly beats the admin's — point at the file rather than let the mismatch
             # look like a ucode bug.

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1204,6 +1204,27 @@ _OSS_MODEL_FAMILIES = ("kimi-", "glm-")
 # model-services listing and `databricks-claude-<family>-*` via the AI Gateway).
 ANTHROPIC_FAMILIES = ("fable", "opus", "sonnet", "haiku")
 
+
+def classify_model_family(model_id: str) -> str | None:
+    """Bucket a model FQN into the family ucode keys its state by, or None if unrecognized.
+
+    Mirrors how discovery buckets a model-services listing (see `discover_model_services`), so a
+    model named in a managed config lands in the same bucket it would have from discovery. Returns
+    one of ``ANTHROPIC_FAMILIES``, ``"codex"``, ``"gemini"``, or ``"oss"``. Matching is by name
+    substring because neither the listing nor the config records a model's API dialect.
+    """
+    for family in ANTHROPIC_FAMILIES:
+        if f"claude-{family}-" in model_id:
+            return family
+    if "gpt-" in model_id:
+        return "codex"
+    if "gemini-" in model_id:
+        return "gemini"
+    if any(oss in model_id for oss in _OSS_MODEL_FAMILIES):
+        return "oss"
+    return None
+
+
 # Per-family token limits (context window + max output tokens). These are a
 # property of the model + its `/ai-gateway/mlflow/v1` route (the gateway rejects
 # requests whose output exceeds the cap), not of any one agent — so every agent

--- a/src/ucode/managed_config.py
+++ b/src/ucode/managed_config.py
@@ -8,9 +8,11 @@ An org admin authors a ``CodingAgentConfig`` through the Databricks AI Gateway; 
 - persisting it to ``~/.ucode/managed-state.json`` (0600), and
 - re-reading it on each launch, falling back to the persisted copy when the read fails.
 
-:func:`managed_launch_state` is the launch path's entry point: it refreshes the manifest and hands
-back the state to configure the agent with. Deciding *which* value wins for a given key is
-:mod:`ucode.managed_resolve`'s job, kept separate so that logic stays pure and I/O-free.
+:func:`refresh_managed_config` is the launch path's entry point. It is called before model discovery,
+because the manifest decides whether that discovery is needed at all; the launch path then hands the
+manifest to :func:`ucode.managed_resolve.resolve_state` once the state it layers over is final.
+Deciding *which* value wins for a given key is :mod:`ucode.managed_resolve`'s job, kept separate so
+that logic stays pure and I/O-free.
 """
 
 from __future__ import annotations
@@ -22,7 +24,6 @@ from typing import cast
 
 import ucode.config_io as config_io
 from ucode.databricks import fetch_managed_coding_agent_configs, get_databricks_token
-from ucode.managed_resolve import resolve_state
 from ucode.ui import print_warning
 
 MANAGED_STATE_PATH = config_io.APP_DIR / "managed-state.json"
@@ -424,27 +425,3 @@ def managed_agent_config_enabled() -> bool:
     Opt-in while the feature is being bug-bashed: without the env var set, launches behave exactly
     as they did before and never read the workspace's config."""
     return os.environ.get(MANAGED_CONFIG_ENV_VAR, "").strip().lower() in ("1", "true", "yes")
-
-
-def managed_launch_state(
-    state: dict, tool: str, *, skip_preflight: bool = False
-) -> tuple[dict, dict | None]:
-    """Return ``(state, managed)`` for launching ``tool`` under any managed config.
-
-    The returned state has the manifest's models and provider layered over the developer's own —
-    managed wins per key — so the settings file written from it reflects the admin's choices. When
-    the workspace has no managed config the state is handed back untouched.
-
-    ``skip_preflight`` mirrors the launch flag: managed/headless launchers pass it to avoid
-    per-launch network calls, so the config is read from the last persisted copy instead of being
-    re-fetched (which means it can be arbitrarily stale until a normal launch refreshes it).
-    """
-    if not managed_agent_config_enabled():
-        return state, None
-    if skip_preflight:
-        managed = load_managed_state(state.get("workspace")) or None
-    else:
-        managed = refresh_managed_config(state)
-    if managed is None:
-        return state, None
-    return resolve_state(managed, state, tool), managed

--- a/src/ucode/managed_resolve.py
+++ b/src/ucode/managed_resolve.py
@@ -73,13 +73,42 @@ def managed_state_overrides(managed: dict, tool: str) -> dict[str, object]:
             overrides["claude_models"] = models
         elif tool == "opencode" and isinstance(models, list):
             # OpenCode selects `provider/model`, so its state is bucketed by provider rather than flat.
-            overrides["opencode_models"] = _bucket_by_provider(models)
+            # No override when nothing buckets: an empty dict would replace the developer's own
+            # models, leaving opencode with none at all.
+            buckets = _bucket_by_provider(models)
+            if buckets:
+                overrides["opencode_models"] = buckets
         else:
             overrides[f"{tool}_models"] = models
     default_model = _str(_agent_model_config(managed, tool).get("default_model"))
     if default_model:
         overrides[f"{tool}_default_model"] = default_model
     return overrides
+
+
+def managed_unservable_models(managed: dict, tool: str) -> list[str]:
+    """The models the manifest names for ``tool`` when it has no provider to serve any of them.
+
+    Only non-empty when *every* named model is unservable, which is when the translation yields
+    nothing and the developer's own models stand — so the caller can say why the admin's list had no
+    effect. opencode has no OpenAI provider and pi has no OSS provider, so each can be handed a
+    valid model FQN it cannot route.
+    """
+    if tool not in ("opencode", "pi"):
+        return []
+    models = _manifest_models(managed, tool)
+    if not isinstance(models, list):
+        return []
+    servable = (
+        _bucket_by_provider(models)
+        if tool == "opencode"
+        else [
+            m
+            for m in models
+            if classify_model_family(m) in (*ANTHROPIC_FAMILIES, "codex", "gemini")
+        ]
+    )
+    return [] if servable else models
 
 
 def _manifest_models(managed: dict, tool: str) -> dict | list | None:

--- a/src/ucode/managed_resolve.py
+++ b/src/ucode/managed_resolve.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from typing import cast
 
+from ucode.databricks import ANTHROPIC_FAMILIES, classify_model_family
 from ucode.state import MANAGED_OVERLAY_KEY
 
 # Proto model-config slot -> the family key `claude.py`'s render_overlay reads. The manifest keeps
@@ -57,37 +58,69 @@ def _agent_model_config(managed: dict, tool: str) -> dict[str, object]:
     return _as_dict(_agent_entry(managed, tool).get("model_config"))
 
 
-def effective_agent_models(managed: dict, state: dict, tool: str) -> dict | list | None:
-    """Resolve ``tool``'s model list/slots from the manifest, falling back to ucode state.
+def managed_state_overrides(managed: dict, tool: str) -> dict[str, object]:
+    """The state keys to layer over local state so ``tool``'s writer sees the admin's models.
 
-    Once the manifest says anything about ``tool``'s models it is the whole allowlist: the
-    developer's discovered models drop out entirely, so a launch can only reach models the admin
-    named. Each claude family resolves only to its own slot — a family the manifest leaves out stays
-    unset rather than inheriting ``default_model``, so ucode writes no
-    ``ANTHROPIC_DEFAULT_<FAMILY>_MODEL`` for it and the agent falls back to its own default. Omitting
-    a family is how an admin steers people off it, and filling it in with ``default_model`` would
-    quietly re-enable what they left out. Every other agent stores a flat list, which has no per-key
-    identity — there the manifest's list replaces the local one outright. Only when the manifest
-    names nothing for ``tool`` does the developer's own list stand.
+    Each agent reads its models from a different shape, so the manifest's list has to be translated
+    rather than dropped into one key: opencode wants provider-bucketed lists, and pi/copilot compose
+    from their own per-agent keys. Returns ``{state_key: value}`` — empty when the manifest names
+    nothing for ``tool``, in which case the developer's own state stands.
     """
-    model_config = _agent_model_config(managed, tool)
-    manifest_models = model_config.get("models")
+    overrides: dict[str, object] = {}
+    models = _manifest_models(managed, tool)
+    if models:
+        if tool == "claude":
+            overrides["claude_models"] = models
+        elif tool == "opencode" and isinstance(models, list):
+            # OpenCode selects `provider/model`, so its state is bucketed by provider rather than flat.
+            overrides["opencode_models"] = _bucket_by_provider(models)
+        else:
+            overrides[f"{tool}_models"] = models
+    default_model = _str(_agent_model_config(managed, tool).get("default_model"))
+    if default_model:
+        overrides[f"{tool}_default_model"] = default_model
+    return overrides
+
+
+def _manifest_models(managed: dict, tool: str) -> dict | list | None:
+    """The manifest's models for ``tool`` in its own vocabulary, or None when it names none."""
+    manifest_models = _agent_model_config(managed, tool).get("models")
     if tool == "claude":
         slots: dict[str, str] = {}
         for slot, family in _CLAUDE_FAMILY_SLOTS.items():
             model = _str(_as_dict(manifest_models).get(slot))
             if model:
                 slots[family] = model
-        if slots:
-            return slots
-        local = _as_dict(state.get("claude_models"))
-        return dict(local) if local else None
+        return slots or None
     if isinstance(manifest_models, list):
-        models = [m for m in (_str(item) for item in manifest_models) if m]
-        if models:
-            return models
-    local_list = state.get(f"{tool}_models")
-    return local_list if local_list else None
+        listed = [model for model in (_str(item) for item in manifest_models) if model]
+        return listed or None
+    return None
+
+
+def _bucket_by_provider(models: list[str]) -> dict[str, list[str]]:
+    """Group model FQNs into OpenCode's provider buckets, mirroring how discovery builds them.
+
+    Discovery derives these from the per-family lists (claude -> anthropic, and gemini/oss as-is), so
+    the same family classification recovers them from a flat manifest list. Models whose family
+    can't be identified are dropped.
+    """
+    buckets: dict[str, list[str]] = {}
+    for model in models:
+        family = classify_model_family(model)
+        if family in ANTHROPIC_FAMILIES:
+            buckets.setdefault("anthropic", []).append(model)
+        elif family in ("gemini", "oss"):
+            buckets.setdefault(family, []).append(model)
+    return buckets
+
+
+def managed_enabled_tools(managed: dict) -> list[str]:
+    """The tools the managed config enables, in the config's own order.
+
+    Every entry is an agent ucode recognizes: ``normalize_managed_config`` drops enum values this
+    build doesn't know, so an unrecognized agent never reaches here."""
+    return list(_as_dict(_as_dict(managed).get("enabled_agents")))
 
 
 def managed_supplies_models(managed: dict | None, tool: str) -> bool:
@@ -116,7 +149,7 @@ def managed_provider_service(managed: dict, tool: str) -> str | None:
 def managed_default_model(managed: dict, tool: str) -> str | None:
     """Return the model the managed config wants ``tool`` to launch on, if it names one.
 
-    Distinct from the family slots :func:`effective_agent_models` resolves: those set what each
+    Distinct from the family slots :func:`managed_state_overrides` resolves: those set what each
     family shortcut maps to, while this is the model the session actually starts on. The launch path
     pins it explicitly, so the admin's choice holds even for agents that would otherwise pick their
     own default."""
@@ -135,11 +168,10 @@ def resolve_state(managed: dict, state: dict, tool: str) -> dict:
     """
     resolved = dict(state)
     overlay: dict[str, object] = {}
-    models = effective_agent_models(managed, state, tool)
-    models_key = f"{tool}_models"
-    if models is not None and models != state.get(models_key):
-        overlay[models_key] = state.get(models_key)
-        resolved[models_key] = models
+    for key, value in managed_state_overrides(managed, tool).items():
+        if value != state.get(key):
+            overlay[key] = state.get(key)
+            resolved[key] = value
     provider = managed_provider_service(managed, tool)
     if provider:
         providers = dict(_as_dict(state.get("provider_services")))

--- a/tests/test_agent_codex.py
+++ b/tests/test_agent_codex.py
@@ -515,6 +515,13 @@ class TestCodexDefaultModel:
 
         assert codex.default_model({"codex_models": models}) == "served-models/databricks-gpt-5-5"
 
+    def test_codex_default_model_wins_over_allowlist(self):
+        state = {
+            "codex_default_model": "admin-chosen-default",
+            "codex_models": ["databricks-gpt-5-5"],
+        }
+        assert codex.default_model(state) == "admin-chosen-default"
+
     def test_openai_model_id_maps_databricks_naming(self):
         assert codex._openai_model_id("databricks-gpt-5-5") == "gpt-5.5"
         assert codex._openai_model_id("databricks-gpt-5-5-mini") == "gpt-5.5-mini"

--- a/tests/test_agent_copilot.py
+++ b/tests/test_agent_copilot.py
@@ -215,3 +215,22 @@ class TestValidateCmd:
         cmd = copilot.validate_cmd("copilot")
 
         assert cmd[:3] == ["copilot", "--additional-mcp-config", f"@{mcp_path}"]
+
+
+class TestManagedModels:
+    def test_managed_models_win_over_the_shared_discovery_lists(self):
+        state = {
+            "copilot_models": ["system.ai.gpt-5"],
+            "claude_models": {"sonnet": "shared-should-not-win"},
+        }
+        assert copilot.default_model(state) == "system.ai.gpt-5"
+
+    def test_falls_back_to_the_shared_lists_without_a_managed_config(self):
+        assert copilot.default_model({"claude_models": {"sonnet": "discovered"}}) == "discovered"
+
+    def test_copilot_default_model_wins_over_allowlist(self):
+        state = {
+            "copilot_default_model": "admin-chosen-default",
+            "copilot_models": ["system.ai.gpt-5"],
+        }
+        assert copilot.default_model(state) == "admin-chosen-default"

--- a/tests/test_agent_gemini.py
+++ b/tests/test_agent_gemini.py
@@ -120,6 +120,13 @@ class TestGeminiDefaultModel:
     def test_returns_none_when_missing(self):
         assert gemini.default_model({}) is None
 
+    def test_gemini_default_model_wins_over_allowlist(self):
+        state = {
+            "gemini_default_model": "admin-chosen-default",
+            "gemini_models": ["gemini-2"],
+        }
+        assert gemini.default_model(state) == "admin-chosen-default"
+
 
 class TestGeminiVersionGating:
     def test_too_new_version_flags_045(self, monkeypatch):

--- a/tests/test_agent_opencode.py
+++ b/tests/test_agent_opencode.py
@@ -328,6 +328,13 @@ class TestOpencodeDefaultModel:
         assert opencode.default_model({}) is None
         assert opencode.default_model({"opencode_models": {}}) is None
 
+    def test_opencode_default_model_wins_over_bucketed_models(self):
+        state = {
+            "opencode_default_model": "admin-chosen-default",
+            "opencode_models": {"anthropic": ["claude-sonnet"]},
+        }
+        assert opencode.default_model(state) == "admin-chosen-default"
+
 
 class TestOpencodeValidateCmd:
     def test_starts_with_binary(self):

--- a/tests/test_agent_pi.py
+++ b/tests/test_agent_pi.py
@@ -413,3 +413,50 @@ class TestValidateAllToolsPiRollback:
         agents_mod.validate_all_tools({"available_tools": ["pi"], "managed_configs": {"pi": True}})
 
         assert not settings_file.exists()
+
+
+class TestManagedModels:
+    """A managed config's models arrive as `pi_models` and must not come from the shared keys."""
+
+    def test_managed_models_win_over_the_shared_discovery_lists(self):
+        state = {
+            "pi_models": ["system.ai.claude-opus-4-8"],
+            "claude_models": {"opus": "shared-should-not-win"},
+        }
+        assert pi.default_model(state) == "system.ai.claude-opus-4-8"
+
+    def test_falls_back_to_the_shared_lists_without_a_managed_config(self):
+        assert pi.default_model({"claude_models": {"opus": "discovered"}}) == "discovered"
+
+    def test_managed_models_split_into_pis_per_provider_inputs(self):
+        # Pi builds one provider block per family, so a flat list has to be classified back out.
+        state = {
+            "pi_models": [
+                "system.ai.claude-opus-4-8",
+                "system.ai.gpt-5",
+                "system.ai.gemini-3-flash",
+            ]
+        }
+        assert pi._managed_model_families(state) == (
+            {"opus": "system.ai.claude-opus-4-8"},
+            ["system.ai.gpt-5"],
+            ["system.ai.gemini-3-flash"],
+        )
+
+    def test_no_split_without_managed_models(self):
+        assert pi._managed_model_families({"claude_models": {"opus": "x"}}) is None
+
+
+class TestManagedDefaultModel:
+    """A managed config's `pi_default_model` takes priority over the allowlist."""
+
+    def test_pi_default_model_wins_over_allowlist(self):
+        state = {
+            "pi_default_model": "admin-chosen-default",
+            "pi_models": ["system.ai.claude-opus-4-8", "system.ai.gpt-5"],
+        }
+        assert pi.default_model(state) == "admin-chosen-default"
+
+    def test_falls_back_to_pi_models_without_default(self):
+        state = {"pi_models": ["system.ai.claude-opus-4-8"]}
+        assert pi.default_model(state) == "system.ai.claude-opus-4-8"

--- a/tests/test_agent_pi.py
+++ b/tests/test_agent_pi.py
@@ -446,6 +446,17 @@ class TestManagedModels:
     def test_no_split_without_managed_models(self):
         assert pi._managed_model_families({"claude_models": {"opus": "x"}}) is None
 
+    def test_none_when_no_managed_model_is_servable(self):
+        # Pi has no OSS provider, so an oss-only list yields no families. Returning an all-empty
+        # tuple would be truthy and suppress the fallback, writing a config with zero providers.
+        assert pi._managed_model_families({"pi_models": ["system.ai.kimi-k2-7-code"]}) is None
+
+    def test_partially_servable_list_still_splits(self):
+        families = pi._managed_model_families(
+            {"pi_models": ["system.ai.kimi-k2-7-code", "system.ai.claude-opus-4-8"]}
+        )
+        assert families == ({"opus": "system.ai.claude-opus-4-8"}, [], [])
+
 
 class TestManagedDefaultModel:
     """A managed config's `pi_default_model` takes priority over the allowlist."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,10 +126,7 @@ def _patch_launch(tool: str):
             "ucode.cli.configure_tool",
             return_value=MINIMAL_STATE,
         ),
-        patch(
-            "ucode.cli.managed_launch_state",
-            side_effect=lambda state, tool: (state, None),
-        ),
+        patch("ucode.cli._fetch_managed_config", return_value=None),
         patch("ucode.cli.launch_agent"),
     ]
 
@@ -253,10 +250,7 @@ class TestSubcommandRouting:
                 return_value=(decision, None),
             ),
             patch("ucode.cli.configure_tool", return_value=state) as mock_configure,
-            patch(
-                "ucode.cli.managed_launch_state",
-                side_effect=lambda state, tool: (state, None),
-            ),
+            patch("ucode.cli._fetch_managed_config", return_value=None),
             patch("ucode.cli.launch_agent"),
         ):
             result = runner.invoke(app, ["codex"])
@@ -723,10 +717,7 @@ class TestAutoConfigureOnFirstRun:
                 return_value=(configured_state, "databricks-claude-sonnet-4"),
             ),
             patch("ucode.cli.configure_tool", return_value=configured_state),
-            patch(
-                "ucode.cli.managed_launch_state",
-                side_effect=lambda state, tool: (state, None),
-            ),
+            patch("ucode.cli._fetch_managed_config", return_value=None),
             patch("ucode.cli.launch_agent"),
         ):
             result = runner.invoke(app, ["claude"])
@@ -751,10 +742,7 @@ class TestAutoConfigureOnFirstRun:
                 return_value=(MINIMAL_STATE, "databricks-claude-sonnet-4"),
             ),
             patch("ucode.cli.configure_tool", return_value=MINIMAL_STATE),
-            patch(
-                "ucode.cli.managed_launch_state",
-                side_effect=lambda state, tool: (state, None),
-            ),
+            patch("ucode.cli._fetch_managed_config", return_value=None),
             patch("ucode.cli.launch_agent"),
         ):
             result = runner.invoke(app, ["claude"])
@@ -778,10 +766,7 @@ class TestAutoConfigureOnFirstRun:
                 return_value=(MINIMAL_STATE, "databricks-claude-sonnet-4"),
             ),
             patch("ucode.cli.configure_tool", return_value=MINIMAL_STATE),
-            patch(
-                "ucode.cli.managed_launch_state",
-                side_effect=lambda state, tool: (state, None),
-            ),
+            patch("ucode.cli._fetch_managed_config", return_value=None),
             patch("ucode.cli.launch_agent"),
         ):
             runner.invoke(app, ["claude"])
@@ -2078,10 +2063,7 @@ class TestSkipPreflightFlag:
                 return_value=(MINIMAL_STATE, "databricks-claude-sonnet-4"),
             ),
             patch("ucode.cli.configure_tool", return_value=MINIMAL_STATE),
-            patch(
-                "ucode.cli.managed_launch_state",
-                side_effect=lambda state, tool: (state, None),
-            ),
+            patch("ucode.cli._fetch_managed_config", return_value=None),
             patch("ucode.cli.launch_agent"),
         ]
 
@@ -2104,3 +2086,107 @@ class TestSkipPreflightFlag:
             result = runner.invoke(app, [tool])
         assert result.exit_code == 0, result.output
         assert cfg.call_args.kwargs["skip_preflight"] is False
+
+
+class TestRejectDisabledAgent:
+    """`enabled_agents` is an allowlist: an agent the admin didn't enable would launch unmanaged."""
+
+    @staticmethod
+    def _reject(managed, tool):
+        import ucode.cli as cli_mod
+
+        cli_mod._reject_disabled_agent(managed, tool)
+
+    def test_raises_naming_the_enabled_agents(self):
+        managed = {"enabled_agents": {"claude": {}, "opencode": {}}}
+        with pytest.raises(RuntimeError, match="doesn't enable Gemini CLI") as exc:
+            self._reject(managed, "gemini")
+        assert "Claude Code, OpenCode" in str(exc.value)
+
+    def test_allows_an_enabled_agent(self):
+        self._reject({"enabled_agents": {"claude": {}}}, "claude")
+
+    @pytest.mark.parametrize("managed", [None, {}, {"budget_policy": {}}])
+    def test_a_config_naming_no_agents_blocks_nothing(self, managed):
+        # No managed config, or one that only sets a budget policy, expresses no opinion on agents.
+        self._reject(managed, "gemini")
+
+
+class TestFetchManagedConfig:
+    """The launch path's managed-config read, which gates both the allowlist and model discovery."""
+
+    @staticmethod
+    def _fetch(state, *, skip_preflight=False):
+        import ucode.cli as cli_mod
+
+        return cli_mod._fetch_managed_config(state, skip_preflight=skip_preflight)
+
+    def test_fetches_fresh_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
+        monkeypatch.setattr(
+            "ucode.cli.refresh_managed_config", lambda state: {"enabled_agents": {}}
+        )
+        assert self._fetch({"workspace": "https://w"}) == {"enabled_agents": {}}
+
+    @pytest.mark.parametrize("env_value", [None, "", "0", "off", "no"])
+    def test_disabled_reads_nothing_at_all(self, monkeypatch, env_value):
+        """While the feature is opt-in, a disabled launch must not read the config or the network."""
+        if env_value is None:
+            monkeypatch.delenv("ENABLE_MANAGED_AGENT_CONFIG", raising=False)
+        else:
+            monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", env_value)
+        for name in ("refresh_managed_config", "load_managed_state"):
+            monkeypatch.setattr(
+                f"ucode.cli.{name}",
+                lambda *a, called=name, **k: pytest.fail(f"{called} must not run when disabled"),
+            )
+        assert self._fetch({"workspace": "https://w"}) is None
+
+    def test_skip_preflight_reads_the_cache_without_fetching(self, monkeypatch):
+        # Headless launchers pass --skip-preflight to avoid per-launch network calls.
+        monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
+        monkeypatch.setattr(
+            "ucode.cli.refresh_managed_config", lambda state: pytest.fail("should not fetch")
+        )
+        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: {"enabled_agents": {}})
+        assert self._fetch({"workspace": "https://w"}, skip_preflight=True) == {
+            "enabled_agents": {}
+        }
+
+    def test_skip_preflight_with_an_empty_cache_is_none(self, monkeypatch):
+        monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
+        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: {})
+        assert self._fetch({"workspace": "https://w"}, skip_preflight=True) is None
+
+
+class TestManagedConfigDecidesDiscoveryFromFreshRead:
+    def test_a_removed_model_list_no_longer_skips_discovery(self, monkeypatch):
+        """The sweep decision must come from the fetched config, not the cached one.
+
+        An admin who removes a previously published model list leaves a cache that still names
+        models. Deciding from that cache would skip discovery for a config that no longer supplies
+        models, so the launch would have neither.
+        """
+        monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
+        stale_cache = {
+            "enabled_agents": {"claude": {"model_config": {"models": {"default_opus_model": "m"}}}}
+        }
+        fresh = {"enabled_agents": {"claude": {"model_config": {}}}}
+        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: stale_cache)
+        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: fresh)
+
+        state = dict(MINIMAL_STATE)
+        with (
+            patch("ucode.cli.normalize_tool", return_value="claude"),
+            patch("ucode.cli.load_state", return_value=state),
+            patch("ucode.cli.apply_pat_environment"),
+            patch("ucode.cli.ensure_bootstrap_dependencies"),
+            patch("ucode.cli.ensure_provider_state", return_value=state),
+            patch("ucode.cli.configure_shared_state", return_value=state) as mock_shared,
+            patch("ucode.cli.configure_tool", return_value=state),
+            patch("ucode.cli.launch_agent"),
+        ):
+            result = runner.invoke(app, ["claude"])
+
+        assert result.exit_code == 0, result.output
+        assert mock_shared.call_args.kwargs["skip_model_discovery"] is False

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -23,6 +23,7 @@ from ucode.databricks import (
     build_shared_base_urls,
     build_skills_mcp_url,
     build_tool_base_url,
+    classify_model_family,
     ensure_databricks_cli_version,
     ensure_pat_bearer,
     get_databricks_token,
@@ -2070,3 +2071,25 @@ class TestInstallAiTools:
         install_ai_tools(["copilot"])
         assert len(warnings) == 1
         assert "copilot: cli-not-on-path: could not resolve copilot" in warnings[0]
+
+
+class TestClassifyModelFamily:
+    """Recovers the bucket a model would land in from discovery, so a managed config's flat list
+    can be translated into the per-family state each agent reads."""
+
+    @pytest.mark.parametrize(
+        ("model_id", "expected"),
+        [
+            ("system.ai.claude-opus-4-8", "opus"),
+            ("system.ai.claude-sonnet-5", "sonnet"),
+            ("databricks-claude-haiku-4-5", "haiku"),
+            ("system.ai.claude-fable-5", "fable"),
+            ("system.ai.gpt-5-3-codex", "codex"),
+            ("system.ai.gemini-3-flash", "gemini"),
+            ("system.ai.kimi-k2-7-code", "oss"),
+            ("system.ai.glm-4-6", "oss"),
+            ("something-unrecognized", None),
+        ],
+    )
+    def test_buckets_by_family(self, model_id, expected):
+        assert classify_model_family(model_id) == expected

--- a/tests/test_managed_config.py
+++ b/tests/test_managed_config.py
@@ -12,7 +12,6 @@ import ucode.managed_config as mc_mod
 from ucode.managed_config import (
     get_managed_config,
     load_managed_state,
-    managed_launch_state,
     normalize_managed_config,
     refresh_managed_config,
     save_managed_state,
@@ -393,87 +392,3 @@ class TestRefreshManagedConfig:
             mc_mod, "get_managed_config", lambda ws, tok: pytest.fail("should not fetch")
         )
         assert refresh_managed_config({}) is None
-
-
-class TestManagedLaunchState:
-    @pytest.fixture(autouse=True)
-    def _stub_token(self, monkeypatch):
-        monkeypatch.setattr(mc_mod, "get_databricks_token", lambda ws, profile: "tok")
-        monkeypatch.setattr(mc_mod, "save_managed_state", lambda ws, cfg: None)
-        monkeypatch.setenv(mc_mod.MANAGED_CONFIG_ENV_VAR, "1")
-
-    def test_layers_managed_models_when_a_config_exists(self, monkeypatch):
-        monkeypatch.setattr(mc_mod, "get_managed_config", lambda ws, tok: (MANAGED, None))
-        state = _state(claude_models={"opus": "local-opus"})
-        resolved, managed = managed_launch_state(state, "claude")
-        assert managed == MANAGED
-        assert resolved["claude_models"]["opus"] == "system.ai.claude-opus-5"
-        # The developer's own state is untouched — precedence is resolved in memory.
-        assert state["claude_models"]["opus"] == "local-opus"
-
-    def test_state_untouched_when_no_managed_config(self, monkeypatch):
-        monkeypatch.setattr(mc_mod, "get_managed_config", lambda ws, tok: (None, None))
-        state = _state(claude_models={"opus": "local-opus"})
-        resolved, managed = managed_launch_state(state, "claude")
-        assert managed is None
-        assert resolved is state
-
-    @pytest.mark.parametrize("env_value", [None, "", "0", "off", "no"])
-    def test_disabled_does_nothing_at_all(self, monkeypatch, env_value):
-        """While the feature is opt-in, a disabled launch must behave exactly as it did before.
-
-        Every side effect the managed path can have is trip-wired, so this fails if any future
-        change reaches the network, the cache, or the developer's state without the env var set.
-        """
-        if env_value is None:
-            monkeypatch.delenv(mc_mod.MANAGED_CONFIG_ENV_VAR, raising=False)
-        else:
-            monkeypatch.setenv(mc_mod.MANAGED_CONFIG_ENV_VAR, env_value)
-        for name in (
-            "get_databricks_token",
-            "fetch_managed_coding_agent_configs",
-            "get_managed_config",
-            "load_managed_state",
-            "save_managed_state",
-            "resolve_state",
-            "print_warning",
-        ):
-            monkeypatch.setattr(
-                mc_mod,
-                name,
-                lambda *a, called=name, **k: pytest.fail(f"{called} must not run when disabled"),
-            )
-
-        assert mc_mod.managed_agent_config_enabled() is False
-        state = _state(claude_models={"opus": "local-opus"})
-        resolved, managed = managed_launch_state(state, "claude")
-        assert managed is None
-        # Same object back, so nothing downstream can see a layered value.
-        assert resolved is state
-        assert state["claude_models"] == {"opus": "local-opus"}
-
-    @pytest.mark.parametrize("env_value", ["1", "true", "TRUE", "yes"])
-    def test_enabled_values(self, monkeypatch, env_value):
-        monkeypatch.setenv(mc_mod.MANAGED_CONFIG_ENV_VAR, env_value)
-        assert mc_mod.managed_agent_config_enabled() is True
-
-    def test_skip_preflight_reads_the_cache_without_fetching(self, monkeypatch):
-        # Headless launchers pass --skip-preflight to avoid per-launch network calls, so the config
-        # comes from the last persisted copy rather than a fresh read.
-        monkeypatch.setattr(
-            mc_mod, "get_managed_config", lambda ws, tok: pytest.fail("should not fetch")
-        )
-        monkeypatch.setattr(mc_mod, "load_managed_state", lambda ws: MANAGED)
-        resolved, managed = managed_launch_state(_state(), "claude", skip_preflight=True)
-        assert managed == MANAGED
-        assert resolved["claude_models"]["opus"] == "system.ai.claude-opus-5"
-
-    def test_skip_preflight_with_no_cache_is_a_noop(self, monkeypatch):
-        monkeypatch.setattr(
-            mc_mod, "get_managed_config", lambda ws, tok: pytest.fail("should not fetch")
-        )
-        monkeypatch.setattr(mc_mod, "load_managed_state", lambda ws: None)
-        state = _state()
-        resolved, managed = managed_launch_state(state, "claude", skip_preflight=True)
-        assert managed is None
-        assert resolved is state

--- a/tests/test_managed_resolve.py
+++ b/tests/test_managed_resolve.py
@@ -16,6 +16,7 @@ from ucode.managed_resolve import (
     managed_provider_service,
     managed_state_overrides,
     managed_supplies_models,
+    managed_unservable_models,
     resolve_state,
 )
 from ucode.state import MANAGED_OVERLAY_KEY
@@ -435,9 +436,29 @@ class TestManagedStateOverrides:
 
     def test_unclassifiable_models_are_dropped_from_buckets(self):
         # A model whose family can't be identified has no provider to route through, so guessing a
-        # bucket would produce a selector OpenCode can't resolve.
+        # bucket would produce a selector OpenCode can't resolve. It is dropped, but the models that
+        # do classify still apply.
+        managed = {
+            "enabled_agents": {
+                "opencode": {
+                    "model_config": {"models": ["mystery-model", "system.ai.claude-opus-4-8"]}
+                }
+            }
+        }
+        assert managed_state_overrides(managed, "opencode") == {
+            "opencode_models": {"anthropic": ["system.ai.claude-opus-4-8"]}
+        }
+
+    def test_no_override_when_nothing_is_servable(self):
+        # An all-unservable list must not replace the developer's buckets with an empty dict —
+        # that would leave OpenCode with no models at all.
         managed = {"enabled_agents": {"opencode": {"model_config": {"models": ["mystery-model"]}}}}
-        assert managed_state_overrides(managed, "opencode") == {"opencode_models": {}}
+        state = _state(opencode_models={"anthropic": ["local-opus"]})
+        assert managed_state_overrides(managed, "opencode") == {}
+        assert resolve_state(managed, state, "opencode")["opencode_models"] == {
+            "anthropic": ["local-opus"]
+        }
+        assert managed_unservable_models(managed, "opencode") == ["mystery-model"]
 
 
 class TestManagedDefaultModelStateOverrides:
@@ -481,3 +502,35 @@ class TestManagedEnabledTools:
     def test_empty_when_the_config_names_no_agents(self):
         # Callers treat this as "no opinion", so a budget-only config blocks nothing.
         assert managed_enabled_tools({"budget_policy": {}}) == []
+
+
+class TestManagedUnservableModels:
+    """Warn when the admin's list names only models the agent has no provider for."""
+
+    @staticmethod
+    def _managed(tool, models):
+        return {"enabled_agents": {tool: {"model_config": {"models": models}}}}
+
+    def test_pi_oss_only_is_unservable(self):
+        # Pi has no OSS provider block.
+        assert managed_unservable_models(
+            self._managed("pi", ["system.ai.kimi-k2-7-code"]), "pi"
+        ) == ["system.ai.kimi-k2-7-code"]
+
+    def test_opencode_gpt_only_is_unservable(self):
+        # OpenCode has no OpenAI provider block.
+        managed = self._managed("opencode", ["system.ai.gpt-5"])
+        assert managed_unservable_models(managed, "opencode") == ["system.ai.gpt-5"]
+
+    @pytest.mark.parametrize(
+        ("tool", "models"),
+        [
+            ("pi", ["system.ai.kimi-k2-7-code", "system.ai.claude-opus-4-8"]),
+            ("opencode", ["system.ai.gpt-5", "system.ai.claude-opus-4-8"]),
+        ],
+    )
+    def test_no_warning_when_anything_is_servable(self, tool, models):
+        assert managed_unservable_models(self._managed(tool, models), tool) == []
+
+    def test_agents_that_pass_models_through_never_warn(self):
+        assert managed_unservable_models(self._managed("codex", ["anything"]), "codex") == []

--- a/tests/test_managed_resolve.py
+++ b/tests/test_managed_resolve.py
@@ -7,12 +7,14 @@ import json
 import pytest
 
 import ucode.agents.claude as claude
+import ucode.agents.opencode as opencode
 import ucode.config_io as config_io
 import ucode.state as state_mod
 from ucode.managed_resolve import (
-    effective_agent_models,
     managed_default_model,
+    managed_enabled_tools,
     managed_provider_service,
+    managed_state_overrides,
     managed_supplies_models,
     resolve_state,
 )
@@ -60,17 +62,19 @@ class TestClaudeModels:
     def test_proto_slots_map_to_families(self):
         # The manifest keeps proto spelling (`default_opus_model`); render_overlay reads `opus`.
         # `fable` has no slot here, so it stays unset rather than inheriting `default_model`.
-        models = effective_agent_models(MANAGED, _state(), "claude")
-        assert models == {
-            "opus": "system.ai.claude-opus-5",
-            "sonnet": "system.ai.claude-sonnet-4-6",
-            "haiku": "system.ai.claude-haiku-4-5",
+        assert managed_state_overrides(MANAGED, "claude") == {
+            "claude_models": {
+                "opus": "system.ai.claude-opus-5",
+                "sonnet": "system.ai.claude-sonnet-4-6",
+                "haiku": "system.ai.claude-haiku-4-5",
+            },
+            "claude_default_model": "system.ai.claude-opus-5",
         }
 
     def test_manifest_wins_over_local_per_family(self):
         state = _state(claude_models={"opus": "system.ai.claude-opus-4-8"})
-        models = effective_agent_models(MANAGED, state, "claude")
-        assert models["opus"] == "system.ai.claude-opus-5"
+        resolved = resolve_state(MANAGED, state, "claude")
+        assert resolved["claude_models"]["opus"] == "system.ai.claude-opus-5"
 
     def test_family_absent_from_manifest_is_dropped(self):
         # The manifest is the whole allowlist: a family the admin didn't pin is left unset rather
@@ -82,7 +86,7 @@ class TestClaudeModels:
             }
         }
         state = _state(claude_models={"opus": "local-opus", "fable": "local-fable"})
-        assert effective_agent_models(managed, state, "claude") == {"opus": "managed-opus"}
+        assert resolve_state(managed, state, "claude")["claude_models"] == {"opus": "managed-opus"}
 
     def test_unset_families_do_not_inherit_the_default_model(self):
         # An admin who names only opus is steering people off the other families, so filling them in
@@ -98,32 +102,30 @@ class TestClaudeModels:
             }
         }
         state = _state(claude_models={"sonnet": "local-sonnet"})
-        assert effective_agent_models(managed, state, "claude") == {"opus": "managed-opus"}
+        assert resolve_state(managed, state, "claude")["claude_models"] == {"opus": "managed-opus"}
 
-    def test_no_manifest_models_falls_back_to_local(self):
+    def test_no_manifest_models_leaves_local_state_alone(self):
+        # No override means resolve_state never touches the key, so the developer's own models stand.
         state = _state(claude_models={"sonnet": "local-sonnet"})
-        assert effective_agent_models({}, state, "claude") == {"sonnet": "local-sonnet"}
-
-    def test_none_when_neither_side_has_models(self):
-        assert effective_agent_models({}, _state(), "claude") is None
+        assert resolve_state({}, state, "claude")["claude_models"] == {"sonnet": "local-sonnet"}
 
 
 class TestListModels:
     def test_manifest_list_replaces_local(self):
         # A flat list has no per-key identity to merge on, so the manifest's list wins outright.
         state = _state(codex_models=["local-codex"])
-        assert effective_agent_models(MANAGED, state, "codex") == [
+        assert resolve_state(MANAGED, state, "codex")["codex_models"] == [
             "databricks-gpt-5-3-codex",
             "databricks-gpt-5-2-codex",
         ]
 
     def test_local_list_stands_when_manifest_silent(self):
         state = _state(codex_models=["local-codex"])
-        assert effective_agent_models({}, state, "codex") == ["local-codex"]
+        assert resolve_state({}, state, "codex")["codex_models"] == ["local-codex"]
 
     def test_blank_entries_dropped(self):
         managed = {"enabled_agents": {"codex": {"model_config": {"models": ["  ", "real", ""]}}}}
-        assert effective_agent_models(managed, _state(), "codex") == ["real"]
+        assert managed_state_overrides(managed, "codex") == {"codex_models": ["real"]}
 
 
 class TestManagedProviderService:
@@ -377,3 +379,105 @@ class TestManagedSuppliesModels:
             }
         }
         assert managed_supplies_models(managed, "claude") is False
+
+
+class TestManagedStateOverrides:
+    """Each agent reads its models from a different shape, so the manifest has to be translated."""
+
+    def test_opencode_gets_provider_buckets_not_a_flat_list(self):
+        # OpenCode's state is `{provider: [models]}` and its writer calls `.get()` on it, so handing
+        # it the manifest's flat list raises AttributeError.
+        managed = {
+            "enabled_agents": {
+                "opencode": {
+                    "model_config": {
+                        "models": [
+                            "system.ai.claude-opus-4-8",
+                            "system.ai.gemini-3-flash",
+                            "system.ai.kimi-k2-7-code",
+                        ]
+                    }
+                }
+            }
+        }
+        assert managed_state_overrides(managed, "opencode") == {
+            "opencode_models": {
+                "anthropic": ["system.ai.claude-opus-4-8"],
+                "gemini": ["system.ai.gemini-3-flash"],
+                "oss": ["system.ai.kimi-k2-7-code"],
+            }
+        }
+
+    def test_opencode_buckets_are_usable_by_its_own_writer(self):
+        managed = {
+            "enabled_agents": {
+                "opencode": {"model_config": {"models": ["system.ai.claude-opus-4-8"]}}
+            }
+        }
+        buckets = managed_state_overrides(managed, "opencode")["opencode_models"]
+        assert opencode._resolve_model_selector("system.ai.claude-opus-4-8", buckets) == (
+            "databricks-anthropic/system.ai.claude-opus-4-8"
+        )
+
+    @pytest.mark.parametrize("tool", ["pi", "copilot"])
+    def test_pi_and_copilot_get_their_own_key(self, tool):
+        # They compose from claude_models/codex_models/gemini_models, which claude, codex, and gemini
+        # also read — writing a per-agent policy there would let one agent's config change another's.
+        managed = {
+            "enabled_agents": {tool: {"model_config": {"models": ["system.ai.claude-opus-4-8"]}}}
+        }
+        assert managed_state_overrides(managed, tool) == {
+            f"{tool}_models": ["system.ai.claude-opus-4-8"]
+        }
+
+    def test_no_overrides_when_the_manifest_names_no_models(self):
+        assert managed_state_overrides({}, "claude") == {}
+
+    def test_unclassifiable_models_are_dropped_from_buckets(self):
+        # A model whose family can't be identified has no provider to route through, so guessing a
+        # bucket would produce a selector OpenCode can't resolve.
+        managed = {"enabled_agents": {"opencode": {"model_config": {"models": ["mystery-model"]}}}}
+        assert managed_state_overrides(managed, "opencode") == {"opencode_models": {}}
+
+
+class TestManagedDefaultModelStateOverrides:
+    """The managed default_model should be layered into state for each agent."""
+
+    @pytest.mark.parametrize("tool", ["pi", "copilot", "gemini", "opencode", "codex"])
+    def test_emits_a_per_agent_default_model_key(self, tool):
+        managed = {"enabled_agents": {tool: {"model_config": {"default_model": "admin-default"}}}}
+        assert managed_state_overrides(managed, tool) == {f"{tool}_default_model": "admin-default"}
+
+    def test_emits_default_model_alongside_the_allowlist(self):
+        managed = {
+            "enabled_agents": {
+                "pi": {
+                    "model_config": {
+                        "default_model": "admin-default",
+                        "models": ["model-a", "model-b"],
+                    }
+                }
+            }
+        }
+        assert managed_state_overrides(managed, "pi") == {
+            "pi_default_model": "admin-default",
+            "pi_models": ["model-a", "model-b"],
+        }
+
+    def test_codex_only_default_model_no_models_field(self):
+        # CodexModelConfig has no `models` field, so only default_model can be set.
+        managed = {"enabled_agents": {"codex": {"model_config": {"default_model": "admin-codex"}}}}
+        state = _state()
+        resolved = resolve_state(managed, state, "codex")
+        assert resolved.get("codex_default_model") == "admin-codex"
+        assert resolved.get("codex_models") is None
+
+
+class TestManagedEnabledTools:
+    def test_lists_the_configs_agents(self):
+        managed = {"enabled_agents": {"claude": {}, "opencode": {}}}
+        assert managed_enabled_tools(managed) == ["claude", "opencode"]
+
+    def test_empty_when_the_config_names_no_agents(self):
+        # Callers treat this as "no opinion", so a budget-only config blocks nothing.
+        assert managed_enabled_tools({"budget_policy": {}}) == []


### PR DESCRIPTION
### Changes
Makes an admin-published managed coding-agent config work for every agent, not just Claude Code, and fixes three bugs found while testing it. All behavior stays behind `ENABLE_MANAGED_AGENT_CONFIG`; with it unset the launch path is unchanged.

1. **Per-agent model shapes.** `managed_state_overrides` translates the manifest's model list into the shape each agent reads: provider-bucketed for opencode, per-agent keys for pi and copilot. Previously every non-claude agent got a flat list, which crashed opencode and was silently ignored by pi and copilot.
2. **pi and copilot get their own state keys** (`pi_models`, `copilot_models`) instead of writing the shared `claude_models`/`codex_models`/`gemini_models`. Those are workspace-wide discovery that claude, codex, and gemini also read, so one agent's managed policy could change what another launched.
3. **The admin's `default_model` now survives the whole session.** Non-claude agents applied it once at launch and then immediately overwrote it: pi/copilot's `launch()` and the 30-minute token refresh re-derive the model from state, which never held it, so they fell back to the allowlist's first entry. `resolve_state` now overlays `<tool>_default_model` and each agent prefers it. Claude was already correct – it pins the model as `ANTHROPIC_MODEL` and never re-derives. Family slots are unaffected: an unset family stays unset rather than inheriting `default_model`.
4. **Blocking error for agents the admin didn't enable.** `enabled_agents` is an allowlist; launching outside it ran fully unmanaged. Checked before model discovery so a rejected launch fails fast instead of after a ~19s sweep.
5. **Model discovery is skipped when the managed config already names models,** removing that sweep from most managed launches.
6. **The managed config is fetched before discovery instead of read from cache.** The allowlist check and the skip-discovery decision are now made from the authoritative config; previously a stale local copy could suppress discovery for a config that no longer named models. `--skip-preflight` still reads the cache by design. This replaces `managed_launch_state` with a fetch plus a separate `resolve_state`, since the manifest has to be layered over post-discovery state.
7. **`classify_model_family`** extracted so a model named in a config buckets exactly as discovery would.


### Test Plan
- uv run pytest --> 1257 passed, 36 skipped
- ruff check + ruff format clean
- added new unit tests all passing

https://github.com/user-attachments/assets/10fea9a2-cc44-4b0f-986b-1426ed8f7361
