### PR TITLE
setup: drop the tracing prompt while managed tracing is broken

### DIFF
--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -876,20 +876,10 @@ def setup_command(from_file: str | None = None) -> int:
 
     manifest: dict = {"default_agent": default_agent, "enabled_agents": enabled_agents}
 
-    print_section("Tracing")
-    if prompt_yes_no_default(
-        "Send coding-session traces to an MLflow experiment in this workspace?",
-        default=bool(_tracing_table_from_state(state)),
-    ):
-        from ucode.tracing import configure_tracing_command
-
-        configure_tracing_command(workspaces=[(workspace, profile)])
-        tracing_table = _tracing_table_from_state(load_state())
-        if tracing_table:
-            manifest["tracing_table"] = tracing_table
-            print_success(f"Tracing configured ({tracing_table})")
-        else:
-            print_warning("Tracing was not enabled, so it is left out of the managed config.")
+    # Tracing is intentionally not prompted here: the managed-tracing path isn't working yet, so
+    # asking would author a `tracing_table` the workspace can't honor. The manifest field and its
+    # serialize/validate support stay in place, so a hand-written `--from-file` config can still set
+    # it once the backend is ready. Re-add the section below when it is.
 
     print_section("MCP servers")
     if prompt_yes_no_default("Set up managed MCP servers for this workspace?", default=False):


### PR DESCRIPTION
Managed tracing doesn't work end to end yet, so `ucode setup` asking "send coding-session traces to an MLflow experiment?" only authored a `tracing_table` the workspace can't honor. The prompt is removed; the flow now goes straight from per-agent models to MCP servers.

## Scope

Prompt-only removal, not a rip-out — since managed tracing is temporarily broken, not going away:

- **Removed:** the interactive Tracing section (`prompt_yes_no_default` + `configure_tracing_command`).
- **Kept:** the `tracing_table` manifest field, its serialize/validate support, `_tracing_table_from_state`, and the summary's Tracing row (reads the manifest, so it shows "disabled" for wizard-authored configs and the real table if a `--from-file` config sets one).

So a hand-written manifest can still carry tracing, and re-adding the prompt when the backend is ready is a localized change. A comment at the removal site says exactly that.

Full test suite passes; no test depended on the prompt sequence.

This pull request and its description were written by Isaac.