### PR TITLE
Register managed-config MCP servers on launch

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -81,6 +81,7 @@ from ucode.managed_wizard import apply_command, setup_command, show_command
 from ucode.mcp import (
     MCP_CLIENTS,
     SKILLS_MCP_KIND,
+    apply_managed_mcp_servers,
     configure_mcp_command,
     configure_skills_mcp_command,
     purge_cross_workspace_mcp_residue,
@@ -1363,6 +1364,37 @@ def _print_budget_panel(recommendation: dict, tool: str, managed: dict | None = 
         console.print(panel)
 
 
+def _register_managed_mcp_servers(managed: dict, tool: str, state: dict) -> None:
+    """Apply the managed config's MCP servers to ``tool`` and persist what was registered.
+
+    Persisting under ``managed_mcp_servers`` lets the next launch diff against it, so a server the
+    admin later removes from the config is unregistered rather than left behind. A failure here never
+    blocks the launch — the agent still starts, just without the workspace's MCP servers.
+    """
+    try:
+        registered = apply_managed_mcp_servers(
+            managed,
+            tool,
+            state["workspace"],
+            state.get("profile"),
+            use_pat=bool(state.get("use_pat")),
+        )
+    except RuntimeError as exc:
+        print_warning(f"Could not register your workspace's MCP servers: {exc}")
+        return
+    # Persist even when empty so a config that dropped its last server clears the prior registration.
+    others = [
+        server
+        for server in (state.get("managed_mcp_servers") or [])
+        if isinstance(server, dict) and tool not in (server.get("clients") or [])
+    ]
+    state["managed_mcp_servers"] = others + registered
+    save_state(state)
+    if registered:
+        names = ", ".join(str(server["name"]) for server in registered)
+        print_note(f"Registered workspace MCP server(s) for {TOOL_SPECS[tool]['display']}: {names}")
+
+
 def _launch_tool(
     tool_name: str,
     ctx: typer.Context,
@@ -1566,6 +1598,12 @@ def _launch_tool(
             )
         if recommendation is not None:
             _print_budget_panel(recommendation, tool, managed)
+        # Register the managed config's MCP servers so they reach the agent's `/mcp` list. Nothing
+        # else on this path does it — the config only lists them — so without this a
+        # workspace-published server never shows up. Skipped under --skip-preflight (deliberately
+        # unmanaged) and --dry-run (writes nothing).
+        if managed is not None and not skip_preflight and not is_dry_run():
+            _register_managed_mcp_servers(managed, tool, state)
         print_success(f"Starting {TOOL_SPECS[tool]['display']}")
         launch_agent(tool, state, ctx.args)
     except RuntimeError as exc:

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -95,29 +95,47 @@ def _tracing_table_from_state(state: dict) -> str | None:
     return destination if isinstance(destination, str) and destination else None
 
 
-def _mcp_type_for_url(url: str) -> str | None:
-    """Classify a registered MCP server's URL into a managed-config type tag.
+def _mcp_server_from_url(url: str) -> tuple[str, str] | None:
+    """Derive a managed-config ``(name, type)`` entry from a registered server's resolved URL.
 
     ``state.json`` stores each MCP server's resolved URL but not its type, while the managed config
-    stores ``{name, type}`` and lets the developer's ucode rebuild the URL. The URL shape is the only
-    signal available, so map it back. Returns None for a URL that matches nothing known, so unknown
-    servers are skipped rather than published with a guessed type.
+    stores ``{name, type}`` and lets the developer's ucode rebuild the URL. So map the URL back to the
+    type *and* the identifier the ai-gateway ``McpServer.name`` field is meant to hold for that type
+    (a UC name for a UC service, a Genie space id for a genie space, a `<catalog>.<schema>` for
+    vector-search / uc-functions, a connection name for external). Deriving ``name`` from the URL —
+    rather than reusing the local display slug — is what lets the developer's ucode reconstruct the
+    URL on launch. Returns None for a URL that matches nothing reconstructable (e.g. an app's
+    off-workspace host), so those are skipped rather than published unusably.
     """
-    if "/ai-gateway/mcp-services/" in url:
-        return "mcp-service"
+    stripped = url.rstrip("/")
+    marker = "/ai-gateway/mcp-services/"
+    if marker in url:
+        # `.../mcp-services/<catalog>.<schema>.<svc>` — store the dash form the launch path expects.
+        service = url.split(marker, 1)[1].split("/", 1)[0]
+        return service.replace(".", "-"), "mcp-service"
     for fragment, tag in (
         ("/api/2.0/mcp/external/", "external"),
         ("/api/2.0/mcp/genie/", "genie-space"),
+    ):
+        if fragment in url:
+            # external -> connection name; genie -> space id. Both are the single trailing segment.
+            return url.split(fragment, 1)[1].split("/", 1)[0], tag
+    for fragment, tag in (
         ("/api/2.0/mcp/vector-search/", "vector-search"),
         ("/api/2.0/mcp/functions/", "uc-functions"),
     ):
         if fragment in url:
-            return tag
-    if url.rstrip("/").endswith("/api/2.0/mcp/sql"):
-        return "sql"
-    # Databricks apps are the residual case: an arbitrary app host with a /mcp suffix.
-    if url.rstrip("/").endswith("/mcp"):
-        return "app"
+            # `.../<catalog>/<schema>` — store the `<catalog>.<schema>` the launch path splits back.
+            rest = url.split(fragment, 1)[1].split("/")
+            if len(rest) >= 2 and rest[0] and rest[1]:
+                return f"{rest[0]}.{rest[1]}", tag
+            return None
+    if stripped.endswith("/api/2.0/mcp/sql"):
+        return "databricks-sql", "sql"
+    # Databricks apps are the residual case: an arbitrary app host with a /mcp suffix. Its host isn't
+    # reconstructable from the workspace + an id, so it can't be published to the managed config yet.
+    if stripped.endswith("/mcp"):
+        return None
     return None
 
 
@@ -130,6 +148,7 @@ def _mcp_servers_from_state(state: dict) -> list[dict]:
     from ucode.mcp import SKILLS_MCP_KIND
 
     servers: list[dict] = []
+    seen: set[str] = set()
     for entry in state.get("mcp_servers") or []:
         if not isinstance(entry, dict) or entry.get("kind") == SKILLS_MCP_KIND:
             continue
@@ -137,11 +156,18 @@ def _mcp_servers_from_state(state: dict) -> list[dict]:
         url = entry.get("url")
         if not isinstance(name, str) or not name or not isinstance(url, str):
             continue
-        tag = _mcp_type_for_url(url)
-        if tag is None:
-            print_warning(f"Skipping MCP server '{name}': unrecognized URL shape ({url}).")
+        resolved = _mcp_server_from_url(url)
+        if resolved is None:
+            print_warning(
+                f"Skipping MCP server '{name}': ucode can't publish it to a managed config "
+                f"(unrecognized or app-hosted URL: {url})."
+            )
             continue
-        servers.append({"name": name, "type": tag})
+        config_name, tag = resolved
+        if config_name in seen:
+            continue
+        seen.add(config_name)
+        servers.append({"name": config_name, "type": tag})
     return servers
 
 

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -960,7 +960,10 @@ def setup_command(from_file: str | None = None) -> int:
     if prompt_yes_no_default("Set up managed MCP servers for this workspace?", default=False):
         from ucode.mcp import configure_mcp_command
 
-        configure_mcp_command()
+        # Managed configs can't carry a Databricks app (its host isn't reconstructable from the
+        # workspace), so hide apps from the picker rather than let an admin pick one that is then
+        # dropped from the published config.
+        configure_mcp_command(exclude_sources={"apps"})
         mcp_servers = _mcp_servers_from_state(load_state())
         if mcp_servers:
             manifest["mcp_servers"] = mcp_servers

--- a/src/ucode/mcp.py
+++ b/src/ucode/mcp.py
@@ -1030,6 +1030,30 @@ def _mcp_server_clients(server: dict) -> list[str]:
     return [client for client in (server.get("clients") or []) if client in MCP_CLIENTS]
 
 
+def _is_app_mcp_server(server: dict) -> bool:
+    """Whether a registered server points at a Databricks app (an off-workspace ``*/mcp`` host).
+
+    Apps are the residual ``/mcp`` URL shape — everything else ucode registers is a known
+    workspace-relative path. Used to hide already-registered apps from the picker where they can't be
+    published (``ucode setup``)."""
+    url = server.get("url")
+    if not isinstance(url, str):
+        return False
+    stripped = url.rstrip("/")
+    known = (
+        "/ai-gateway/mcp-services/",
+        "/api/2.0/mcp/external/",
+        "/api/2.0/mcp/genie/",
+        "/api/2.0/mcp/vector-search/",
+        "/api/2.0/mcp/functions/",
+    )
+    if any(fragment in url for fragment in known):
+        return False
+    if stripped.endswith("/api/2.0/mcp/sql"):
+        return False
+    return stripped.endswith("/mcp")
+
+
 def managed_mcp_server_entry(name: str, mcp_type: str, workspace: str) -> tuple[str, str] | None:
     """Rebuild an ``(entry_name, url)`` pair from a managed config's ``{name, type}`` entry.
 
@@ -1590,12 +1614,18 @@ MCP_SEARCH_SOURCES = (
 )
 
 
-def prompt_for_mcp_search_sources() -> set[str] | None:
+def prompt_for_mcp_search_sources(exclude_sources: set[str] | None = None) -> set[str] | None:
     """First wizard step: choose which sources to search. Returns the set of
-    selected source keys, or `None` if the user cancelled (Ctrl-C)."""
+    selected source keys, or `None` if the user cancelled (Ctrl-C).
+
+    ``exclude_sources`` drops source keys the caller can't use — e.g. `ucode setup` excludes
+    ``apps`` because a managed config can't carry an app's off-workspace host, so offering it would
+    let an admin pick a server that is then silently dropped."""
+    excluded = exclude_sources or set()
     choices = [
         questionary.Choice(title=label, value=key, checked=checked)
         for key, label, checked in MCP_SEARCH_SOURCES
+        if key not in excluded
     ]
     selection = _scrolling_checkbox(
         "Search for:",
@@ -1652,7 +1682,15 @@ def setup_mcp_clients(state: dict, section: str) -> tuple[str, str | None, list[
     return workspace, profile, clients
 
 
-def configure_mcp_command(location: str | None = None, services: set[str] | None = None) -> int:
+def configure_mcp_command(
+    location: str | None = None,
+    services: set[str] | None = None,
+    *,
+    exclude_sources: set[str] | None = None,
+) -> int:
+    """Interactive MCP picker. ``exclude_sources`` hides search sources the caller can't use —
+    `ucode setup` passes ``{"apps"}`` because a managed config can't carry an app's off-workspace
+    host, so an app picked here would be silently dropped from the published config."""
     if services is not None and location is None:
         # `--services` works standalone with full names (`system.ai.github`): the
         # `<catalog>.<schema>` to configure is derived from them. Bare short names
@@ -1692,18 +1730,23 @@ def configure_mcp_command(location: str | None = None, services: set[str] | None
             print_success("Saved")
         return 0
 
+    excluded_sources = exclude_sources or set()
     original_mcp_servers: list[dict] = list(state.get("mcp_servers") or [])
     # Skills connections are managed by `configure skills`, so keep them out of
     # the picker and carry them through untouched.
     skills_servers = _skills_entries(original_mcp_servers)
     picker_servers = [s for s in original_mcp_servers if s.get("kind") != SKILLS_MCP_KIND]
+    # Drop already-registered servers from an excluded source too (e.g. a previously-added app under
+    # `ucode setup`), so the picker never shows a server the caller couldn't re-add.
+    if "apps" in excluded_sources:
+        picker_servers = [s for s in picker_servers if not _is_app_mcp_server(s)]
     original_by_name = _servers_by_name(picker_servers)
 
     # Two-step wizard: (1) choose which sources to search, (2) pick servers from
     # the results. Pressing Left (←) in the picker returns to step 1, so the user
     # can revise their source selection without restarting the command.
     while True:
-        sources = prompt_for_mcp_search_sources()
+        sources = prompt_for_mcp_search_sources(exclude_sources=excluded_sources)
         if sources is None:
             return 0
         discovered = _discover_selected_mcp_sources(workspace, profile, sources)

--- a/src/ucode/mcp.py
+++ b/src/ucode/mcp.py
@@ -351,7 +351,12 @@ def remove_client_mcp_server(client: str, name: str) -> list[str]:
 
 def revert_mcp_configs(state: dict) -> dict[str, bool]:
     results: dict[str, bool] = {}
-    for server in state.get("mcp_servers") or []:
+    # Both the developer's own servers and any registered from the workspace's managed config, so a
+    # revert leaves no ucode-added MCP server behind in an agent's config.
+    all_servers = list(state.get("mcp_servers") or []) + list(
+        state.get("managed_mcp_servers") or []
+    )
+    for server in all_servers:
         name = server.get("name")
         if not isinstance(name, str) or not name:
             continue
@@ -1023,6 +1028,89 @@ def prompt_for_mcp_server_choices(
 
 def _mcp_server_clients(server: dict) -> list[str]:
     return [client for client in (server.get("clients") or []) if client in MCP_CLIENTS]
+
+
+# Managed-config MCP `type` tags whose URL can be rebuilt from the stored `{name, type}` alone.
+# Other tags (genie-space, app, vector-search, uc-functions) need an id/host the manifest doesn't
+# carry, so they are skipped on launch until the manifest stores enough to reconstruct them.
+_MANAGED_MCP_SUPPORTED_TYPES = ("sql", "external", "mcp-service")
+
+
+def managed_mcp_server_url(name: str, mcp_type: str, workspace: str) -> str | None:
+    """Rebuild a launchable MCP URL from a managed config's ``{name, type}`` entry.
+
+    Returns None for a type this can't reconstruct from name+type alone, so the caller skips it
+    rather than registering a broken server. Mirrors the URL shapes :func:`_resolve_mcp_selection`
+    builds for the interactive picker.
+    """
+    if mcp_type == "sql":
+        return f"{workspace}/api/2.0/mcp/sql"
+    if mcp_type == "external":
+        return f"{workspace}/api/2.0/mcp/external/{name}"
+    if mcp_type == "mcp-service":
+        # The manifest stores the service in dash form (`system-ai-dbsql`), matching the entry name
+        # the interactive path registers; the URL wants the UC dotted form. Only the catalog and
+        # schema separators (the first two dashes) become dots — the service name keeps its own.
+        parts = name.split("-", 2)
+        if len(parts) != 3:
+            return None
+        return build_mcp_service_url(workspace, ".".join(parts))
+    return None
+
+
+def apply_managed_mcp_servers(
+    managed: dict, tool: str, workspace: str, profile: str | None = None, *, use_pat: bool = False
+) -> list[dict]:
+    """Register the managed config's MCP servers with ``tool`` so they reach its `/mcp` list.
+
+    The managed config only lists ``{name, type}`` entries; nothing else on the launch path turns
+    them into agent MCP registrations, so without this a workspace-published server never shows up.
+    Reconstructs the URL for each supported type (see :data:`_MANAGED_MCP_SUPPORTED_TYPES`), diffs
+    against what ucode previously registered, and applies the change for the launching tool only.
+
+    Returns the server dicts registered (for state persistence); an empty list when the config names
+    none, or names only types that can't yet be reconstructed.
+    """
+    if tool not in MCP_CLIENTS:
+        return []
+    entries = managed.get("mcp_servers")
+    if not isinstance(entries, list):
+        return []
+    working: list[dict] = []
+    seen: set[str] = set()
+    skipped: list[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        mcp_type = entry.get("type")
+        if not isinstance(name, str) or not name or not isinstance(mcp_type, str):
+            continue
+        url = managed_mcp_server_url(name, mcp_type, workspace)
+        if url is None:
+            skipped.append(f"{name} ({mcp_type})")
+            continue
+        if name in seen:
+            continue
+        seen.add(name)
+        working.append({"name": name, "url": url, "auth": "proxy", "clients": [tool]})
+    if skipped:
+        print_warning(
+            "Skipping managed MCP server(s) ucode can't yet auto-register from the workspace "
+            f"config: {', '.join(skipped)}. Add them with `ucode configure mcp`."
+        )
+    if not working:
+        return []
+    # Diff against the managed servers ucode registered on a prior launch so a removed entry is
+    # unregistered and an unchanged one is a no-op. Only this tool's managed servers are considered.
+    state = load_state()
+    previous = [
+        server
+        for server in (state.get("managed_mcp_servers") or [])
+        if isinstance(server, dict) and tool in (server.get("clients") or [])
+    ]
+    apply_mcp_server_changes(previous, working, [tool], workspace, profile, use_pat=use_pat)
+    return working
 
 
 def _resolve_mcp_selection(

--- a/src/ucode/mcp.py
+++ b/src/ucode/mcp.py
@@ -1030,31 +1030,47 @@ def _mcp_server_clients(server: dict) -> list[str]:
     return [client for client in (server.get("clients") or []) if client in MCP_CLIENTS]
 
 
-# Managed-config MCP `type` tags whose URL can be rebuilt from the stored `{name, type}` alone.
-# Other tags (genie-space, app, vector-search, uc-functions) need an id/host the manifest doesn't
-# carry, so they are skipped on launch until the manifest stores enough to reconstruct them.
-_MANAGED_MCP_SUPPORTED_TYPES = ("sql", "external", "mcp-service")
+def managed_mcp_server_entry(name: str, mcp_type: str, workspace: str) -> tuple[str, str] | None:
+    """Rebuild an ``(entry_name, url)`` pair from a managed config's ``{name, type}`` entry.
 
+    ``entry_name`` is the identifier the server is registered under with the agent (dots stripped,
+    since the agent CLIs reject them); ``url`` is what the proxy forwards to. Returns None for a
+    type/name this can't reconstruct, so the caller skips it rather than registering a broken server.
+    Mirrors the shapes :func:`_resolve_mcp_selection` builds for the interactive picker, so a managed
+    and a locally-configured copy of the same server land on the same name.
 
-def managed_mcp_server_url(name: str, mcp_type: str, workspace: str) -> str | None:
-    """Rebuild a launchable MCP URL from a managed config's ``{name, type}`` entry.
-
-    Returns None for a type this can't reconstruct from name+type alone, so the caller skips it
-    rather than registering a broken server. Mirrors the URL shapes :func:`_resolve_mcp_selection`
-    builds for the interactive picker.
+    The ai-gateway ``McpServer.name`` field is interpreted per ``type`` (see the proto): a UC name for
+    a UC service, a Genie space id for a genie space, a connection name for external, and — as ucode
+    serializes them — a `<catalog>.<schema>` for vector-search / uc-functions.
     """
     if mcp_type == "sql":
-        return f"{workspace}/api/2.0/mcp/sql"
+        return "databricks-sql", f"{workspace}/api/2.0/mcp/sql"
     if mcp_type == "external":
-        return f"{workspace}/api/2.0/mcp/external/{name}"
+        return name, f"{workspace}/api/2.0/mcp/external/{name}"
     if mcp_type == "mcp-service":
-        # The manifest stores the service in dash form (`system-ai-dbsql`), matching the entry name
-        # the interactive path registers; the URL wants the UC dotted form. Only the catalog and
-        # schema separators (the first two dashes) become dots — the service name keeps its own.
+        # Stored in dash form (`system-ai-dbsql`), which is already the registered name; the URL wants
+        # the UC dotted form. Only the catalog and schema separators (first two dashes) become dots —
+        # the service name keeps its own dashes/underscores.
         parts = name.split("-", 2)
         if len(parts) != 3:
             return None
-        return build_mcp_service_url(workspace, ".".join(parts))
+        return name, build_mcp_service_url(workspace, ".".join(parts))
+    if mcp_type == "genie-space":
+        # `name` is the Genie space id (per the proto); register under the id-based name the
+        # interactive path falls back to, and point the URL at the space.
+        return f"databricks-genie-{name}", f"{workspace}/api/2.0/mcp/genie/{name}"
+    if mcp_type in ("vector-search", "uc-functions"):
+        # `name` is a `<catalog>.<schema>`; the URL is workspace-relative on that pair, and the
+        # registered name is the same dot-free slug the interactive path uses.
+        catalog, _, schema = name.partition(".")
+        if not catalog or not schema or "." in schema:
+            return None
+        url_path = "vector-search" if mcp_type == "vector-search" else "functions"
+        name_prefix = (
+            "databricks-vector-search" if mcp_type == "vector-search" else "databricks-functions"
+        )
+        entry_name = _catalog_schema_server_name(name_prefix, catalog, schema, set())
+        return entry_name, f"{workspace}/api/2.0/mcp/{url_path}/{catalog}/{schema}"
     return None
 
 
@@ -1065,8 +1081,9 @@ def apply_managed_mcp_servers(
 
     The managed config only lists ``{name, type}`` entries; nothing else on the launch path turns
     them into agent MCP registrations, so without this a workspace-published server never shows up.
-    Reconstructs the URL for each supported type (see :data:`_MANAGED_MCP_SUPPORTED_TYPES`), diffs
-    against what ucode previously registered, and applies the change for the launching tool only.
+    Reconstructs each entry's ``(name, url)`` (see :func:`managed_mcp_server_entry`), diffs against
+    what ucode previously registered, and applies the change for the launching tool only. Entries
+    whose URL can't be rebuilt (e.g. ``app``, which needs an off-workspace host) are skipped.
 
     Returns the server dicts registered (for state persistence); an empty list when the config names
     none, or names only types that can't yet be reconstructed.
@@ -1086,14 +1103,15 @@ def apply_managed_mcp_servers(
         mcp_type = entry.get("type")
         if not isinstance(name, str) or not name or not isinstance(mcp_type, str):
             continue
-        url = managed_mcp_server_url(name, mcp_type, workspace)
-        if url is None:
+        resolved = managed_mcp_server_entry(name, mcp_type, workspace)
+        if resolved is None:
             skipped.append(f"{name} ({mcp_type})")
             continue
-        if name in seen:
+        entry_name, url = resolved
+        if entry_name in seen:
             continue
-        seen.add(name)
-        working.append({"name": name, "url": url, "auth": "proxy", "clients": [tool]})
+        seen.add(entry_name)
+        working.append({"name": entry_name, "url": url, "auth": "proxy", "clients": [tool]})
     if skipped:
         print_warning(
             "Skipping managed MCP server(s) ucode can't yet auto-register from the workspace "

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -72,32 +72,46 @@ class TestTracingReadback:
         assert wizard._tracing_table_from_state({"tracing": "on"}) is None
 
 
-class TestMcpUrlClassification:
+class TestMcpServerFromUrl:
     @pytest.mark.parametrize(
         ("url", "expected"),
         [
-            ("https://ws.example.com/ai-gateway/mcp-services/system.ai.github", "mcp-service"),
-            ("https://ws.example.com/api/2.0/mcp/external/jira-prod", "external"),
-            ("https://ws.example.com/api/2.0/mcp/genie/01ef", "genie-space"),
-            ("https://ws.example.com/api/2.0/mcp/vector-search/main/default", "vector-search"),
-            ("https://ws.example.com/api/2.0/mcp/functions/main/default", "uc-functions"),
-            ("https://ws.example.com/api/2.0/mcp/sql", "sql"),
-            ("https://mcp-myapp-123.aws.databricksapps.com/mcp", "app"),
+            # mcp-service stores the dash form the launch path rebuilds the dotted URL from.
+            (
+                "https://ws.example.com/ai-gateway/mcp-services/system.ai.github",
+                ("system-ai-github", "mcp-service"),
+            ),
+            ("https://ws.example.com/api/2.0/mcp/external/jira-prod", ("jira-prod", "external")),
+            ("https://ws.example.com/api/2.0/mcp/genie/01ef", ("01ef", "genie-space")),
+            # vector-search / uc-functions store `<catalog>.<schema>`, not the local display slug.
+            (
+                "https://ws.example.com/api/2.0/mcp/vector-search/my_cat/my_schema",
+                ("my_cat.my_schema", "vector-search"),
+            ),
+            (
+                "https://ws.example.com/api/2.0/mcp/functions/dev_cat/dev_fixture",
+                ("dev_cat.dev_fixture", "uc-functions"),
+            ),
+            ("https://ws.example.com/api/2.0/mcp/sql", ("databricks-sql", "sql")),
         ],
     )
     def test_known_urls(self, url, expected):
-        assert wizard._mcp_type_for_url(url) == expected
+        assert wizard._mcp_server_from_url(url) == expected
 
-    def test_trailing_slash_is_tolerated(self):
-        assert wizard._mcp_type_for_url("https://ws.example.com/api/2.0/mcp/sql/") == "sql"
+    def test_apps_are_not_publishable(self):
+        # An app's host isn't reconstructable from the workspace + an id, so it can't be published.
+        assert (
+            wizard._mcp_server_from_url("https://mcp-myapp-123.aws.databricksapps.com/mcp") is None
+        )
 
     def test_unknown_url_yields_none(self):
-        # Better to skip a server than publish it with a guessed type.
-        assert wizard._mcp_type_for_url("https://example.com/something/else") is None
+        assert wizard._mcp_server_from_url("https://example.com/something/else") is None
 
-    def test_sql_is_not_confused_for_app(self):
-        # Both end in a fixed segment; sql must win since it is checked first.
-        assert wizard._mcp_type_for_url("https://ws.example.com/api/2.0/mcp/sql") == "sql"
+    def test_vector_search_needs_both_catalog_and_schema(self):
+        assert (
+            wizard._mcp_server_from_url("https://ws.example.com/api/2.0/mcp/functions/onlycat")
+            is None
+        )
 
 
 class TestMcpServersFromState:
@@ -111,9 +125,25 @@ class TestMcpServersFromState:
                 {"name": "databricks-sql", "url": f"{WORKSPACE}/api/2.0/mcp/sql"},
             ]
         }
+        # The published name comes from the URL (the identifier the server field holds), not the
+        # local display name.
         assert wizard._mcp_servers_from_state(state) == [
-            {"name": "databricks-github", "type": "mcp-service"},
+            {"name": "system-ai-github", "type": "mcp-service"},
             {"name": "databricks-sql", "type": "sql"},
+        ]
+
+    def test_publishes_catalog_schema_for_uc_functions(self):
+        # The lossy local slug is replaced with the dotted catalog.schema the launch path can split.
+        state = {
+            "mcp_servers": [
+                {
+                    "name": "databricks-functions-dev-cat-dev-fixture",
+                    "url": f"{WORKSPACE}/api/2.0/mcp/functions/dev_cat/dev_fixture",
+                },
+            ]
+        }
+        assert wizard._mcp_servers_from_state(state) == [
+            {"name": "dev_cat.dev_fixture", "type": "uc-functions"},
         ]
 
     def test_skips_the_skills_registry_entry(self):
@@ -133,8 +163,13 @@ class TestMcpServersFromState:
         }
         assert wizard._mcp_servers_from_state(state) == [{"name": "databricks-sql", "type": "sql"}]
 
-    def test_skips_unclassifiable_servers(self):
-        state = {"mcp_servers": [{"name": "mystery", "url": "https://example.com/nope"}]}
+    def test_skips_apps_and_unclassifiable_servers(self):
+        state = {
+            "mcp_servers": [
+                {"name": "mystery", "url": "https://example.com/nope"},
+                {"name": "databricks-app-x", "url": "https://x-1.databricksapps.com/mcp"},
+            ]
+        }
         assert wizard._mcp_servers_from_state(state) == []
 
     def test_skips_entries_missing_name_or_url(self):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2337,34 +2337,58 @@ class TestPurgeCrossWorkspaceSkillsEntry:
         assert state["mcp_servers"] == []
 
 
-class TestManagedMcpServerUrl:
+class TestManagedMcpServerEntry:
     def test_sql(self):
-        assert mcp.managed_mcp_server_url("databricks-sql", "sql", WS) == f"{WS}/api/2.0/mcp/sql"
+        assert mcp.managed_mcp_server_entry("databricks-sql", "sql", WS) == (
+            "databricks-sql",
+            f"{WS}/api/2.0/mcp/sql",
+        )
 
     def test_external_uses_the_connection_name(self):
-        assert (
-            mcp.managed_mcp_server_url("jira-prod", "external", WS)
-            == f"{WS}/api/2.0/mcp/external/jira-prod"
+        assert mcp.managed_mcp_server_entry("jira-prod", "external", WS) == (
+            "jira-prod",
+            f"{WS}/api/2.0/mcp/external/jira-prod",
         )
 
     def test_mcp_service_undashes_catalog_and_schema_only(self):
         # The manifest stores the dash form; only the first two dashes (catalog.schema) become dots,
-        # so a service name keeps its own dashes/underscores.
-        assert (
-            mcp.managed_mcp_server_url("system-ai-dbsql", "mcp-service", WS)
-            == f"{WS}/ai-gateway/mcp-services/system.ai.dbsql"
+        # so a service name keeps its own dashes/underscores. The entry name stays the dash form.
+        assert mcp.managed_mcp_server_entry("system-ai-dbsql", "mcp-service", WS) == (
+            "system-ai-dbsql",
+            f"{WS}/ai-gateway/mcp-services/system.ai.dbsql",
         )
-        assert (
-            mcp.managed_mcp_server_url("system-ai-google_calendar", "mcp-service", WS)
-            == f"{WS}/ai-gateway/mcp-services/system.ai.google_calendar"
+        assert mcp.managed_mcp_server_entry("system-ai-google_calendar", "mcp-service", WS) == (
+            "system-ai-google_calendar",
+            f"{WS}/ai-gateway/mcp-services/system.ai.google_calendar",
         )
 
     def test_mcp_service_needs_three_parts(self):
-        assert mcp.managed_mcp_server_url("justtwo-parts", "mcp-service", WS) is None
+        assert mcp.managed_mcp_server_entry("justtwo-parts", "mcp-service", WS) is None
 
-    def test_unsupported_types_return_none(self):
-        for mcp_type in ("genie-space", "app", "vector-search", "uc-functions", "bogus"):
-            assert mcp.managed_mcp_server_url("x", mcp_type, WS) is None
+    def test_genie_space_uses_the_space_id(self):
+        assert mcp.managed_mcp_server_entry("01ef9a", "genie-space", WS) == (
+            "databricks-genie-01ef9a",
+            f"{WS}/api/2.0/mcp/genie/01ef9a",
+        )
+
+    def test_uc_functions_splits_catalog_schema(self):
+        # The dot-free entry name is a slug; the URL uses the raw catalog/schema path segments.
+        entry_name, url = mcp.managed_mcp_server_entry("dev_cat.dev_fixture", "uc-functions", WS)
+        assert "." not in entry_name
+        assert url == f"{WS}/api/2.0/mcp/functions/dev_cat/dev_fixture"
+
+    def test_vector_search_splits_catalog_schema(self):
+        entry_name, url = mcp.managed_mcp_server_entry("my_cat.my_schema", "vector-search", WS)
+        assert "." not in entry_name
+        assert url == f"{WS}/api/2.0/mcp/vector-search/my_cat/my_schema"
+
+    def test_catalog_schema_needs_exactly_two_parts(self):
+        assert mcp.managed_mcp_server_entry("onlycatalog", "uc-functions", WS) is None
+        assert mcp.managed_mcp_server_entry("a.b.c", "uc-functions", WS) is None
+
+    def test_app_and_unknown_types_return_none(self):
+        for mcp_type in ("app", "bogus"):
+            assert mcp.managed_mcp_server_entry("x", mcp_type, WS) is None
 
 
 class TestApplyManagedMcpServers:
@@ -2390,18 +2414,37 @@ class TestApplyManagedMcpServers:
         assert {s["name"] for s in registered} == {"system-ai-dbsql", "databricks-sql"}
         assert all(s["clients"] == ["claude"] for s in registered)
 
+    def test_registers_genie_and_catalog_schema_types(self, monkeypatch):
+        applied = {}
+        monkeypatch.setattr(mcp, "load_state", lambda: {})
+        monkeypatch.setattr(
+            mcp,
+            "apply_mcp_server_changes",
+            lambda prev, working, *a, **k: applied.update({"working": working}),
+        )
+        managed = self._managed(
+            {"name": "01ef9a", "type": "genie-space"},
+            {"name": "cat.sch", "type": "uc-functions"},
+        )
+        registered = mcp.apply_managed_mcp_servers(managed, "claude", WS)
+        names = {s["name"] for s in registered}
+        assert "databricks-genie-01ef9a" in names
+        assert any(n.startswith("databricks-functions-") for n in names)
+
     def test_skips_and_warns_on_unsupported_types(self, monkeypatch):
+        # `app` is the remaining type ucode can't rebuild from the config (needs an off-workspace
+        # host); it is skipped with a warning while the supported entry still registers.
         warned: list[str] = []
         monkeypatch.setattr(mcp, "load_state", lambda: {})
         monkeypatch.setattr(mcp, "apply_mcp_server_changes", lambda *a, **k: None)
         monkeypatch.setattr(mcp, "print_warning", lambda msg: warned.append(msg))
         managed = self._managed(
             {"name": "system-ai-dbsql", "type": "mcp-service"},
-            {"name": "my-space", "type": "genie-space"},
+            {"name": "my-app", "type": "app"},
         )
         registered = mcp.apply_managed_mcp_servers(managed, "claude", WS)
         assert {s["name"] for s in registered} == {"system-ai-dbsql"}
-        assert warned and "my-space" in warned[0]
+        assert warned and "my-app" in warned[0]
 
     def test_diffs_against_this_tools_previously_registered_servers(self, monkeypatch):
         seen_prev = {}
@@ -2435,7 +2478,7 @@ class TestApplyManagedMcpServers:
         )
         monkeypatch.setattr(mcp, "print_warning", lambda msg: None)
         registered = mcp.apply_managed_mcp_servers(
-            self._managed({"name": "s", "type": "genie-space"}), "claude", WS
+            self._managed({"name": "s", "type": "app"}), "claude", WS
         )
         assert registered == []
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -572,7 +572,9 @@ def _patch_mcp_choices(monkeypatch, *values: str, categories: set[str] | None = 
     # `categories`, which are unioned in.
     default_sources = {"external", "apps", "mcp-services", "genie"}
     selected_sources = default_sources | (categories or set())
-    monkeypatch.setattr(mcp, "prompt_for_mcp_search_sources", lambda: selected_sources)
+    monkeypatch.setattr(
+        mcp, "prompt_for_mcp_search_sources", lambda exclude_sources=None: selected_sources
+    )
     # Stub the always-on discoveries so configure_mcp_command tests don't hit
     # real APIs. Individual tests override these after calling the helper.
     monkeypatch.setattr(mcp, "discover_mcp_service_names", lambda workspace, profile=None: [])
@@ -675,7 +677,7 @@ class TestConfigureMcpWizardNavigation:
 
         source_calls: list[int] = []
 
-        def fake_sources():
+        def fake_sources(exclude_sources=None):
             source_calls.append(1)
             return {"external", "apps", "mcp-services", "genie"}
 
@@ -700,7 +702,7 @@ class TestConfigureMcpWizardNavigation:
         monkeypatch.setattr(mcp, "ensure_databricks_auth", lambda workspace, profile=None: None)
         monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude"])
         # Cancelling the first screen (None) returns without discovering anything.
-        monkeypatch.setattr(mcp, "prompt_for_mcp_search_sources", lambda: None)
+        monkeypatch.setattr(mcp, "prompt_for_mcp_search_sources", lambda exclude_sources=None: None)
         monkeypatch.setattr(
             mcp,
             "prompt_for_mcp_server_choices",
@@ -1139,7 +1141,7 @@ class TestConfigureMcpCommand:
         monkeypatch.setattr(
             mcp,
             "prompt_for_mcp_search_sources",
-            lambda: {"external", "apps", "mcp-services", "genie"},
+            lambda exclude_sources=None: {"external", "apps", "mcp-services", "genie"},
         )
         monkeypatch.setattr(
             mcp,
@@ -2493,3 +2495,47 @@ class TestApplyManagedMcpServers:
             self._managed({"name": "databricks-sql", "type": "sql"}), "not-a-client", WS
         )
         assert registered == []
+
+
+class TestPromptForMcpSearchSourcesExclusion:
+    def _values(self, monkeypatch, exclude):
+        captured: dict = {}
+
+        class FakePrompt:
+            def ask(self):
+                return []
+
+        def fake_checkbox(*args, **kwargs):
+            captured["choices"] = kwargs["choices"]
+            return FakePrompt()
+
+        monkeypatch.setattr(mcp, "_scrolling_checkbox", fake_checkbox)
+        mcp.prompt_for_mcp_search_sources(exclude_sources=exclude)
+        return [c.value for c in captured["choices"]]
+
+    def test_apps_excluded(self, monkeypatch):
+        values = self._values(monkeypatch, {"apps"})
+        assert "apps" not in values
+        assert "external" in values and "genie" in values
+
+    def test_nothing_excluded_by_default(self, monkeypatch):
+        assert "apps" in self._values(monkeypatch, None)
+
+
+class TestIsAppMcpServer:
+    def test_app_host_is_an_app(self):
+        assert mcp._is_app_mcp_server({"url": "https://myapp-1.databricksapps.com/mcp"}) is True
+
+    def test_workspace_relative_shapes_are_not_apps(self):
+        for url in (
+            f"{WS}/api/2.0/mcp/sql",
+            f"{WS}/api/2.0/mcp/external/jira",
+            f"{WS}/api/2.0/mcp/genie/01ef",
+            f"{WS}/api/2.0/mcp/vector-search/main/default",
+            f"{WS}/api/2.0/mcp/functions/main/default",
+            f"{WS}/ai-gateway/mcp-services/system.ai.dbsql",
+        ):
+            assert mcp._is_app_mcp_server({"url": url}) is False
+
+    def test_non_string_url_is_not_an_app(self):
+        assert mcp._is_app_mcp_server({}) is False

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2335,3 +2335,118 @@ class TestPurgeCrossWorkspaceSkillsEntry:
 
         assert removed == [("claude", mcp.SKILLS_MCP_SERVER_NAME)]
         assert state["mcp_servers"] == []
+
+
+class TestManagedMcpServerUrl:
+    def test_sql(self):
+        assert mcp.managed_mcp_server_url("databricks-sql", "sql", WS) == f"{WS}/api/2.0/mcp/sql"
+
+    def test_external_uses_the_connection_name(self):
+        assert (
+            mcp.managed_mcp_server_url("jira-prod", "external", WS)
+            == f"{WS}/api/2.0/mcp/external/jira-prod"
+        )
+
+    def test_mcp_service_undashes_catalog_and_schema_only(self):
+        # The manifest stores the dash form; only the first two dashes (catalog.schema) become dots,
+        # so a service name keeps its own dashes/underscores.
+        assert (
+            mcp.managed_mcp_server_url("system-ai-dbsql", "mcp-service", WS)
+            == f"{WS}/ai-gateway/mcp-services/system.ai.dbsql"
+        )
+        assert (
+            mcp.managed_mcp_server_url("system-ai-google_calendar", "mcp-service", WS)
+            == f"{WS}/ai-gateway/mcp-services/system.ai.google_calendar"
+        )
+
+    def test_mcp_service_needs_three_parts(self):
+        assert mcp.managed_mcp_server_url("justtwo-parts", "mcp-service", WS) is None
+
+    def test_unsupported_types_return_none(self):
+        for mcp_type in ("genie-space", "app", "vector-search", "uc-functions", "bogus"):
+            assert mcp.managed_mcp_server_url("x", mcp_type, WS) is None
+
+
+class TestApplyManagedMcpServers:
+    def _managed(self, *servers):
+        return {"mcp_servers": list(servers)}
+
+    def test_registers_supported_servers_for_the_launching_tool(self, monkeypatch):
+        applied = {}
+        monkeypatch.setattr(mcp, "load_state", lambda: {})
+        monkeypatch.setattr(
+            mcp,
+            "apply_mcp_server_changes",
+            lambda prev, working, clients, ws, profile=None, **kw: applied.update(
+                {"working": working, "clients": clients, "prev": prev}
+            ),
+        )
+        managed = self._managed(
+            {"name": "system-ai-dbsql", "type": "mcp-service"},
+            {"name": "databricks-sql", "type": "sql"},
+        )
+        registered = mcp.apply_managed_mcp_servers(managed, "claude", WS)
+        assert applied["clients"] == ["claude"]
+        assert {s["name"] for s in registered} == {"system-ai-dbsql", "databricks-sql"}
+        assert all(s["clients"] == ["claude"] for s in registered)
+
+    def test_skips_and_warns_on_unsupported_types(self, monkeypatch):
+        warned: list[str] = []
+        monkeypatch.setattr(mcp, "load_state", lambda: {})
+        monkeypatch.setattr(mcp, "apply_mcp_server_changes", lambda *a, **k: None)
+        monkeypatch.setattr(mcp, "print_warning", lambda msg: warned.append(msg))
+        managed = self._managed(
+            {"name": "system-ai-dbsql", "type": "mcp-service"},
+            {"name": "my-space", "type": "genie-space"},
+        )
+        registered = mcp.apply_managed_mcp_servers(managed, "claude", WS)
+        assert {s["name"] for s in registered} == {"system-ai-dbsql"}
+        assert warned and "my-space" in warned[0]
+
+    def test_diffs_against_this_tools_previously_registered_servers(self, monkeypatch):
+        seen_prev = {}
+        monkeypatch.setattr(
+            mcp,
+            "load_state",
+            lambda: {
+                "managed_mcp_servers": [
+                    {"name": "old", "url": "u", "clients": ["claude"]},
+                    {"name": "other-tool", "url": "u", "clients": ["codex"]},
+                ]
+            },
+        )
+        monkeypatch.setattr(
+            mcp,
+            "apply_mcp_server_changes",
+            lambda prev, working, *a, **k: seen_prev.update({"prev": prev}),
+        )
+        mcp.apply_managed_mcp_servers(
+            self._managed({"name": "databricks-sql", "type": "sql"}), "claude", WS
+        )
+        # Only this tool's prior servers form the diff baseline; codex's are left alone.
+        assert [s["name"] for s in seen_prev["prev"]] == ["old"]
+
+    def test_no_supported_servers_does_nothing(self, monkeypatch):
+        monkeypatch.setattr(mcp, "load_state", lambda: {})
+        monkeypatch.setattr(
+            mcp,
+            "apply_mcp_server_changes",
+            lambda *a, **k: pytest.fail("should not apply when nothing is registerable"),
+        )
+        monkeypatch.setattr(mcp, "print_warning", lambda msg: None)
+        registered = mcp.apply_managed_mcp_servers(
+            self._managed({"name": "s", "type": "genie-space"}), "claude", WS
+        )
+        assert registered == []
+
+    def test_mcp_only_client_returns_empty(self, monkeypatch):
+        # A tool that isn't an MCP client can't have servers registered against it.
+        monkeypatch.setattr(
+            mcp,
+            "apply_mcp_server_changes",
+            lambda *a, **k: pytest.fail("should not apply for a non-client tool"),
+        )
+        registered = mcp.apply_managed_mcp_servers(
+            self._managed({"name": "databricks-sql", "type": "sql"}), "not-a-client", WS
+        )
+        assert registered == []


### PR DESCRIPTION
  A workspace's managed config lists MCP servers, but nothing on the launch path ever registered them with
  the agent — `resolve_state` handles models/provider but had no MCP handling, and the servers were only
  shown in the summary as "(pending)". So a workspace-published MCP server never reached the agent's `/mcp`
  list.

  This registers them on launch, reconstructing each server's URL from its `{name, type}` and applying it
  for the launching tool via the same path `configure mcp` uses.

  **Supported types** (every one whose URL is workspace-relative):
  - `sql`, `external`, `mcp-service`
  - `genie-space` (stores the space id), `vector-search` / `uc-functions` (store `<catalog>.<schema>`)

  The fix for genie/vector-search/uc-functions was in what the admin serializer stores: it used to publish
  the local *display slug* (e.g. `databricks-functions-dev-cat-fixture` — underscores flattened to hyphens,
  catalog/schema boundary lost), which the launch path couldn't reverse. Now it stores the identifier the
  ai-gateway `McpServer.name` field is documented to hold per type. No server-side change needed — the
  proto already models this.

  **Apps** are the one type a managed config can't carry (the host is off-workspace, not reconstructable
  from the workspace + an id). They're skipped by the serializer, and `ucode setup`'s picker now hides the
  "Databricks apps" source so an admin never picks one that gets silently dropped. The developer `ucode
  configure mcp` path is unchanged — apps still work there.

  Registered servers are persisted under `managed_mcp_servers` so the next launch diffs against them (a
  server the admin removes gets unregistered), and `revert_mcp_configs` clears them too.

  Verified end-to-end against a live workspace: all six reconstructable types register with correct proxy
  URLs, including the `dev_elaine_wang_...` uc-functions case that was broken before.

Co-authored-by: Isaac