### PR TITLE
Warn in `ucode setup` when an MPS isn't usable by all workspace users

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Literal, NamedTuple, cast, overload
 from urllib import error as urllib_error
 from urllib import request as urllib_request
-from urllib.parse import urlencode, urlparse
+from urllib.parse import quote, urlencode, urlparse
 
 from databricks.sql.exc import ServerOperationError
 
@@ -1943,6 +1943,43 @@ def get_model_provider_service(
     if entry is None:
         return None, "model-provider-service response had an unexpected shape"
     return entry, None
+
+
+# The group every workspace user belongs to. USE_SCHEMA granted to it (directly or inherited from
+# the catalog) is what lets an arbitrary developer pull a config that routes through an MPS in that
+# schema; without it they hit "User does not have USE_SCHEMA on Schema <catalog>.<schema>".
+_ALL_WORKSPACE_USERS_GROUP = "account users"
+
+
+def all_users_can_use_schema(workspace: str, token: str, schema_full_name: str) -> bool | None:
+    """Whether the `account users` group has USE_SCHEMA on ``<catalog>.<schema>``.
+
+    Uses UC's effective-permissions API, so a USE_SCHEMA inherited from a catalog-level grant counts.
+    Returns True/False, or None when the check itself could not be made (API unreachable or an
+    unexpected shape) — callers treat None as "unknown" and skip the warning rather than cry wolf.
+
+    A False here is only a heuristic: a workspace may instead grant access through team groups or
+    individual users, so callers must warn rather than block on it.
+    """
+    hostname = workspace_hostname(workspace)
+    principal = quote(_ALL_WORKSPACE_USERS_GROUP)
+    url = (
+        f"https://{hostname}/api/2.1/unity-catalog/effective-permissions/"
+        f"schema/{schema_full_name}?principal={principal}"
+    )
+    payload, reason = _http_get_json(url, token, timeout=30)
+    if reason is not None or not isinstance(payload, dict):
+        return None
+    for assignment in payload.get("privilege_assignments") or []:
+        if not isinstance(assignment, dict):
+            continue
+        for entry in assignment.get("privileges") or []:
+            if isinstance(entry, dict) and entry.get("privilege") in (
+                "USE_SCHEMA",
+                "ALL_PRIVILEGES",
+            ):
+                return True
+    return False
 
 
 def is_model_provider_feature_unavailable(reason: str | None) -> bool:

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -21,6 +21,7 @@ from ucode.agents import TOOL_SPECS, check_gateway_endpoint
 from ucode.config_io import is_dry_run
 from ucode.databricks import (
     ANTHROPIC_FAMILIES,
+    all_users_can_use_schema,
     create_coding_agent_config,
     delete_coding_agent_config,
     discover_claude_models_unbucketed,
@@ -234,7 +235,30 @@ def _select_provider_service(tool: str, workspace: str, token: str) -> dict | No
     )
     if not selected:
         return None
-    return next(service for service in usable if service["name"] == selected)
+    service = next(service for service in usable if service["name"] == selected)
+    _warn_if_mps_not_broadly_accessible(workspace, token, service["name"])
+    return service
+
+
+def _warn_if_mps_not_broadly_accessible(workspace: str, token: str, service_name: str) -> None:
+    """Warn if the picked MPS's schema isn't granted to all workspace users.
+
+    A developer who pulls a config routing through this MPS needs USE_SCHEMA on its schema, or they
+    hit "User does not have USE_SCHEMA on Schema <catalog>.<schema>" at launch. This only warns
+    (never blocks): access may instead come from a team group the check can't see, and an
+    inconclusive check stays silent.
+    """
+    schema = ".".join(service_name.split(".")[:2])
+    if schema.count(".") != 1:
+        return
+    with spinner("Checking who can use this service..."):
+        accessible = all_users_can_use_schema(workspace, token, schema)
+    if accessible is False:
+        print_warning(
+            f"All workspace users don't appear to have USE_SCHEMA on `{schema}`, so developers "
+            f"who pull this config may not be able to use `{service_name}`. Grant USE_SCHEMA on "
+            f"`{schema}` to the `account users` group (or the teams that need it) in Unity Catalog."
+        )
 
 
 def _prompt_models_for_agent(tool: str, state: dict, provider_service: dict | None) -> dict:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,9 @@ def _isolate_ucode_state(tmp_path, monkeypatch):
     state_dir.mkdir()
     monkeypatch.setattr(state_mod, "STATE_PATH", state_dir / "state.json")
     monkeypatch.setattr(config_io_mod, "APP_DIR", state_dir)
+    # Isolate the managed-config opt-in from the developer's own shell: leaving it set changes what
+    # `ucode`/`ucode configure` do mid-test. Tests that exercise the managed path set it explicitly.
+    monkeypatch.delenv("ENABLE_MANAGED_AGENT_CONFIG", raising=False)
     # The model-services listing is memoized for the life of the process, so without this a cached
     # result would leak into the next test and make a stubbed listing look like it was never called.
     databricks_mod.clear_model_services_cache()

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -19,6 +19,7 @@ from ucode.databricks import (
     _run_databricks_cli_installer,
     _scrub_databrickscfg,
     _scrub_json,
+    all_users_can_use_schema,
     build_auth_shell_command,
     build_auth_token_argv,
     build_databricks_cli_env,
@@ -2695,3 +2696,67 @@ class TestDiscoverSqlWarehouses:
         )
         with pytest.raises(RuntimeError, match="No usable SQL warehouse"):
             discover_sql_warehouses(WS, "token")
+
+
+class TestAllUsersCanUseSchema:
+    def _stub(self, monkeypatch, payload, reason=None):
+        monkeypatch.setattr(
+            db_mod, "_http_get_json", lambda url, token, timeout=30: (payload, reason)
+        )
+
+    def test_true_when_account_users_have_use_schema(self, monkeypatch):
+        self._stub(
+            monkeypatch,
+            {
+                "privilege_assignments": [
+                    {"principal": "account users", "privileges": [{"privilege": "USE_SCHEMA"}]}
+                ]
+            },
+        )
+        assert all_users_can_use_schema("https://ws", "tok", "main.default") is True
+
+    def test_true_when_account_users_have_all_privileges(self, monkeypatch):
+        self._stub(
+            monkeypatch,
+            {
+                "privilege_assignments": [
+                    {"principal": "account users", "privileges": [{"privilege": "ALL_PRIVILEGES"}]}
+                ]
+            },
+        )
+        assert all_users_can_use_schema("https://ws", "tok", "main.default") is True
+
+    def test_false_when_no_use_schema(self, monkeypatch):
+        # An empty assignment list is what the API returns when the group has no grant on the schema.
+        self._stub(monkeypatch, {})
+        assert all_users_can_use_schema("https://ws", "tok", "main.tien_le") is False
+
+    def test_false_when_only_unrelated_privileges(self, monkeypatch):
+        self._stub(
+            monkeypatch,
+            {
+                "privilege_assignments": [
+                    {"principal": "account users", "privileges": [{"privilege": "MANAGE"}]}
+                ]
+            },
+        )
+        assert all_users_can_use_schema("https://ws", "tok", "main.default") is False
+
+    def test_none_when_the_call_fails(self, monkeypatch):
+        self._stub(monkeypatch, None, reason="HTTP 403 Forbidden")
+        assert all_users_can_use_schema("https://ws", "tok", "main.default") is None
+
+    def test_none_on_unexpected_shape(self, monkeypatch):
+        self._stub(monkeypatch, [])
+        assert all_users_can_use_schema("https://ws", "tok", "main.default") is None
+
+    def test_requests_the_account_users_principal(self, monkeypatch):
+        seen = {}
+        monkeypatch.setattr(
+            db_mod,
+            "_http_get_json",
+            lambda url, token, timeout=30: (seen.setdefault("url", url), ({}, None))[1],
+        )
+        all_users_can_use_schema("https://ws", "tok", "main.tien_le")
+        assert "effective-permissions/schema/main.tien_le" in seen["url"]
+        assert "principal=account%20users" in seen["url"]

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -895,6 +895,7 @@ class TestProviderServiceSelection:
                 "prompt_for_selection",
                 side_effect=["mps", "main.default.lilly-anthropic"],
             ),
+            patch.object(wizard, "all_users_can_use_schema", return_value=True),
         ):
             service = wizard._select_provider_service("claude", WORKSPACE, "token")
         assert service == ANTHROPIC_SERVICE
@@ -911,10 +912,45 @@ class TestProviderServiceSelection:
                 "prompt_for_selection",
                 side_effect=["mps", "main.default.lilly-anthropic"],
             ) as select,
+            patch.object(wizard, "all_users_can_use_schema", return_value=True),
         ):
             wizard._select_provider_service("claude", WORKSPACE, "token")
         offered = [value for value, _ in select.call_args_list[1][0][1]]
         assert offered == ["main.default.lilly-anthropic"]
+
+    def test_warns_when_all_users_lack_schema_access(self):
+        # The picked MPS's schema isn't granted to all workspace users, so developers who pull the
+        # config may hit "does not have USE_SCHEMA"; warn but still return the service (never block).
+        with (
+            patch.object(
+                wizard, "list_model_provider_services", return_value=([ANTHROPIC_SERVICE], None)
+            ),
+            patch.object(
+                wizard, "prompt_for_selection", side_effect=["mps", "main.default.lilly-anthropic"]
+            ),
+            patch.object(wizard, "all_users_can_use_schema", return_value=False),
+            patch.object(wizard, "print_warning") as warn,
+        ):
+            service = wizard._select_provider_service("claude", WORKSPACE, "token")
+        assert service == ANTHROPIC_SERVICE
+        assert warn.called
+        assert "main.default" in warn.call_args[0][0]
+
+    def test_no_warning_when_access_check_is_inconclusive(self):
+        # A None result (API unreachable / unexpected shape) must not cry wolf.
+        with (
+            patch.object(
+                wizard, "list_model_provider_services", return_value=([ANTHROPIC_SERVICE], None)
+            ),
+            patch.object(
+                wizard, "prompt_for_selection", side_effect=["mps", "main.default.lilly-anthropic"]
+            ),
+            patch.object(wizard, "all_users_can_use_schema", return_value=None),
+            patch.object(wizard, "print_warning") as warn,
+        ):
+            service = wizard._select_provider_service("claude", WORKSPACE, "token")
+        assert service == ANTHROPIC_SERVICE
+        assert not warn.called
 
     def test_cancelling_the_service_picker_returns_none(self):
         with (


### PR DESCRIPTION
An admin can pick a Model Provider Service whose schema isn't granted to the workspace, and developers who later pull that managed config hit "User does not have USE_SCHEMA on Schema <catalog>.<schema>" at launch. After the admin selects an MPS, check whether the `account users` group has USE_SCHEMA on its schema (via UC effective-permissions, so a catalog-level grant counts) and print a non-blocking warning if not.

It only warns: access may instead come from a team group the check can't see, and an inconclusive check (API unreachable) stays silent rather than crying wolf.

Also isolate ENABLE_MANAGED_AGENT_CONFIG in the test fixture so the dev's shell env can't change CLI behavior mid-test.

Co-authored-by: Isaac