### PR TITLE
setup: reject budget tiers that repeat an agent/model pair

### DIFF
--- a/src/ucode/managed_setup.py
+++ b/src/ucode/managed_setup.py
@@ -547,6 +547,7 @@ def _validate_budget_policy(budget_policy: dict, enabled_agents: dict[str, dict]
             )
 
     percentages: list[float] = []
+    combos: list[tuple[str, str]] = []
     tiers = budget_policy.get("tiers")
     for index, tier in enumerate(tiers if isinstance(tiers, list) else []):
         if not isinstance(tier, dict):
@@ -584,9 +585,19 @@ def _validate_budget_policy(budget_policy: dict, enabled_agents: dict[str, dict]
                 )
         if not tier_model:
             errors.append(f"budget_policy.tiers[{index}]: default_model is required.")
+        if tier_agent and tier_model:
+            combos.append((str(tier_agent), str(tier_model)))
 
     if len(set(percentages)) != len(percentages):
         errors.append("budget_policy tier spending_percentage values must be unique.")
+    # Two tiers with the same agent+model are a no-op: the server picks the highest crossed tier, so
+    # the second never changes what the lower one already selected. Flagging it catches a tier the
+    # admin meant to be a real step-down but left unchanged.
+    if len(set(combos)) != len(combos):
+        errors.append(
+            "budget_policy tiers must each route to a different agent/model — two tiers with the "
+            "same pair make the higher one a no-op."
+        )
     return errors
 
 

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -546,6 +546,7 @@ def _prompt_budget_policy(
 
     tiers: list[dict] = []
     seen_percentages: set[float] = set()
+    seen_combos: set[tuple[str, str]] = set()
     print_note(
         "Add one tier per step-down. Each tier activates once spend reaches its percentage, and "
         "the highest activated tier wins."
@@ -575,7 +576,17 @@ def _prompt_budget_policy(
             model = prompt_for_text(f"Tier {index}: which model?")
         if not model:
             break
+        if (agent, model) in seen_combos:
+            # The highest crossed tier wins, so a second tier on the same agent+model never changes
+            # what the lower one already selected — it is a step-down that doesn't step down. Reject
+            # it here rather than let the admin build a policy with a silently inert tier.
+            print_err(
+                f"{TOOL_SPECS[agent]['display']} / {model} is already used by another tier; a "
+                "repeated agent/model makes this tier a no-op. Pick a different one."
+            )
+            continue
         seen_percentages.add(fraction)
+        seen_combos.add((agent, model))
         tiers.append(
             {
                 "spending_percentage": fraction,

--- a/tests/test_managed_setup.py
+++ b/tests/test_managed_setup.py
@@ -676,6 +676,65 @@ class TestValidate:
         errors = validate_manifest(manifest, STATE)
         assert any("must be unique" in e for e in errors)
 
+    def test_tier_agent_model_pairs_must_differ(self):
+        # Distinct percentages, same agent+model: the higher tier is a no-op, because the server
+        # picks the highest crossed tier and it selects the same pair the lower one already did.
+        manifest = {
+            **_minimal_manifest(),
+            "budget_policy": {
+                "budget_id": BUDGET_ID,
+                "tiers": [
+                    {
+                        "spending_percentage": 0.5,
+                        "default_agent": "claude",
+                        "default_model": "system.ai.claude-opus-4-8",
+                    },
+                    {
+                        "spending_percentage": 0.9,
+                        "default_agent": "claude",
+                        "default_model": "system.ai.claude-opus-4-8",
+                    },
+                ],
+            },
+        }
+        errors = validate_manifest(manifest, STATE)
+        assert any("no-op" in e for e in errors), errors
+
+    def test_same_agent_different_model_across_tiers_is_allowed(self):
+        # A real step-down: same agent, cheaper model. Must not be flagged as a duplicate. Both
+        # models are configured on the agent, so the tier-model check passes and only the
+        # duplicate-combo rule is under test.
+        manifest = {
+            "default_agent": "claude",
+            "enabled_agents": {
+                "claude": {
+                    "model_config": {
+                        "default_model": "system.ai.claude-opus-4-8",
+                        "models": {
+                            "default_opus_model": "system.ai.claude-opus-4-8",
+                            "default_sonnet_model": "system.ai.claude-sonnet-4-6",
+                        },
+                    }
+                }
+            },
+            "budget_policy": {
+                "budget_id": BUDGET_ID,
+                "tiers": [
+                    {
+                        "spending_percentage": 0.5,
+                        "default_agent": "claude",
+                        "default_model": "system.ai.claude-opus-4-8",
+                    },
+                    {
+                        "spending_percentage": 0.9,
+                        "default_agent": "claude",
+                        "default_model": "system.ai.claude-sonnet-4-6",
+                    },
+                ],
+            },
+        }
+        assert validate_manifest(manifest, STATE) == []
+
     def test_tier_agent_must_be_enabled(self):
         manifest = {
             **_minimal_manifest(),

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -1171,7 +1171,10 @@ class TestBudgetPolicy:
                 }
             }
         }
-        budgets = [{"id": BUDGET_ID, "display_name": "eng"}]
+        # `has_per_user_alert` is required since the budget-threshold gate landed on main: spend
+        # routing needs a per-user threshold, so a budget without one is filtered out and the policy
+        # flow returns before the tier loop this test exercises.
+        budgets = [{"id": BUDGET_ID, "display_name": "eng", "has_per_user_alert": True}]
         with (
             patch.object(wizard, "prompt_yes_no_default", side_effect=[True, True, False]),
             patch.object(wizard, "list_workspace_budgets", return_value=(budgets, None)),

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -1085,6 +1085,51 @@ class TestBudgetPolicy:
         }
         assert validate_manifest(manifest, STATE) == []
 
+    def test_a_repeated_agent_model_pair_is_rejected_and_re_prompted(self):
+        # The highest crossed tier wins, so a second tier on the same agent+model is inert. The loop
+        # must reject the repeat and re-prompt, the way it already does for a repeated percentage.
+        two_models = {
+            "claude": {
+                "model_config": {
+                    "default_model": "system.ai.claude-opus-4-8",
+                    "models": {
+                        "default_opus_model": "system.ai.claude-opus-4-8",
+                        "default_sonnet_model": "system.ai.claude-sonnet-4-6",
+                    },
+                }
+            }
+        }
+        budgets = [{"id": BUDGET_ID, "display_name": "eng"}]
+        with (
+            patch.object(wizard, "prompt_yes_no_default", side_effect=[True, True, False]),
+            patch.object(wizard, "list_workspace_budgets", return_value=(budgets, None)),
+            patch.object(
+                wizard,
+                "prompt_for_selection",
+                side_effect=[
+                    BUDGET_ID,
+                    # Tier 1: claude / opus.
+                    "claude",
+                    "system.ai.claude-opus-4-8",
+                    # Tier 2 first attempt: claude / opus again — rejected, so the loop re-asks.
+                    "claude",
+                    "system.ai.claude-opus-4-8",
+                    # Tier 2 retry: a genuine step-down.
+                    "claude",
+                    "system.ai.claude-sonnet-4-6",
+                ],
+            ),
+            patch.object(wizard, "prompt_for_text", return_value="tiered"),
+            patch.object(wizard, "prompt_for_percentage", side_effect=[0.5, 0.9, 0.9]),
+            patch.object(wizard, "print_err") as err,
+        ):
+            policy = wizard._prompt_budget_policy(WORKSPACE, "token", two_models, STATE)
+        assert [(t["default_agent"], t["default_model"]) for t in policy["tiers"]] == [
+            ("claude", "system.ai.claude-opus-4-8"),
+            ("claude", "system.ai.claude-sonnet-4-6"),
+        ]
+        assert any("no-op" in call.args[0] for call in err.call_args_list)
+
 
 class TestConfiguredModelsForAgent:
     def test_flat_list_plus_default(self):


### PR DESCRIPTION
`ucode setup`'s budget section, and `validate_manifest`, both guard against duplicate tier *percentages* — but neither noticed two tiers routing to the same *agent+model*. That pair is a no-op: the server picks the highest crossed tier, so a second tier on the same agent+model never changes what the lower one already selected. It reads as a step-down that doesn't step down.

## Fix

Guarded at both layers, matching the existing percentage checks:
- The wizard's tier loop rejects a repeated `(agent, model)` and re-prompts.
- `validate_manifest` flags it, so a hand-edited or `--from-file` manifest is caught too.

Same agent with a **different** model stays allowed — that's a real step-down (Opus → Sonnet) — so the rule keys on the `(agent, model)` pair, not the agent alone.

## Tests

+4, mutation-verified: dropping either guard fails its test, and a same-agent-different-model case pins that the rule doesn't over-reject.

This pull request and its description were written by Isaac.