### PR TITLE
Improve "ucode configure" under managed config

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -222,7 +222,12 @@ def _resolve_workspace_then_maybe_reject(
     entries = workspace_entries or [_prompt_for_configuration(None)]
     workspace, profile = entries[0]
     set_current_workspace(workspace)
-    managed = load_managed_state(workspace)
+    # Fetch, don't just read the local cache: on a fresh machine (or right after a reinstall) the
+    # cache is empty until the first launch, so a cache read would miss a config the workspace does
+    # publish and wrongly fall through to the local configure flow. `refresh_managed_config` reaches
+    # the workspace and never raises — it falls back to the persisted copy, then None, on failure.
+    with spinner("Checking for a managed coding agent config..."):
+        managed = refresh_managed_config({"workspace": workspace, "profile": profile})
     if not managed:
         _maybe_offer_admin_setup(workspace, profile)
         return entries

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -2169,6 +2169,12 @@ def configure(
         # scriptable), and when --dry-run is set.
         if fully_interactive and not dry_run and prompt_yes_no("Configure MCP servers now?"):
             configure_mcp_command()
+    except typer.Exit:
+        # `typer.Exit` subclasses RuntimeError, so it has to be re-raised ahead of the handler
+        # below. Otherwise a clean exit (e.g. `_reject_configure_under_managed_config` under a
+        # managed config) is followed by `print_err(str(exc))` printing the exit code — a bare,
+        # meaningless "ERROR 0".
+        raise
     except RuntimeError as exc:
         print_err(str(exc))
         raise typer.Exit(1) from None

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -220,15 +220,42 @@ def _resolve_workspace_then_maybe_reject(
     if not managed_agent_config_enabled():
         return workspace_entries
     entries = workspace_entries or [_prompt_for_configuration(None)]
-    workspace = entries[0][0]
+    workspace, profile = entries[0]
     set_current_workspace(workspace)
     managed = load_managed_state(workspace)
     if not managed:
+        _maybe_offer_admin_setup(workspace, profile)
         return entries
     print_success("A managed config has been detected for your workspace — you're all set.")
     _print_managed_summary(managed, load_state(), tool=None)
     print_note("Configuration is complete. Just run `ucode` to launch with it applied.")
     raise typer.Exit(0)
+
+
+def _maybe_offer_admin_setup(workspace: str, profile: str | None) -> None:
+    """When a workspace admin runs ``configure`` on a workspace with no managed config, offer to
+    bail out so they can publish one with ``ucode setup`` instead.
+
+    Admins are the ones who'd want a managed config; a plain developer just gets the normal
+    configure flow. If they accept, exit cleanly (assuming they'll run `ucode setup`); if they
+    decline, fall through to configure their own local settings. The check is best-effort: any
+    failure to determine admin status (auth or SCIM unreachable) silently skips the prompt.
+    """
+    try:
+        token = get_databricks_token(workspace, profile)
+    except RuntimeError:
+        return
+    with spinner("Checking your workspace permissions..."):
+        is_admin = is_workspace_admin(workspace, token)
+    if not is_admin:
+        return
+    print_note(
+        "No managed config exists for this workspace. As a workspace admin you can publish one "
+        "with `ucode setup`, which every developer then picks up automatically."
+    )
+    if prompt_yes_no("Stop here and run `ucode setup` instead?"):
+        print_note("Run `ucode setup` to author your workspace's managed config, then `ucode apply`.")
+        raise typer.Exit(0)
 
 
 def _print_discovery_diagnostics(state: dict) -> None:

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -201,21 +201,32 @@ def _print_managed_summary(managed: dict, state: dict, tool: str | None) -> None
     )
 
 
-def _reject_configure_under_managed_config() -> None:
-    """Short-circuit ``ucode configure`` when the workspace publishes a managed config.
+def _resolve_workspace_then_maybe_reject(
+    workspace_entries: list[tuple[str, str | None]] | None,
+) -> list[tuple[str, str | None]] | None:
+    """Resolve the workspace ``ucode configure`` targets, then short-circuit if it is managed.
 
-    Configuring locally would be overridden at launch anyway. Rather than erroring, show the
-    developer the config their admin already set and point them at `ucode`. Without a managed
-    config the command still runs unchanged.
+    When managed coding-agent configs are enabled, ``ucode configure`` must still let a developer
+    switch workspaces — so resolve the target workspace up front (prompting when the interactive
+    path gave no ``--workspaces``/``--profiles``) and make it current *before* deciding whether to
+    short-circuit. Only then, if that workspace already publishes a managed config, configuring
+    locally would be overridden at launch anyway: show the admin's config and point the developer
+    at `ucode`.
+
+    Returns the resolved entries to configure when there is no managed config so the caller reuses
+    them instead of prompting again. Without the feature enabled it returns ``workspace_entries``
+    unchanged and prompts nothing.
     """
     if not managed_agent_config_enabled():
-        return
-    state = load_state()
-    managed = load_managed_state(state.get("workspace"))
+        return workspace_entries
+    entries = workspace_entries or [_prompt_for_configuration(None)]
+    workspace = entries[0][0]
+    set_current_workspace(workspace)
+    managed = load_managed_state(workspace)
     if not managed:
-        return
+        return entries
     print_success("A managed config has been detected for your workspace — you're all set.")
-    _print_managed_summary(managed, state, tool=None)
+    _print_managed_summary(managed, load_state(), tool=None)
     print_note("Configuration is complete. Just run `ucode` to launch with it applied.")
     raise typer.Exit(0)
 
@@ -2014,7 +2025,6 @@ def configure(
     prompt_optional_updates = not skip_upgrade
     try:
         install_databricks_cli()
-        _reject_configure_under_managed_config()
         if agent is not None and agents is not None:
             raise RuntimeError("Use either --agent or --agents, not both.")
         if workspaces is not None and profiles is not None:
@@ -2027,6 +2037,14 @@ def configure(
         workspace_entries = _parse_workspaces_option(workspaces) if workspaces is not None else None
         if profiles is not None:
             workspace_entries = _parse_profiles_option(profiles)
+        # Whether the user named the workspace(s) via flags, captured before the resolver below
+        # may fill `workspace_entries` from a prompt — this, not the resolved value, decides the
+        # fully-interactive MCP prompt at the end.
+        flag_driven_workspace = workspace_entries is not None
+        # Under a managed config, resolve (prompting when interactive) and set the target workspace
+        # first, so the developer can switch workspaces; only then short-circuit if that workspace
+        # is already managed. Returns the resolved entries so the flow below doesn't prompt again.
+        workspace_entries = _resolve_workspace_then_maybe_reject(workspace_entries)
         # Only forward the opt-in flags when set so existing call expectations
         # (and defaults) stay unchanged for the common interactive path.
         skip_kwargs: dict = {}
@@ -2131,8 +2149,10 @@ def configure(
                 )
             # Only the no-agent, no-workspace path is truly interactive (the user
             # picked agents/workspace via prompts); that's where we offer the MCP
-            # step below. Flag-driven runs stay scriptable.
-            fully_interactive = workspace_entries is None
+            # step below. Flag-driven runs stay scriptable. Keyed off whether the
+            # workspace came from a flag, not the now-resolved `workspace_entries`
+            # (which the managed-config resolver may have filled from a prompt).
+            fully_interactive = not flag_driven_workspace
         if tracing:
             # The workspaces were just configured, so enable tracing for them
             # directly instead of re-prompting. Fall back to the workspace that

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -250,10 +250,10 @@ def _maybe_offer_admin_setup(workspace: str, profile: str | None) -> None:
     if not is_admin:
         return
     print_note(
-        "No managed config exists for this workspace. As a workspace admin you can publish one "
-        "with `ucode setup`, which every developer then picks up automatically."
+        "✨ New: as a workspace admin you can publish a managed config with `ucode setup` — set "
+        "the agents, models, MCPs, and skills once, and every developer picks them up automatically."
     )
-    if prompt_yes_no("Stop here and run `ucode setup` instead?"):
+    if prompt_yes_no("Set one up now with `ucode setup`?"):
         print_note("Run `ucode setup` to author your workspace's managed config, then `ucode apply`.")
         raise typer.Exit(0)
 

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -254,7 +254,9 @@ def _maybe_offer_admin_setup(workspace: str, profile: str | None) -> None:
         "the agents, models, MCPs, and skills once, and every developer picks them up automatically."
     )
     if prompt_yes_no("Set one up now with `ucode setup`?"):
-        print_note("Run `ucode setup` to author your workspace's managed config, then `ucode apply`.")
+        print_note(
+            "Run `ucode setup` to author your workspace's managed config, then `ucode apply`."
+        )
         raise typer.Exit(0)
 
 

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -156,21 +156,28 @@ def _policy_summary_lines(managed: dict) -> list[str]:
     return lines
 
 
-def _print_managed_summary(managed: dict, state: dict, tool: str) -> None:
-    """Show the developer which of their admin's settings are in force for this launch."""
+def _print_managed_summary(managed: dict, state: dict, tool: str | None) -> None:
+    """Show which of the admin's settings are in force.
+
+    With ``tool`` set (launch path) the per-agent Agent/Provider/Model lines are included;
+    with ``tool=None`` (e.g. ``ucode configure`` under a managed config) they are skipped
+    since no single agent has been chosen yet.
+    """
     lines = [f"[bold]Workspace:[/bold] [cyan]{state.get('workspace', '?')}[/cyan]"]
-    lines.append(f"[bold]Agent:[/bold] [green]{TOOL_SPECS[tool]['display']}[/green]")
+    if tool is not None:
+        lines.append(f"[bold]Agent:[/bold] [green]{TOOL_SPECS[tool]['display']}[/green]")
     enabled = [t for t in (managed.get("enabled_agents") or {}) if t in TOOL_SPECS]
     if enabled:
         lines.append(
             f"[bold]Enabled agents:[/bold] {', '.join(TOOL_SPECS[t]['display'] for t in enabled)}"
         )
-    provider = managed_provider_service(managed, tool)
-    if provider:
-        lines.append(f"[bold]Provider:[/bold] [magenta]{provider}[/magenta]")
-    model = managed_default_model(managed, tool)
-    if model:
-        lines.append(f"[bold]Model:[/bold] [magenta]{model}[/magenta]")
+    if tool is not None:
+        provider = managed_provider_service(managed, tool)
+        if provider:
+            lines.append(f"[bold]Provider:[/bold] [magenta]{provider}[/magenta]")
+        model = managed_default_model(managed, tool)
+        if model:
+            lines.append(f"[bold]Model:[/bold] [magenta]{model}[/magenta]")
     # Always listed, including when empty: "none configured" tells a developer their admin set none,
     # which a missing row leaves ambiguous. Shown as the admin configured them — registering them
     # locally is a separate change, hence "pending".
@@ -195,18 +202,22 @@ def _print_managed_summary(managed: dict, state: dict, tool: str) -> None:
 
 
 def _reject_configure_under_managed_config() -> None:
-    """Refuse ``ucode configure`` when the workspace publishes a managed config.
+    """Short-circuit ``ucode configure`` when the workspace publishes a managed config.
 
-    Configuring locally would be overridden at launch anyway, so it is an error rather than a
-    silently-ignored run. Without a managed config the command still runs unchanged.
+    Configuring locally would be overridden at launch anyway. Rather than erroring, show the
+    developer the config their admin already set and point them at `ucode`. Without a managed
+    config the command still runs unchanged.
     """
     if not managed_agent_config_enabled():
         return
-    if load_managed_state(load_state().get("workspace")):
-        raise RuntimeError(
-            "The ucode configure command is being deprecated. Please run `ucode` to launch "
-            "with your admin's managed config applied"
-        )
+    state = load_state()
+    managed = load_managed_state(state.get("workspace"))
+    if not managed:
+        return
+    print_success("A managed config has been detected for your workspace — you're all set.")
+    _print_managed_summary(managed, state, tool=None)
+    print_note("Configuration is complete. Just run `ucode` to launch with it applied.")
+    raise typer.Exit(0)
 
 
 def _print_discovery_diagnostics(state: dict) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,9 @@ def _isolate_ucode_state(tmp_path, monkeypatch):
     state_dir.mkdir()
     monkeypatch.setattr(state_mod, "STATE_PATH", state_dir / "state.json")
     monkeypatch.setattr(config_io_mod, "APP_DIR", state_dir)
+    # Isolate the managed-config opt-in from the developer's own shell: leaving it set would make
+    # `ucode configure` prompt for a workspace mid-test. Tests that exercise the managed path set it.
+    monkeypatch.delenv("ENABLE_MANAGED_AGENT_CONFIG", raising=False)
     # The model-services listing is memoized for the life of the process, so without this a cached
     # result would leak into the next test and make a stubbed listing look like it was never called.
     databricks_mod.clear_model_services_cache()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2236,6 +2236,12 @@ class TestConfigureDeprecation:
         assert "managed config has been detected" in out
         assert "run `ucode`" in out
 
+    @staticmethod
+    def _stub_not_admin(monkeypatch):
+        # No managed config -> the resolver now checks admin status; keep the developer case simple.
+        monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
+        monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: False)
+
     def test_prompts_for_the_workspace_before_checking_the_config(self, monkeypatch):
         # The whole point: even under a managed config the developer can still switch workspaces,
         # so the prompt runs (and the picked workspace is made current) before the config check.
@@ -2246,19 +2252,72 @@ class TestConfigureDeprecation:
         )
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: picked.append(ws))
         monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
+        self._stub_not_admin(monkeypatch)
         entries = self._resolve(None)
         assert picked == ["https://picked"]
         assert entries == [("https://picked", None)]
 
-    def test_returns_flag_entries_and_proceeds_without_a_managed_config(self, monkeypatch, capsys):
-        # Setting up a new workspace still goes through `ucode configure`, so say nothing and
-        # hand the resolved workspace back to the caller instead of re-prompting.
+    def test_returns_flag_entries_and_proceeds_without_a_managed_config(self, monkeypatch):
+        # Setting up a new workspace still goes through `ucode configure`, so hand the resolved
+        # workspace back to the caller instead of re-prompting.
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
         monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
+        self._stub_not_admin(monkeypatch)
         entries = self._resolve([("https://w", None)])
         assert entries == [("https://w", None)]
-        assert capsys.readouterr().out == ""
+
+    def test_admin_who_declines_proceeds_with_configure(self, monkeypatch):
+        # An admin on a config-less workspace is offered `ucode setup`; declining continues the
+        # normal configure flow and returns the resolved workspace.
+        monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
+        monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
+        monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: True)
+        monkeypatch.setattr("ucode.cli.prompt_yes_no", lambda prompt: False)
+        entries = self._resolve([("https://w", None)])
+        assert entries == [("https://w", None)]
+
+    def test_admin_who_accepts_exits_to_run_setup(self, monkeypatch):
+        import typer
+
+        monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
+        monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
+        monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: True)
+        monkeypatch.setattr("ucode.cli.prompt_yes_no", lambda prompt: True)
+        with pytest.raises(typer.Exit) as exc:
+            self._resolve([("https://w", None)])
+        assert exc.value.exit_code == 0
+
+    def test_non_admin_is_never_prompted_for_setup(self, monkeypatch):
+        monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
+        monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
+        monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: False)
+        monkeypatch.setattr(
+            "ucode.cli.prompt_yes_no",
+            lambda prompt: pytest.fail("non-admins must not be prompted for setup"),
+        )
+        entries = self._resolve([("https://w", None)])
+        assert entries == [("https://w", None)]
+
+    def test_admin_check_failure_skips_the_setup_prompt(self, monkeypatch):
+        # `is_workspace_admin` returns None when the check itself fails; treat as "don't prompt".
+        monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
+        monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
+        monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: None)
+        monkeypatch.setattr(
+            "ucode.cli.prompt_yes_no",
+            lambda prompt: pytest.fail("must not prompt when admin status is unknown"),
+        )
+        entries = self._resolve([("https://w", None)])
+        assert entries == [("https://w", None)]
 
     def test_configure_command_exits_zero_without_erroring(self, monkeypatch):
         # `typer.Exit(0)` subclasses RuntimeError, so the command's own RuntimeError handler must

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2226,8 +2226,8 @@ class TestConfigureDeprecation:
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
         monkeypatch.setattr("ucode.cli.load_state", lambda: {"workspace": "https://w"})
         monkeypatch.setattr(
-            "ucode.cli.load_managed_state",
-            lambda ws: {"enabled_agents": {"claude": {}}},
+            "ucode.cli.refresh_managed_config",
+            lambda state: {"enabled_agents": {"claude": {}}},
         )
         with pytest.raises(typer.Exit) as exc:
             self._resolve([("https://w", None)])
@@ -2235,6 +2235,24 @@ class TestConfigureDeprecation:
         out = capsys.readouterr().out
         assert "managed config has been detected" in out
         assert "run `ucode`" in out
+
+    def test_fetches_the_config_rather_than_reading_a_cold_cache(self, monkeypatch):
+        # The gap this guards: on a fresh machine the local cache is empty until the first launch,
+        # so a cache read would miss a config the workspace does publish. The resolver must fetch.
+        import typer
+
+        monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
+        monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.load_state", lambda: {"workspace": "https://w"})
+        # Cold cache — a cache read would wrongly fall through to the local configure flow.
+        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
+        monkeypatch.setattr(
+            "ucode.cli.refresh_managed_config",
+            lambda state: {"enabled_agents": {"claude": {}}},
+        )
+        with pytest.raises(typer.Exit) as exc:
+            self._resolve([("https://w", None)])
+        assert exc.value.exit_code == 0
 
     @staticmethod
     def _stub_not_admin(monkeypatch):
@@ -2251,7 +2269,7 @@ class TestConfigureDeprecation:
             "ucode.cli._prompt_for_configuration", lambda tool=None: ("https://picked", None)
         )
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: picked.append(ws))
-        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
         self._stub_not_admin(monkeypatch)
         entries = self._resolve(None)
         assert picked == ["https://picked"]
@@ -2262,7 +2280,7 @@ class TestConfigureDeprecation:
         # workspace back to the caller instead of re-prompting.
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
-        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
         self._stub_not_admin(monkeypatch)
         entries = self._resolve([("https://w", None)])
         assert entries == [("https://w", None)]
@@ -2272,7 +2290,7 @@ class TestConfigureDeprecation:
         # normal configure flow and returns the resolved workspace.
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
-        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
         monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
         monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: True)
         monkeypatch.setattr("ucode.cli.prompt_yes_no", lambda prompt: False)
@@ -2284,7 +2302,7 @@ class TestConfigureDeprecation:
 
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
-        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
         monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
         monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: True)
         monkeypatch.setattr("ucode.cli.prompt_yes_no", lambda prompt: True)
@@ -2295,7 +2313,7 @@ class TestConfigureDeprecation:
     def test_non_admin_is_never_prompted_for_setup(self, monkeypatch):
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
-        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
         monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
         monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: False)
         monkeypatch.setattr(
@@ -2309,7 +2327,7 @@ class TestConfigureDeprecation:
         # `is_workspace_admin` returns None when the check itself fails; treat as "don't prompt".
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
-        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
         monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
         monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: None)
         monkeypatch.setattr(
@@ -2326,8 +2344,8 @@ class TestConfigureDeprecation:
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
         monkeypatch.setattr("ucode.cli.load_state", lambda: {"workspace": "https://w"})
         monkeypatch.setattr(
-            "ucode.cli.load_managed_state",
-            lambda ws: {"enabled_agents": {"claude": {}}},
+            "ucode.cli.refresh_managed_config",
+            lambda state: {"enabled_agents": {"claude": {}}},
         )
         with (
             patch("ucode.cli.install_databricks_cli"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2210,54 +2210,76 @@ class TestManagedConfigDecidesDiscoveryFromFreshRead:
 
 
 class TestConfigureDeprecation:
-    """`ucode configure` short-circuits once a managed config exists, since the admin's wins anyway."""
+    """`ucode configure` resolves the target workspace first, then short-circuits once a managed
+    config exists for it, since the admin's wins anyway."""
 
     @staticmethod
-    def _reject():
+    def _resolve(entries=None):
         import ucode.cli as cli_mod
 
-        cli_mod._reject_configure_under_managed_config()
+        return cli_mod._resolve_workspace_then_maybe_reject(entries)
 
     def test_shows_summary_and_exits_when_a_managed_config_exists(self, monkeypatch, capsys):
         import typer
 
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
+        monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
         monkeypatch.setattr("ucode.cli.load_state", lambda: {"workspace": "https://w"})
         monkeypatch.setattr(
             "ucode.cli.load_managed_state",
             lambda ws: {"enabled_agents": {"claude": {}}},
         )
         with pytest.raises(typer.Exit) as exc:
-            self._reject()
+            self._resolve([("https://w", None)])
         assert exc.value.exit_code == 0
         out = capsys.readouterr().out
         assert "managed config has been detected" in out
         assert "run `ucode`" in out
 
-    def test_silent_and_proceeds_without_a_managed_config(self, monkeypatch, capsys):
-        # Setting up a new workspace still goes through `ucode configure`, so say nothing.
+    def test_prompts_for_the_workspace_before_checking_the_config(self, monkeypatch):
+        # The whole point: even under a managed config the developer can still switch workspaces,
+        # so the prompt runs (and the picked workspace is made current) before the config check.
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
-        monkeypatch.setattr("ucode.cli.load_state", lambda: {"workspace": "https://w"})
+        picked = []
+        monkeypatch.setattr(
+            "ucode.cli._prompt_for_configuration", lambda tool=None: ("https://picked", None)
+        )
+        monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: picked.append(ws))
         monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
-        self._reject()
+        entries = self._resolve(None)
+        assert picked == ["https://picked"]
+        assert entries == [("https://picked", None)]
+
+    def test_returns_flag_entries_and_proceeds_without_a_managed_config(self, monkeypatch, capsys):
+        # Setting up a new workspace still goes through `ucode configure`, so say nothing and
+        # hand the resolved workspace back to the caller instead of re-prompting.
+        monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
+        monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
+        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
+        entries = self._resolve([("https://w", None)])
+        assert entries == [("https://w", None)]
         assert capsys.readouterr().out == ""
 
     def test_configure_command_exits_zero_without_erroring(self, monkeypatch):
         # `typer.Exit(0)` subclasses RuntimeError, so the command's own RuntimeError handler must
         # not catch the clean exit and print `str(exc)` -> a bare, meaningless "ERROR 0".
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
+        monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
         monkeypatch.setattr("ucode.cli.load_state", lambda: {"workspace": "https://w"})
         monkeypatch.setattr(
             "ucode.cli.load_managed_state",
             lambda ws: {"enabled_agents": {"claude": {}}},
         )
-        with patch("ucode.cli.install_databricks_cli"):
+        with (
+            patch("ucode.cli.install_databricks_cli"),
+            patch("ucode.cli._prompt_for_configuration", return_value=("https://w", None)),
+        ):
             result = runner.invoke(app, ["configure"])
         assert result.exit_code == 0, result.output
         assert "ERROR" not in result.output
 
     @pytest.mark.parametrize("env_value", [None, "", "0"])
-    def test_silent_when_the_env_var_is_off(self, monkeypatch, capsys, env_value):
+    def test_passes_entries_through_when_the_env_var_is_off(self, monkeypatch, capsys, env_value):
         if env_value is None:
             monkeypatch.delenv("ENABLE_MANAGED_AGENT_CONFIG", raising=False)
         else:
@@ -2266,7 +2288,11 @@ class TestConfigureDeprecation:
             "ucode.cli.load_managed_state",
             lambda ws: pytest.fail("must not read the config when disabled"),
         )
-        self._reject()
+        monkeypatch.setattr(
+            "ucode.cli._prompt_for_configuration",
+            lambda tool=None: pytest.fail("must not prompt when disabled"),
+        )
+        assert self._resolve(None) is None
         assert capsys.readouterr().out == ""
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2242,6 +2242,20 @@ class TestConfigureDeprecation:
         self._reject()
         assert capsys.readouterr().out == ""
 
+    def test_configure_command_exits_zero_without_erroring(self, monkeypatch):
+        # `typer.Exit(0)` subclasses RuntimeError, so the command's own RuntimeError handler must
+        # not catch the clean exit and print `str(exc)` -> a bare, meaningless "ERROR 0".
+        monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
+        monkeypatch.setattr("ucode.cli.load_state", lambda: {"workspace": "https://w"})
+        monkeypatch.setattr(
+            "ucode.cli.load_managed_state",
+            lambda ws: {"enabled_agents": {"claude": {}}},
+        )
+        with patch("ucode.cli.install_databricks_cli"):
+            result = runner.invoke(app, ["configure"])
+        assert result.exit_code == 0, result.output
+        assert "ERROR" not in result.output
+
     @pytest.mark.parametrize("env_value", [None, "", "0"])
     def test_silent_when_the_env_var_is_off(self, monkeypatch, capsys, env_value):
         if env_value is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2210,7 +2210,7 @@ class TestManagedConfigDecidesDiscoveryFromFreshRead:
 
 
 class TestConfigureDeprecation:
-    """`ucode configure` is refused once a managed config exists, since the admin's wins anyway."""
+    """`ucode configure` short-circuits once a managed config exists, since the admin's wins anyway."""
 
     @staticmethod
     def _reject():
@@ -2218,13 +2218,21 @@ class TestConfigureDeprecation:
 
         cli_mod._reject_configure_under_managed_config()
 
-    def test_blocks_when_a_managed_config_exists(self, monkeypatch):
+    def test_shows_summary_and_exits_when_a_managed_config_exists(self, monkeypatch, capsys):
+        import typer
+
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.load_state", lambda: {"workspace": "https://w"})
-        monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: {"enabled_agents": {}})
-        with pytest.raises(RuntimeError, match="being deprecated") as exc:
+        monkeypatch.setattr(
+            "ucode.cli.load_managed_state",
+            lambda ws: {"enabled_agents": {"claude": {}}},
+        )
+        with pytest.raises(typer.Exit) as exc:
             self._reject()
-        assert "Please run `ucode`" in str(exc.value)
+        assert exc.value.exit_code == 0
+        out = capsys.readouterr().out
+        assert "managed config has been detected" in out
+        assert "run `ucode`" in out
 
     def test_silent_and_proceeds_without_a_managed_config(self, monkeypatch, capsys):
         # Setting up a new workspace still goes through `ucode configure`, so say nothing.


### PR DESCRIPTION
  Cleans up how `ucode configure` behaves when managed agent configs are enabled (`ENABLE_MANAGED_AGENT_CONFIG`).

  - **Show the config summary instead of a "deprecated" error.** When a managed config exists, print the workspace's config summary + a "you're
  all set, just run `ucode`" note and exit cleanly.
  - **Fix `ERROR 0`.** `typer.Exit(0)` subclasses `RuntimeError`, so the clean exit was caught by the command's own `RuntimeError` handler and
  printed as a bare "ERROR 0". Re-raise `typer.Exit` ahead of that handler.
  - **Prompt for the workspace first.** The short-circuit used to run before any workspace prompt, so a developer whose current workspace was
  already managed could never switch workspaces. Now resolve the target workspace (prompt or `--workspaces`/`--profiles`), set it current, then
  short-circuit only if *that* workspace is managed.
  - **Nudge admins toward `ucode setup`.** If the resolved workspace has no managed config and the caller is a workspace admin, offer to stop
  and run `ucode setup` instead. Non-admins (and any case where the admin check can't be made) just proceed.

  Also isolates `ENABLE_MANAGED_AGENT_CONFIG` in the test fixture so the dev's shell env can't make configure tests prompt mid-run.
Co-authored-by: Isaac