### PR TITLE
setup: consolidate managed-settings.json into managed-state.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,10 @@ the config applies machine-wide or per user. Claude Code is asked one model per 
 skipped. It then offers tracing, managed MCP servers, skills, and a spend-based budget policy that
 switches the default agent and model as the workspace burns through a budget.
 
-The result is written to `~/.ucode/managed-settings.json`, which `ucode apply` publishes to the
-workspace. Your own agent configs are left alone, with one exception: answering yes to tracing, MCP
+The result is written to `~/.ucode/managed-state.json` — the one local managed-config file — which
+`ucode apply` publishes to the workspace. Because a launch reads that same file, `ucode --dry-run`
+tries the authored config on this machine before it is published, without fetching or overwriting
+it. Your own agent configs are left alone, with one exception: answering yes to tracing, MCP
 servers, or skills runs the matching `ucode configure` step, which does configure this machine.
 
 ```bash
@@ -196,8 +198,11 @@ ucode setup show
 # Walk the flow without writing anything.
 ucode setup --dry-run
 
+# Try the authored config locally before publishing (no fetch, no overwrite).
+ucode --dry-run
+
 # Skip the prompts and load a hand-written config instead (validated before saving).
-ucode setup --from-file ./managed-settings.json
+ucode setup --from-file ./managed-config.json
 ```
 
 Once the manifest looks right, publish it:
@@ -259,7 +264,7 @@ pick the new config up on their next ucode run.
 | `~/.copilot/.env` | GitHub Copilot CLI |
 | `~/.pi/agent/models.json` | Pi |
 | `~/.cursor/mcp.json` | Cursor Agent (MCP servers only) |
-| `~/.ucode/managed-settings.json` | The managed config authored by `ucode setup` (admins) |
+| `~/.ucode/managed-state.json` | The managed config — authored by `ucode setup` (admins) and refreshed from the workspace on launch |
 
 Existing files are backed up before being overwritten. `ucode revert` restores backups.
 

--- a/src/ucode/managed_config.py
+++ b/src/ucode/managed_config.py
@@ -1,12 +1,20 @@
 """Admin-authored managed coding-agent config: fetch, normalize, and local persistence.
 
 An org admin authors a ``CodingAgentConfig`` through the Databricks AI Gateway; developers read it
-(non-admin) and ``ucode`` applies it locally. This module owns the developer-read half:
+(non-admin) and ``ucode`` applies it locally. This module owns the fetch/normalize side and the one
+local file, ``~/.ucode/managed-state.json`` (0600), that both roles share:
 
 - fetching the raw manifest (via :func:`ucode.databricks.fetch_managed_coding_agent_configs`),
 - normalizing the proto-JSON into a stable internal dict keyed by ucode's own tool names,
-- persisting it to ``~/.ucode/managed-state.json`` (0600), and
+- persisting it via :func:`save_managed_state` / :func:`load_managed_state` — the admin-write side
+  (``managed_setup`` / ``managed_wizard``) authors the manifest here, and the launch path pulls the
+  published copy back into the same file, and
 - re-reading it on each launch, falling back to the persisted copy when the read fails.
+
+There is deliberately one file, not a separate authored ``managed-settings.json``: the workspace is
+the source of truth, so an authored draft and the pulled copy are the same shape and coexist in
+``managed-state.json``. ``ucode --dry-run`` reads the local draft without fetching or overwriting it,
+which is how an admin tries a config out between ``ucode setup`` and ``ucode apply``.
 
 :func:`refresh_managed_config` is the launch path's entry point. It is called before model discovery,
 because the manifest decides whether that discovery is needed at all; the launch path then hands the
@@ -370,6 +378,11 @@ def load_managed_state(workspace: str | None) -> dict | None:
 
     Returns the normalized config dict (the ``config`` field), only when the stored file is for the
     same workspace — so a stale file from another workspace is ignored rather than misapplied.
+
+    This is the single local managed config: ``ucode setup`` authors it here, ``ucode --dry-run``
+    reads it to try the authored config locally, ``ucode apply`` publishes it, and a normal launch
+    refreshes it from the workspace. The admin-authored draft and the pulled copy share one file
+    because the workspace is the source of truth — to keep a draft, publish it with ``ucode apply``.
     """
     if not workspace:
         return None
@@ -378,6 +391,16 @@ def load_managed_state(workspace: str | None) -> dict | None:
         return None
     config = data.get("config")
     return config if isinstance(config, dict) else None
+
+
+def managed_state_workspace() -> str | None:
+    """The workspace the on-disk managed config was authored/pulled for, or None when there is none.
+
+    Lets a caller that has no workspace in local ucode state (e.g. ``ucode setup --show`` before
+    ``ucode configure``) still find the manifest on disk and report which workspace it belongs to.
+    """
+    workspace = config_io.read_json_safe(MANAGED_STATE_PATH).get("workspace")
+    return workspace if isinstance(workspace, str) and workspace else None
 
 
 def refresh_managed_config(state: dict) -> dict | None:

--- a/src/ucode/managed_resolve.py
+++ b/src/ucode/managed_resolve.py
@@ -1,9 +1,10 @@
 """Resolve the effective agent settings from the managed config plus local ucode state.
 
-The admin-authored manifest (``~/.ucode/managed-state.json``, written by
-:mod:`ucode.managed_config`) and the developer's own ucode state (``~/.ucode/state.json``) stay
-separate files — they are never merged on disk. Instead this module resolves them *per key* at
-config-write time: whatever the manifest specifies wins, and anything it leaves unset falls back to
+The managed config (``~/.ucode/managed-state.json`` — authored by ``ucode setup`` and refreshed
+from the workspace at launch, both through :mod:`ucode.managed_config`) and the developer's own
+ucode state (``~/.ucode/state.json``) stay separate files — they are never merged on disk. Instead
+this module resolves them *per key* at config-write time: whatever the manifest specifies wins, and
+anything it leaves unset falls back to
 the developer's ucode state. The resolved view is what gets rendered into the agent config files
 (e.g. ``~/.claude/ucode-settings.json``), so managed settings take precedence for every ``ucode``
 command without either file being rewritten.

--- a/src/ucode/managed_setup.py
+++ b/src/ucode/managed_setup.py
@@ -4,32 +4,28 @@ This module owns the admin-write half of the managed config, mirroring the devel
 :mod:`ucode.managed_config`:
 
 - which models an admin may pick for each agent (:func:`model_options_for_agent`),
-- validating a manifest before it is published (:func:`validate_manifest`),
+- validating a manifest before it is published (:func:`validate_manifest`), and
 - serializing ucode's internal manifest shape into proto-JSON ``CodingAgentConfig``
-  (:func:`serialize_managed_config`), and
-- persisting the authored manifest to ``~/.ucode/managed-settings.json``.
+  (:func:`serialize_managed_config`).
 
 The manifest shape here is exactly the one :func:`ucode.managed_config.normalize_managed_config`
 produces, so ``serialize`` then ``normalize`` round-trips to the input. The enum maps are derived by
 inverting that module's maps rather than restated, so a new agent or MCP type only has to be added
 once.
 
-``managed-settings.json`` (authored by an admin, published by ``ucode apply``) is distinct from
-``managed-state.json`` (pulled from the workspace by a developer, owned by ``managed_config``).
+Local persistence is not duplicated here: the authored manifest is saved to and loaded from the one
+local file, ``~/.ucode/managed-state.json``, via :func:`ucode.managed_config.save_managed_state` and
+:func:`ucode.managed_config.load_managed_state` — the same file the launch path pulls into.
 
-The interactive wizard that calls these helpers, and the publish step, live in later changes; this
-module deliberately stops at "catalogs + validate + serialize + persist".
+The interactive wizard that calls these helpers, and the publish step, live in
+:mod:`ucode.managed_wizard`.
 """
 
 from __future__ import annotations
 
-import json
-import os
 import uuid
-from pathlib import Path
 from typing import cast
 
-import ucode.config_io as config_io
 from ucode.databricks import (
     ANTHROPIC_FAMILIES,
     model_version_sort_key,
@@ -39,8 +35,6 @@ from ucode.managed_config import (
     AGENT_ENUM_TO_TOOL,
     MCP_TYPE_ENUM_TO_TAG,
 )
-
-MANAGED_SETTINGS_PATH = config_io.APP_DIR / "managed-settings.json"
 
 # ucode tool name -> CodingAgent proto enum, and ucode MCP type tag -> McpServerType proto enum.
 # Inverted from the read side's maps so the two directions cannot drift: adding an agent to
@@ -599,56 +593,3 @@ def _validate_budget_policy(budget_policy: dict, enabled_agents: dict[str, dict]
             "same pair make the higher one a no-op."
         )
     return errors
-
-
-def save_managed_settings(workspace: str, manifest: dict) -> None:
-    """Persist the authored manifest to ``~/.ucode/managed-settings.json``. No-op in dry-run.
-
-    Stored alongside its workspace so ``ucode apply`` can refuse to publish a manifest that was
-    authored against a different workspace.
-    """
-    if config_io.is_dry_run():
-        return
-    payload = {"workspace": workspace, "config": manifest}
-    config_io.ensure_parent_dir(MANAGED_SETTINGS_PATH)
-    try:
-        MANAGED_SETTINGS_PATH.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-    except OSError as exc:
-        raise RuntimeError(
-            f"Failed to write managed settings file: {MANAGED_SETTINGS_PATH}"
-        ) from exc
-    _restrict_permissions(MANAGED_SETTINGS_PATH)
-
-
-def _restrict_permissions(path: Path) -> None:
-    """Best-effort chmod 0600, matching how ``managed_config`` protects ``managed-state.json``.
-
-    An unpublished manifest can name internal catalogs, budgets, and MCP servers, so it should not
-    be group- or world-readable. No-op where unsupported (e.g. Windows).
-    """
-    try:
-        os.chmod(path, 0o600)
-    except (OSError, NotImplementedError):
-        pass
-
-
-def load_managed_settings(workspace: str | None = None) -> dict | None:
-    """Load the authored manifest, or None when absent (or authored for another workspace).
-
-    Passing ``workspace`` scopes the read the way :func:`ucode.managed_config.load_managed_state`
-    does, so a manifest left over from a different workspace is ignored rather than published to the
-    wrong place. Omit it to read whatever is on disk.
-    """
-    data = config_io.read_json_safe(MANAGED_SETTINGS_PATH)
-    if not data:
-        return None
-    if workspace is not None and data.get("workspace") != workspace:
-        return None
-    manifest = data.get("config")
-    return manifest if isinstance(manifest, dict) else None
-
-
-def managed_settings_workspace() -> str | None:
-    """The workspace the on-disk manifest was authored for, or None when there is no manifest."""
-    workspace = config_io.read_json_safe(MANAGED_SETTINGS_PATH).get("workspace")
-    return workspace if isinstance(workspace, str) and workspace else None

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -988,8 +988,13 @@ def setup_from_file(path: str) -> int:
 
     save_managed_state(workspace, manifest)
     _render_summary(workspace, manifest)
-    print_success(f"Saved to {manifest_path.name} -> ~/.ucode/managed-state.json")
-    _print_next_steps()
+    if is_dry_run():
+        print_success(
+            f"Dry run: {manifest_path.name} was not written to ~/.ucode/managed-state.json."
+        )
+    else:
+        print_success(f"Saved to {manifest_path.name} -> ~/.ucode/managed-state.json")
+        _print_next_steps()
     return 0
 
 
@@ -1133,8 +1138,11 @@ def setup_command(from_file: str | None = None) -> int:
     save_managed_state(workspace, manifest)
     _render_summary(workspace, manifest)
     console.print()
-    print_success("Saved to ~/.ucode/managed-state.json")
-    _print_next_steps()
+    if is_dry_run():
+        print_success("Dry run: nothing was written to ~/.ucode/managed-state.json.")
+    else:
+        print_success("Saved to ~/.ucode/managed-state.json")
+        _print_next_steps()
     return 0
 
 

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -2,8 +2,10 @@
 
 Workspace admins run this to build the ``CodingAgentConfig`` their developers will pull. It walks
 the admin through agents, per-agent models, tracing, MCP servers, skills, and a spend-routing budget
-policy, then writes the manifest to ``~/.ucode/managed-settings.json``. Publishing it to the
-workspace is ``ucode apply`` (a separate command, so an admin can review the file first).
+policy, then writes the manifest to ``~/.ucode/managed-state.json`` (the one local managed-config
+file, owned by :mod:`ucode.managed_config`). An admin can try it with ``ucode --dry-run`` and then
+publish it to the workspace with ``ucode apply`` (a separate command, so the file can be reviewed
+first).
 
 Serialization, validation, and the per-agent model catalogs live in :mod:`ucode.managed_setup`; this
 module is the interaction layer on top of them. Sub-flows an admin already knows — tracing, MCP,
@@ -36,14 +38,17 @@ from ucode.databricks import (
     service_usable_for_tool,
     update_coding_agent_config,
 )
-from ucode.managed_config import get_managed_config
+from ucode.managed_config import (
+    get_managed_config,
+    load_managed_state,
+    managed_state_workspace,
+    save_managed_state,
+)
 from ucode.managed_setup import (
     CLAUDE_SLOT_FOR_FAMILY,
     claude_family_candidates,
     claude_family_for_model,
-    load_managed_settings,
     model_options_for_agent,
-    save_managed_settings,
     serialize_managed_config,
     supports_provider_service,
     validate_manifest,
@@ -357,7 +362,7 @@ def _prompt_models_for_agent(tool: str, state: dict, provider_service: dict | No
     # Nothing pre-checked: the first option is whatever discovery sorted first, not a
     # recommendation — for pi it is a Claude model, for codex the oldest GPT. Pre-checking it made
     # "hit Enter" produce an arbitrary config. (A worthwhile follow-up is to pre-check the models
-    # this workspace was configured with last time, which `load_managed_settings` already loads for
+    # this workspace was configured with last time, which `load_managed_state` already loads for
     # the agent picker, so a re-run becomes an edit rather than a re-entry.)
     picked = _require_multi_selection(
         f"Select models for {display}:",
@@ -981,9 +986,9 @@ def setup_from_file(path: str) -> int:
             print_note(error)
         return 1
 
-    save_managed_settings(workspace, manifest)
+    save_managed_state(workspace, manifest)
     _render_summary(workspace, manifest)
-    print_success(f"Saved to {manifest_path.name} -> ~/.ucode/managed-settings.json")
+    print_success(f"Saved to {manifest_path.name} -> ~/.ucode/managed-state.json")
     _print_next_steps()
     return 0
 
@@ -991,9 +996,10 @@ def setup_from_file(path: str) -> int:
 def _print_next_steps() -> None:
     console.print()
     print_heading("Next steps")
-    # Deliberately only `apply`. There is no way yet to try the authored config locally: the
-    # manifest describes what developers should get, while `ucode configure --dry-run` previews
-    # this machine's own agent configs, so pointing at it implied a local test it doesn't perform.
+    # The authored manifest is saved to the same local file a launch reads, so `ucode --dry-run`
+    # previews this machine's agents *as configured by the manifest* without fetching or overwriting
+    # it — a real local test of the config before it is published.
+    print_note("Try it locally:               ucode --dry-run")
     print_note("Publish it to the workspace:  ucode apply")
 
 
@@ -1038,7 +1044,7 @@ def setup_command(from_file: str | None = None) -> int:
             "serves models for at least one agent."
         )
 
-    previous = load_managed_settings(workspace) or {}
+    previous = load_managed_state(workspace) or {}
     previously_enabled = [
         tool for tool in (previous.get("enabled_agents") or {}) if tool in TOOL_SPECS
     ]
@@ -1124,18 +1130,20 @@ def setup_command(from_file: str | None = None) -> int:
             print_note(error)
         return 1
 
-    save_managed_settings(workspace, manifest)
+    save_managed_state(workspace, manifest)
     _render_summary(workspace, manifest)
     console.print()
-    print_success("Saved to ~/.ucode/managed-settings.json")
+    print_success("Saved to ~/.ucode/managed-state.json")
     _print_next_steps()
     return 0
 
 
 def show_command() -> int:
     """Print the authored manifest and the proto-JSON `ucode apply` would publish."""
-    workspace = load_state().get("workspace")
-    manifest = load_managed_settings(workspace)
+    # Fall back to the workspace the on-disk file was authored for, so `ucode setup --show` still
+    # works before `ucode configure` has put a workspace in local state.
+    workspace = load_state().get("workspace") or managed_state_workspace()
+    manifest = load_managed_state(workspace)
     if manifest is None:
         print_note("No managed config has been authored yet. Run `ucode setup` to create one.")
         return 0
@@ -1225,7 +1233,7 @@ def apply_command(*, yes: bool = False) -> int:
     if not workspace:
         workspace, profile = _prompt_for_configuration()
 
-    manifest = load_managed_settings(workspace)
+    manifest = load_managed_state(workspace)
     if manifest is None:
         raise RuntimeError(
             "No managed config has been authored for this workspace. Run `ucode setup` first "
@@ -1241,7 +1249,7 @@ def apply_command(*, yes: bool = False) -> int:
         print_err("The authored config is not valid, so it was not published:")
         for error in errors:
             print_note(error)
-        print_note("Re-run `ucode setup` to fix it, or edit ~/.ucode/managed-settings.json.")
+        print_note("Re-run `ucode setup` to fix it, or edit ~/.ucode/managed-state.json.")
         return 1
 
     token = get_databricks_token(workspace, profile)

--- a/tests/test_managed_config.py
+++ b/tests/test_managed_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import stat
 
@@ -18,6 +19,7 @@ from ucode.managed_config import (
     refresh_managed_config,
     save_managed_state,
 )
+from ucode.managed_setup import serialize_managed_config
 
 # A representative raw CodingAgentConfig proto-JSON manifest (mirrors what the API returns).
 RAW_MANIFEST = {
@@ -228,6 +230,23 @@ class TestPersistence:
         monkeypatch.setattr(config_io_mod, "is_dry_run", lambda: True)
         save_managed_state("https://ws.example.com", {"default_agent": "claude"})
         assert not _managed_path.exists()
+
+    def test_corrupt_file_reads_as_absent(self, _managed_path):
+        # A truncated/hand-mangled file must not crash a launch: it reads as "no config" so the
+        # launch falls through rather than raising on JSON it can't parse.
+        _managed_path.parent.mkdir(parents=True, exist_ok=True)
+        _managed_path.write_text("{not json", encoding="utf-8")
+        assert load_managed_state("https://ws.example.com") is None
+        assert managed_state_workspace() is None
+
+    def test_loaded_config_serializes_to_a_json_encodable_payload(self, _managed_path):
+        # `ucode apply` POSTs the serialized config, so a manifest that survives a disk round-trip
+        # must still serialize to something json.dumps accepts with no custom encoder.
+        cfg = normalize_managed_config(RAW_MANIFEST)
+        save_managed_state("https://ws.example.com", cfg)
+        loaded = load_managed_state("https://ws.example.com")
+        assert loaded is not None
+        assert json.loads(json.dumps(serialize_managed_config(loaded)))
 
 
 class TestFetchClient:

--- a/tests/test_managed_config.py
+++ b/tests/test_managed_config.py
@@ -7,11 +7,13 @@ import stat
 
 import pytest
 
+import ucode.config_io as config_io_mod
 import ucode.databricks as db_mod
 import ucode.managed_config as mc_mod
 from ucode.managed_config import (
     get_managed_config,
     load_managed_state,
+    managed_state_workspace,
     normalize_managed_config,
     refresh_managed_config,
     save_managed_state,
@@ -210,6 +212,22 @@ class TestPersistence:
         save_managed_state("https://ws.example.com", {"default_agent": "claude"})
         save_managed_state("https://ws.example.com", {})
         assert load_managed_state("https://ws.example.com") == {}
+
+    def test_workspace_is_stored_alongside_the_config(self, _managed_path):
+        # `ucode setup --show` reads this when local state carries no workspace yet, so the authored
+        # file can still be found and attributed on disk.
+        save_managed_state("https://ws.example.com", {"default_agent": "claude"})
+        assert managed_state_workspace() == "https://ws.example.com"
+
+    def test_workspace_is_none_when_absent(self, _managed_path):
+        assert managed_state_workspace() is None
+
+    def test_dry_run_writes_nothing(self, _managed_path, monkeypatch):
+        # Under --dry-run the config writers print instead of touching disk, so a launch that
+        # dry-runs an admin's authored draft never overwrites it.
+        monkeypatch.setattr(config_io_mod, "is_dry_run", lambda: True)
+        save_managed_state("https://ws.example.com", {"default_agent": "claude"})
+        assert not _managed_path.exists()
 
 
 class TestFetchClient:

--- a/tests/test_managed_setup.py
+++ b/tests/test_managed_setup.py
@@ -7,13 +7,8 @@ property pins the write side to the read side, so the two cannot drift as the pr
 
 from __future__ import annotations
 
-import json
-import stat
-
 import pytest
 
-import ucode.config_io as config_io_mod
-import ucode.managed_setup as managed_setup_mod
 from ucode.managed_config import (
     AGENT_ENUM_TO_TOOL,
     MCP_TYPE_ENUM_TO_TAG,
@@ -24,11 +19,8 @@ from ucode.managed_setup import (
     MCP_TAG_TO_TYPE_ENUM,
     claude_family_for_model,
     claude_model_slots,
-    load_managed_settings,
-    managed_settings_workspace,
     model_families_for_agent,
     model_options_for_agent,
-    save_managed_settings,
     serialize_managed_config,
     supports_provider_service,
     validate_manifest,
@@ -906,78 +898,3 @@ class TestValidate:
             "mcp_servers": [{"type": "bogus"}],
         }
         assert len(validate_manifest(manifest, STATE)) >= 3
-
-
-class TestPersistence:
-    def test_round_trips_through_disk(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
-        monkeypatch.setattr(
-            managed_setup_mod, "MANAGED_SETTINGS_PATH", tmp_path / "managed-settings.json"
-        )
-        manifest = _full_manifest()
-        save_managed_settings(WORKSPACE, manifest)
-        assert load_managed_settings(WORKSPACE) == manifest
-
-    def test_stores_the_workspace_alongside_the_manifest(self, tmp_path, monkeypatch):
-        path = tmp_path / "managed-settings.json"
-        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
-        monkeypatch.setattr(managed_setup_mod, "MANAGED_SETTINGS_PATH", path)
-        save_managed_settings(WORKSPACE, _minimal_manifest())
-        assert json.loads(path.read_text())["workspace"] == WORKSPACE
-        assert managed_settings_workspace() == WORKSPACE
-
-    def test_load_is_workspace_scoped(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
-        monkeypatch.setattr(
-            managed_setup_mod, "MANAGED_SETTINGS_PATH", tmp_path / "managed-settings.json"
-        )
-        save_managed_settings(WORKSPACE, _minimal_manifest())
-        # A manifest authored for another workspace must not be published to this one.
-        assert load_managed_settings("https://other.example.com") is None
-
-    def test_load_without_a_workspace_returns_whatever_is_on_disk(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
-        monkeypatch.setattr(
-            managed_setup_mod, "MANAGED_SETTINGS_PATH", tmp_path / "managed-settings.json"
-        )
-        save_managed_settings(WORKSPACE, _minimal_manifest())
-        assert load_managed_settings() == _minimal_manifest()
-
-    def test_load_returns_none_when_absent(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
-        monkeypatch.setattr(managed_setup_mod, "MANAGED_SETTINGS_PATH", tmp_path / "missing.json")
-        assert load_managed_settings(WORKSPACE) is None
-        assert managed_settings_workspace() is None
-
-    def test_dry_run_writes_nothing(self, tmp_path, monkeypatch):
-        path = tmp_path / "managed-settings.json"
-        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
-        monkeypatch.setattr(managed_setup_mod, "MANAGED_SETTINGS_PATH", path)
-        monkeypatch.setattr(config_io_mod, "is_dry_run", lambda: True)
-        save_managed_settings(WORKSPACE, _minimal_manifest())
-        assert not path.exists()
-
-    def test_corrupt_file_reads_as_absent(self, tmp_path, monkeypatch):
-        path = tmp_path / "managed-settings.json"
-        path.write_text("{not json", encoding="utf-8")
-        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
-        monkeypatch.setattr(managed_setup_mod, "MANAGED_SETTINGS_PATH", path)
-        assert load_managed_settings(WORKSPACE) is None
-
-    def test_serialized_payload_is_json_encodable(self, tmp_path, monkeypatch):
-        # `ucode apply` POSTs this, so it must survive json.dumps with no custom encoder.
-        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
-        monkeypatch.setattr(
-            managed_setup_mod, "MANAGED_SETTINGS_PATH", tmp_path / "managed-settings.json"
-        )
-        save_managed_settings(WORKSPACE, _full_manifest())
-        manifest = load_managed_settings(WORKSPACE)
-        assert manifest is not None
-        assert json.loads(json.dumps(serialize_managed_config(manifest)))
-
-    def test_settings_file_is_user_only(self, tmp_path, monkeypatch):
-        path = tmp_path / "managed-settings.json"
-        monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
-        monkeypatch.setattr(managed_setup_mod, "MANAGED_SETTINGS_PATH", path)
-        save_managed_settings(WORKSPACE, _minimal_manifest())
-        assert stat.S_IMODE(path.stat().st_mode) & 0o077 == 0

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -16,7 +16,7 @@ from typer.testing import CliRunner
 
 import ucode.cli as cli_mod
 import ucode.config_io as config_io_mod
-import ucode.managed_setup as managed_setup_mod
+import ucode.managed_config as managed_config_mod
 import ucode.managed_wizard as wizard
 from ucode.cli import app
 from ucode.managed_setup import validate_manifest
@@ -43,11 +43,9 @@ STATE = {
 
 @pytest.fixture(autouse=True)
 def _isolate_settings(tmp_path, monkeypatch):
-    """Point the manifest path at a tmp dir so no test touches the real ~/.ucode."""
+    """Point the managed-config file at a tmp dir so no test touches the real ~/.ucode."""
     monkeypatch.setattr(config_io_mod, "APP_DIR", tmp_path)
-    monkeypatch.setattr(
-        managed_setup_mod, "MANAGED_SETTINGS_PATH", tmp_path / "managed-settings.json"
-    )
+    monkeypatch.setattr(managed_config_mod, "MANAGED_STATE_PATH", tmp_path / "managed-state.json")
     monkeypatch.setattr(config_io_mod, "_dry_run", False)
 
 
@@ -1550,13 +1548,13 @@ class TestSetupFromFile:
         path = self._write(tmp_path, self._valid())
         with patch.object(wizard, "load_state", return_value=STATE):
             assert wizard.setup_from_file(str(path)) == 0
-        assert managed_setup_mod.load_managed_settings(WORKSPACE) == self._valid()
+        assert managed_config_mod.load_managed_state(WORKSPACE) == self._valid()
 
     def test_invalid_manifest_returns_1_and_saves_nothing(self, tmp_path):
         path = self._write(tmp_path, {"enabled_agents": {"claude": {}}})
         with patch.object(wizard, "load_state", return_value=STATE):
             assert wizard.setup_from_file(str(path)) == 1
-        assert managed_setup_mod.load_managed_settings(WORKSPACE) is None
+        assert managed_config_mod.load_managed_state(WORKSPACE) is None
 
     def test_missing_file_is_actionable(self, tmp_path):
         with patch.object(wizard, "load_state", return_value=STATE):
@@ -1595,7 +1593,7 @@ class TestShowCommand:
                 "claude": {"model_config": {"default_model": "system.ai.claude-opus-4-8"}}
             },
         }
-        managed_setup_mod.save_managed_settings(WORKSPACE, manifest)
+        managed_config_mod.save_managed_state(WORKSPACE, manifest)
         with patch.object(wizard, "load_state", return_value={"workspace": WORKSPACE}):
             assert wizard.show_command() == 0
         out = capsys.readouterr().out
@@ -1812,7 +1810,7 @@ class TestApplyCommand:
                 wizard.apply_command()
 
     def test_creates_when_no_config_exists(self):
-        managed_setup_mod.save_managed_settings(WORKSPACE, self.MANIFEST)
+        managed_config_mod.save_managed_state(WORKSPACE, self.MANIFEST)
         created = {}
 
         def fake_create(workspace, token, payload):
@@ -1827,7 +1825,7 @@ class TestApplyCommand:
     def test_updates_in_place_when_a_config_exists(self):
         # Delete-then-create would leave the workspace with no config if the create failed, so an
         # existing config must be PATCHed rather than replaced.
-        managed_setup_mod.save_managed_settings(WORKSPACE, self.MANIFEST)
+        managed_config_mod.save_managed_state(WORKSPACE, self.MANIFEST)
         existing = {"name": "coding-agent-configs/abc", "enabled_agents": {"codex": {}}}
         updated = {}
         created = {"called": False}
@@ -1853,7 +1851,7 @@ class TestApplyCommand:
 
     def test_invalid_manifest_is_not_published(self):
         # `default_agent` names an agent that isn't enabled.
-        managed_setup_mod.save_managed_settings(
+        managed_config_mod.save_managed_state(
             WORKSPACE, {"default_agent": "codex", "enabled_agents": {"claude": {}}}
         )
         created = {"called": False}
@@ -1871,7 +1869,7 @@ class TestApplyCommand:
         # `apply` process used to reject a model it had just offered:
         #   claude: model 'system.ai.claude-opus-4-1' is not available on this workspace.
         # `apply` re-fetches the full listing rather than trusting what `setup` left in state.
-        managed_setup_mod.save_managed_settings(
+        managed_config_mod.save_managed_state(
             WORKSPACE,
             {
                 "default_agent": "claude",
@@ -1909,7 +1907,7 @@ class TestApplyCommand:
     def test_a_failed_inventory_fetch_does_not_block_publishing(self):
         # The re-fetch is best-effort: a transient listing failure must not turn into a refusal to
         # publish a manifest that validates against what state already knows.
-        managed_setup_mod.save_managed_settings(WORKSPACE, self.MANIFEST)
+        managed_config_mod.save_managed_state(WORKSPACE, self.MANIFEST)
         published: dict = {}
 
         def fake_create(workspace, token, payload):
@@ -1926,7 +1924,7 @@ class TestApplyCommand:
         assert published
 
     def test_declining_the_prompt_publishes_nothing(self):
-        managed_setup_mod.save_managed_settings(WORKSPACE, self.MANIFEST)
+        managed_config_mod.save_managed_state(WORKSPACE, self.MANIFEST)
         created = {"called": False}
 
         def fake_create(*a, **k):
@@ -1940,7 +1938,7 @@ class TestApplyCommand:
         assert created["called"] is False
 
     def test_yes_skips_the_prompt(self):
-        managed_setup_mod.save_managed_settings(WORKSPACE, self.MANIFEST)
+        managed_config_mod.save_managed_state(WORKSPACE, self.MANIFEST)
 
         def refuse(*a, **k):
             raise AssertionError("--yes must not prompt")
@@ -1948,7 +1946,7 @@ class TestApplyCommand:
         assert self._run(yes=True, prompt_yes_no_default=refuse) == 0
 
     def test_non_admin_is_rejected_before_publishing(self):
-        managed_setup_mod.save_managed_settings(WORKSPACE, self.MANIFEST)
+        managed_config_mod.save_managed_state(WORKSPACE, self.MANIFEST)
         created = {"called": False}
 
         def fake_create(*a, **k):
@@ -1963,7 +1961,7 @@ class TestApplyCommand:
 
     def test_unreadable_existing_config_refuses_to_publish(self):
         # Publishing without knowing whether a config exists risks silently overwriting one.
-        managed_setup_mod.save_managed_settings(WORKSPACE, self.MANIFEST)
+        managed_config_mod.save_managed_state(WORKSPACE, self.MANIFEST)
         created = {"called": False}
 
         def fake_create(*a, **k):
@@ -1978,7 +1976,7 @@ class TestApplyCommand:
         assert created["called"] is False
 
     def test_existing_config_without_a_resource_name_is_an_error(self):
-        managed_setup_mod.save_managed_settings(WORKSPACE, self.MANIFEST)
+        managed_config_mod.save_managed_state(WORKSPACE, self.MANIFEST)
         with pytest.raises(RuntimeError, match="resource name"):
             self._run(get_managed_config=lambda *a, **k: ({"enabled_agents": {}}, None))
 


### PR DESCRIPTION
## What

The managed coding-agent config lived in two near-identical local files:

- `~/.ucode/managed-settings.json` — authored by `ucode setup`, read by `ucode apply` to publish (owned by `managed_setup`).
- `~/.ucode/managed-state.json` — pulled from the workspace at launch by `refresh_managed_config`, read at launch (owned by `managed_config`).

Both used the same on-disk shape `{"workspace", "config"}`, and `serialize_managed_config` then `normalize_managed_config` already round-trips one into the other — so the split was two names for one thing.

This consolidates onto a single file, **`managed-state.json`**:

- Removes `MANAGED_SETTINGS_PATH` and the `save_managed_settings` / `load_managed_settings` / `managed_settings_workspace` helpers (and a duplicate `_restrict_permissions`) from `managed_setup`.
- The author side (`setup`, `setup --from-file`, `setup show`, `apply`) now uses `managed_config.save_managed_state` / `load_managed_state`, plus a new `managed_config.managed_state_workspace()` for `ucode setup show` before a workspace is in local state.

## Why this is coherent

The workspace is the source of truth. `ucode setup` writes the draft to `managed-state.json`; `ucode --dry-run` reads that same file **without fetching or overwriting** (launch path: `if dry_run: managed = load_managed_state(current)`), so an admin can try an authored config on their own machine before publishing — the `setup` → `ucode --dry-run` → `apply` flow the two-file split couldn't express. A non-dry-run launch refreshes the file from the workspace; to keep a draft, publish it with `ucode apply`. (A real launch between `setup` and `apply` replacing an unapplied draft is the accepted tradeoff.)

## Also

- `setup --dry-run` ("walk the flow without writing any files") no longer prints a false "Saved to…" line + apply next-steps; under dry-run it reports that nothing was written, while `save_managed_state` still previews the would-be payload.
- Persistence tests moved from `test_managed_setup.py` onto `test_managed_config.py` (against `load_managed_state`); `test_managed_wizard.py` repointed.
- Docstrings + README updated.

## Testing

- Full non-e2e suite green; `ruff check` / `ruff format` / `ty` clean.

This pull request and its description were written by Isaac.