### PR TITLE
ui: show a scroll hint when a picker list is too long to fit

### DIFF
--- a/src/ucode/ui.py
+++ b/src/ucode/ui.py
@@ -21,6 +21,23 @@ from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn
 console = Console(highlight=False)
 err_console = Console(stderr=True, highlight=False)
 
+# questionary scrolls a window over a long choice list, but doesn't advertise it. Past this many
+# options the list can't all be on screen, so the pickers append a "↑/↓ scroll" note to their
+# instruction line. Matches mcp.py's MCP_PICKER_VISIBLE_ROWS so both picker families agree.
+_SCROLL_HINT_THRESHOLD = 10
+
+
+def _with_scroll_hint(instruction: str, option_count: int) -> str:
+    """Append a scroll affordance when the option list is too long to fully show at once.
+
+    The hint is discoverability only — questionary already scrolls; users just can't tell there is
+    more below the fold. Short lists are left alone so the instruction stays terse.
+    """
+    if option_count > _SCROLL_HINT_THRESHOLD:
+        return f"{instruction[:-1]}, ↑/↓ scroll)" if instruction.endswith(")") else instruction
+    return instruction
+
+
 # Output verbosity. "normal" (default) renders decorative panels; "low" trades
 # them for terse single-line output. Set once at CLI entry via set_verbosity.
 _verbosity = "normal"
@@ -385,6 +402,7 @@ def prompt_for_multi_selection(
     instruction = "(space to toggle, enter to confirm)"
     if searchable:
         instruction = "(type to filter, space to toggle, enter to confirm)"
+    instruction = _with_scroll_hint(instruction, len(options))
     answer = questionary.checkbox(
         prompt,
         choices=choices,
@@ -494,13 +512,15 @@ def prompt_for_selection(
         ]
     )
     choices = [questionary.Choice(title=label, value=value) for value, label in options]
+    instruction = "(type to filter, arrow keys to move)" if searchable else "(use arrow keys)"
+    instruction = _with_scroll_hint(instruction, len(options))
     answer = questionary.select(
         prompt,
         choices=choices,
         style=style,
         pointer="›",
         qmark="",
-        instruction="(type to filter, arrow keys to move)" if searchable else "(use arrow keys)",
+        instruction=instruction,
         use_search_filter=searchable,
         use_jk_keys=not searchable,
     ).ask()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -16,7 +16,9 @@ from ucode.ui import (
     format_token_count,
     format_usd,
     normalize_workspace_url,
+    prompt_for_multi_selection,
     prompt_for_percentage,
+    prompt_for_selection,
     prompt_for_text,
     prompt_for_workspace,
     prompt_yes_no_default,
@@ -162,6 +164,47 @@ class TestNormalizeWorkspaceUrl:
     def test_whitespace_only_raises(self):
         with pytest.raises(ValueError, match="empty"):
             normalize_workspace_url("   ")
+
+
+class TestScrollHint:
+    """A long picker list scrolls, but questionary doesn't say so — the pickers add the hint."""
+
+    def _opts(self, n):
+        return [(f"m{i}", f"m{i}") for i in range(n)]
+
+    def test_short_list_gets_no_hint(self):
+        with patch("ucode.ui.questionary.select") as sel:
+            sel.return_value.ask.return_value = "m0"
+            prompt_for_selection("pick", self._opts(5))
+        assert "scroll" not in sel.call_args.kwargs["instruction"]
+
+    def test_long_single_select_gets_the_hint(self):
+        with patch("ucode.ui.questionary.select") as sel:
+            sel.return_value.ask.return_value = "m0"
+            prompt_for_selection("pick", self._opts(16))
+        assert "↑/↓ scroll" in sel.call_args.kwargs["instruction"]
+
+    def test_long_multi_select_gets_the_hint(self):
+        with patch("ucode.ui.questionary.checkbox") as chk:
+            chk.return_value.ask.return_value = []
+            prompt_for_multi_selection("pick", self._opts(16))
+        assert "↑/↓ scroll" in chk.call_args.kwargs["instruction"]
+
+    def test_hint_preserves_the_filter_affordance(self):
+        # The hint must extend the instruction, not replace it — a searchable long list keeps both.
+        with patch("ucode.ui.questionary.select") as sel:
+            sel.return_value.ask.return_value = "m0"
+            prompt_for_selection("pick", self._opts(16), searchable=True)
+        instruction = sel.call_args.kwargs["instruction"]
+        assert "type to filter" in instruction
+        assert "↑/↓ scroll" in instruction
+
+    def test_threshold_is_inclusive_of_ten(self):
+        # Exactly the visible-row count still fits, so no hint; one more overflows.
+        with patch("ucode.ui.questionary.select") as sel:
+            sel.return_value.ask.return_value = "m0"
+            prompt_for_selection("pick", self._opts(10))
+        assert "scroll" not in sel.call_args.kwargs["instruction"]
 
 
 class TestFormatTokenCount:


### PR DESCRIPTION
questionary scrolls a window over a long choice list but never says so. On the model / budget / tier pickers — a real workspace exposes ~16 GPT model ids — a user can't tell there are options below the fold.

`prompt_for_selection` and `prompt_for_multi_selection` now append `↑/↓ scroll` to the instruction line once the option count passes the visible-row count (10, matching `mcp.py`'s `MCP_PICKER_VISIBLE_ROWS`).

## Scope

Discoverability only:
- Scrolling already worked — this just advertises it.
- The hint **extends** the instruction rather than replacing it, so a searchable long list still shows `type to filter`.
- Short lists stay terse.
- No pagination: these are fully in-memory lists with type-to-filter, so fetch-more would add complexity for no gain.

## Tests

+5, mutation-verified (a no-op hint fails the long-list cases). Threshold is inclusive of 10 — exactly the visible rows still fit.

This pull request and its description were written by Isaac.