### PR TITLE
Fix missing httpx dependency for MCP proxy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
   "databricks-sql-connector>=3.6.0",
+  "httpx>=0.27.1",
   # `ucode mcp-proxy` bridges a client's stdio MCP transport to a Databricks
   # streamable-HTTP MCP endpoint, injecting a freshly-minted OAuth bearer per
   # request. Uses the official MCP SDK's stdio server + streamable-HTTP client.

--- a/tests/test_mcp_proxy.py
+++ b/tests/test_mcp_proxy.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import tomllib
+from pathlib import Path
+
 import anyio
 import httpx
 import pytest
@@ -10,6 +13,13 @@ from ucode import mcp_proxy
 
 WS = "https://example.databricks.com"
 URL = f"{WS}/api/2.0/mcp/functions/system/ai"
+
+
+def test_httpx_is_a_direct_runtime_dependency():
+    project = tomllib.loads((Path(__file__).parent.parent / "pyproject.toml").read_text())[
+        "project"
+    ]
+    assert any(dependency.startswith("httpx") for dependency in project["dependencies"])
 
 
 class TestDatabricksTokenAuth:

--- a/uv.lock
+++ b/uv.lock
@@ -3159,6 +3159,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "databricks-sql-connector" },
+    { name = "httpx" },
     { name = "mcp" },
     { name = "questionary" },
     { name = "tomlkit" },
@@ -3180,6 +3181,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "databricks-sql-connector", specifier = ">=3.6.0" },
+    { name = "httpx", specifier = ">=0.27.1" },
     { name = "mcp", specifier = ">=1.28.0" },
     { name = "mlflow", extras = ["databricks"], marker = "extra == 'tracing'", specifier = ">=3.4" },
     { name = "questionary", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary
- declare `httpx` as a direct runtime dependency because `ucode.mcp_proxy` imports it
- update the lockfile metadata
- add a regression check for the packaged dependency

## Testing
- `uv run pytest tests/test_mcp_proxy.py`
- `uv run ruff check .`