### PR TITLE
apply: drop --dry-run; it always validates before publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,6 @@ Once the manifest looks right, publish it:
 # Validate, show what would change, and ask before publishing.
 ucode apply
 
-# Preview without publishing.
-ucode apply --dry-run
-
 # Publish without the confirmation prompt (for CI).
 ucode apply --yes
 ```

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -2345,13 +2345,13 @@ def apply_cmd(
         bool,
         typer.Option("--yes", "-y", help="Publish without the confirmation prompt."),
     ] = False,
-    dry_run: Annotated[
-        bool,
-        typer.Option("--dry-run", help="Validate and preview without publishing."),
-    ] = False,
 ) -> None:
-    """Publish this workspace's managed coding config (workspace admins only)."""
-    set_dry_run(dry_run)
+    """Publish this workspace's managed coding config (workspace admins only).
+
+    Always validates the manifest before publishing (and shows what would change, then confirms), so
+    there is no separate dry-run: `ucode setup` only ever writes a valid manifest, and a
+    hand-editing admin sees any error here before anything reaches the workspace.
+    """
     # See the `setup` callback: `typer.Exit` subclasses RuntimeError, so it must be raised after
     # the try block or the handler below would report a successful exit as an error.
     try:

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -1085,10 +1085,6 @@ def apply_command(*, yes: bool = False) -> int:
         print_note("Nothing was published.")
         return 1
 
-    if is_dry_run():
-        print_success("Dry run: the config was validated but not published.")
-        return 0
-
     if existing is None:
         with spinner("Publishing the managed config..."):
             published, publish_reason = create_coding_agent_config(workspace, token, payload)

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -1610,18 +1610,6 @@ class TestApplyCommand:
         with pytest.raises(RuntimeError, match="resource name"):
             self._run(get_managed_config=lambda *a, **k: ({"enabled_agents": {}}, None))
 
-    def test_dry_run_validates_without_publishing(self, monkeypatch):
-        managed_setup_mod.save_managed_settings(WORKSPACE, self.MANIFEST)
-        monkeypatch.setattr(config_io_mod, "_dry_run", True)
-        created = {"called": False}
-
-        def fake_create(*a, **k):
-            created["called"] = True
-            return {}, None
-
-        assert self._run(create_coding_agent_config=fake_create) == 0
-        assert created["called"] is False
-
 
 class TestPublishFailureMessages:
     """The server's error codes, turned into something an admin can act on."""
@@ -1678,12 +1666,14 @@ class TestCliWiring:
         assert result.exit_code == 0
         assert "apply" in result.output
 
-    def test_apply_declares_yes_and_dry_run(self):
-        # Asserted on the declared options rather than rendered help, which Rich ellipsizes at
-        # narrow terminal widths (see test_setup_help_lists_from_file).
+    def test_apply_declares_yes_and_no_dry_run(self):
+        # `--dry-run` was removed: apply always validates before publishing, so a separate
+        # validate-only mode is redundant. Asserted on declared options rather than rendered help,
+        # which Rich ellipsizes at narrow widths (see test_setup_help_lists_from_file).
         command = typer.main.get_command(app).commands["apply"]  # type: ignore[attr-defined]
         declared = {opt for param in command.params for opt in param.opts}
-        assert {"--yes", "--dry-run"} <= declared
+        assert "--yes" in declared
+        assert "--dry-run" not in declared
 
     def test_apply_error_exits_nonzero_with_a_message(self):
         with patch.object(cli_mod, "apply_command", side_effect=RuntimeError("no config authored")):


### PR DESCRIPTION
`ucode apply --dry-run` validated and previewed without writing — but `apply` already validates unconditionally before it publishes, shows the summary, and asks for confirmation. So the flag added a mode with no distinct value.

`ucode setup` only ever writes a valid manifest; the one case worth guarding is a hand-edited `managed-settings.json`, and that's caught by the normal validation `apply` runs regardless.

## Changes

- Remove the `--dry-run` option from `apply_cmd` and the `is_dry_run()` early-out in `apply_command`.
- The confirmation prompt still gates every publish, and the manifest is still validated first — `ucode apply` on an invalid hand-edit fails before anything reaches the workspace.
- README updated.

**Untouched** — two unrelated dry-runs that share the name: `ucode setup --dry-run` (walk the flow without writing) and `ucode --dry-run` (launch against the last saved config) keep their flags.

## Tests

Dropped `test_dry_run_validates_without_publishing` (behaviour gone); the option-declaration test now asserts `--dry-run` is absent and `--yes` present.

This pull request and its description were written by Isaac.