### PR TITLE
setup: per-family Claude models for provider services, with quick setup

### DIFF
--- a/src/ucode/agents/__init__.py
+++ b/src/ucode/agents/__init__.py
@@ -22,7 +22,7 @@ from ucode.databricks import (
     get_databricks_token,
     install_ai_tools,
     install_databricks_cli,
-    map_bedrock_claude_models,
+    map_claude_family_models,
     resolve_provider_service,
 )
 from ucode.state import get_provider_service, load_state, save_state
@@ -285,13 +285,18 @@ def resolve_provider_models(
 ) -> tuple[dict | None, str | None, bool]:
     """Validate ``provider`` for ``tool`` and return the model ids to pin.
 
-    Returns ``(provider_models, error, relayed)``. ``provider_models`` is a
-    ``{family: model_id}`` dict for a Bedrock-backed claude service (whose
-    provider-side ids must be pinned explicitly), or None for an Anthropic/
-    canonical service or when ``provider`` is None. ``relayed`` is True for a
-    credential-less Anthropic subscription relay, which the launch path wires
-    with the relayed overlay + refresh proxy. A non-None ``error`` means the
-    provider is invalid for the tool and the caller should not launch.
+    Returns ``(provider_models, error, relayed)``. ``provider_models`` is a ``{family: model_id}``
+    dict for a Bedrock-backed claude service (whose provider-side ids must be pinned explicitly), or
+    None for an Anthropic/canonical service or when ``provider`` is None. ``relayed`` is True for a
+    credential-less Anthropic subscription relay, which the launch path wires with the relayed
+    overlay + refresh proxy. A non-None ``error`` means the provider is invalid for the tool and the
+    caller should not launch.
+
+    This is the *developer-configured* path (``ucode configure`` then ``ucode claude``) and its
+    behaviour is deliberately unchanged: only Bedrock pins, re-derived from the service's live
+    targets. The *managed* path pins from the admin's authored manifest slots instead — see
+    ``managed_resolve.managed_provider_family_models`` and its launch call site — so an admin's
+    chosen versions win rather than being re-derived here.
     """
     if not provider:
         return None, None, False
@@ -301,7 +306,7 @@ def resolve_provider_models(
         return None, error, False
     relayed = bool(service.get("relayed"))
     if service["provider_type"] in BEDROCK_PROVIDER_TYPES:
-        return map_bedrock_claude_models(service.get("targets") or []), None, relayed
+        return map_claude_family_models(service.get("targets") or []), None, relayed
     return None, None, relayed
 
 

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -71,6 +71,7 @@ from ucode.managed_resolve import (
     managed_default_model,
     managed_enabled_tools,
     managed_launch_model,
+    managed_provider_family_models,
     managed_provider_service,
     managed_supplies_models,
     managed_unservable_models,
@@ -1486,6 +1487,19 @@ def _launch_tool(
                         f"{TOOL_SPECS[tool]['display']}, which can't be used: {error}"
                     )
                 raise RuntimeError(error)
+            # A managed config launch uses exactly what the admin authored: pin Claude's family
+            # models from the manifest's slots rather than the versions resolve_provider_models
+            # re-derived from the service's live targets. The developer-configured path keeps that
+            # re-derivation (see resolve_provider_models). Only when the manifest actually selected
+            # this provider for claude, and authored something to pin.
+            if (
+                tool == "claude"
+                and managed is not None
+                and provider == managed_provider_service(managed, tool)
+            ):
+                authored = managed_provider_family_models(managed)
+                if authored:
+                    provider_models = authored
         if routing_agent is not None and enable_smart_routing_flag:
             state = routing_agent.enable_smart_routing(state)
         # The router's per-launch pick for the root session. Codex pins it as the

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -2055,7 +2055,7 @@ def service_usable_for_tool(tool: str, service: dict) -> bool:
     if not tool_supports_provider_type(tool, provider_type):
         return False
     if provider_type in BEDROCK_PROVIDER_TYPES:
-        return bool(map_bedrock_claude_models(service.get("targets") or []))
+        return bool(map_claude_family_models(service.get("targets") or []))
     return True
 
 
@@ -2095,7 +2095,7 @@ def resolve_provider_service(
             f"Model provider service '{service_name}' is a '{provider_type}' provider, "
             f"which {tool} can't route to (supported: {supported})."
         )
-    if provider_type in BEDROCK_PROVIDER_TYPES and not map_bedrock_claude_models(
+    if provider_type in BEDROCK_PROVIDER_TYPES and not map_claude_family_models(
         match.get("targets") or []
     ):
         return None, (
@@ -2105,12 +2105,11 @@ def resolve_provider_service(
     return match, None
 
 
-# Bedrock exposes Claude under provider-side ids like
-# `us.anthropic.claude-sonnet-4-6`, `global.anthropic.claude-opus-4-8`, or the
-# region-less `anthropic.claude-opus-4-8`. We map each service target to a
-# Claude family and keep the best id per family. Claude Code only takes one
-# default per family; users switch to any other listed region profile at runtime
-# with `/model <full-id>` or `--model`.
+# A Model Provider Service exposes Claude under per-family target ids: Bedrock as provider-side
+# slugs (`us.anthropic.claude-sonnet-4-6`, `global.anthropic.claude-opus-4-8`, region-less
+# `anthropic.claude-opus-4-8`), Anthropic as canonical names (`claude-sonnet-5`). Either way we map
+# each target to a Claude family and keep the best id per family. Claude Code takes one default per
+# family; users switch to any other listed id at runtime with `/model <full-id>` or `--model`.
 _BEDROCK_CLAUDE_FAMILIES = ("opus", "sonnet", "haiku")
 # When the same model/version is offered under several cross-region inference
 # profiles, prefer the broadest-routing one as the pinned default.
@@ -2137,11 +2136,14 @@ def _bedrock_sort_key(model_id: str) -> tuple:
     return (version, _bedrock_region_rank(model_id))
 
 
-def map_bedrock_claude_models(targets: list[str]) -> dict[str, str]:
-    """Map Bedrock service targets to ``{family: model_id}`` for opus/sonnet/
-    haiku, choosing the highest-versioned id per family and, on a version tie,
-    the broadest-routing region profile. Targets that don't name a Claude family
-    are ignored."""
+def map_claude_family_models(targets: list[str]) -> dict[str, str]:
+    """Map a service's Claude targets to ``{family: model_id}`` for opus/sonnet/haiku.
+
+    Chooses the highest-versioned id per family and, on a version tie, the broadest-routing region
+    profile (Bedrock targets carry a region prefix; canonical Anthropic ids rank equal, so version
+    alone decides). Targets that don't name a Claude family are ignored, so a mixed catalog (e.g. a
+    Bedrock service also exposing Titan embeddings) yields only the Claude families.
+    """
     best_key: dict[str, tuple] = {}
     result: dict[str, str] = {}
     for model_id in targets:

--- a/src/ucode/managed_resolve.py
+++ b/src/ucode/managed_resolve.py
@@ -185,6 +185,44 @@ def managed_default_model(managed: dict, tool: str) -> str | None:
     return _str(_agent_model_config(managed, tool).get("default_model"))
 
 
+def managed_provider_family_models(managed: dict) -> dict[str, str] | None:
+    """Claude's authored per-family models for launch, when a managed config routes it through a
+    Model Provider Service.
+
+    The launch path pins each ``ANTHROPIC_DEFAULT_<FAMILY>_MODEL`` from this so a *managed* launch
+    uses exactly the versions the admin chose in ``ucode setup`` — rather than
+    ``resolve_provider_models`` re-deriving "newest per family" from the service's live targets. It
+    returns the manifest's own family slots (``{opus: id, sonnet: id, ...}``), i.e. what the wizard's
+    per-family prompt authored.
+
+    Falls back to the single ``default_model`` (mapped to its family) when the manifest carries no
+    slots — the case where the service is ``allow_all_targets`` so setup could only ask for one
+    overall default. Returns None when neither is present, leaving the launch path to its usual
+    provider handling.
+
+    TODO: when the service is ``allow_all_targets`` an admin can't enumerate a per-family choice yet.
+    A list-models API for provider services would let the wizard offer the full catalog per family;
+    until then the single default is the best the manifest can express.
+    """
+    from ucode.managed_setup import claude_family_for_model
+
+    config = _agent_model_config(managed, "claude")
+    slots: dict[str, str] = {}
+    raw_slots = _as_dict(config.get("models"))
+    for slot, family in _CLAUDE_FAMILY_SLOTS.items():
+        model = _str(raw_slots.get(slot))
+        if model:
+            slots[family] = model
+    if slots:
+        return slots
+    default_model = _str(config.get("default_model"))
+    if default_model:
+        family = claude_family_for_model(default_model)
+        if family:
+            return {family: default_model}
+    return None
+
+
 def recommended_agent(recommendation: dict | None, managed: dict) -> str | None:
     """The agent the budget tier recommends, or the config's ``default_agent`` when it names none.
 

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -32,6 +32,7 @@ from ucode.databricks import (
     is_workspace_admin,
     list_model_provider_services,
     list_workspace_budgets,
+    map_claude_family_models,
     service_usable_for_tool,
     update_coding_agent_config,
 )
@@ -39,6 +40,7 @@ from ucode.managed_config import get_managed_config
 from ucode.managed_setup import (
     CLAUDE_SLOT_FOR_FAMILY,
     claude_family_candidates,
+    claude_family_for_model,
     load_managed_settings,
     model_options_for_agent,
     save_managed_settings,
@@ -286,7 +288,17 @@ def _prompt_models_for_agent(tool: str, state: dict, provider_service: dict | No
         service_name = provider_service["name"]
         model_config["model_provider_service"] = service_name
         targets = provider_service_model_options(provider_service)
-        if targets:
+        if tool == "claude" and _pins_family_models(targets):
+            # `targets` (not the raw service) publishes explicit Claude models, and `render_overlay`
+            # pins each family to a chosen version from them — Bedrock slugs
+            # (`us.anthropic.claude-opus-4-8-v1:0`) or canonical Anthropic ids (`claude-opus-4-8`).
+            # So Claude needs a default *per family*, not one overall, mirroring the Databricks-hosted
+            # path. (A service with no enumerable targets pins nothing and takes a single default —
+            # handled below.) Keyed on `targets`, the same list the prompt consumes, so the decision
+            # and the prompt can't disagree — `allow_all_targets` zeroes `targets`, so it correctly
+            # falls through to the single-default branch even if the raw service also lists Claude.
+            model_config.update(_prompt_claude_provider_family_models(targets, service_name))
+        elif targets:
             model_config["default_model"] = _require_selection(
                 f"Default model for {display} (from {service_name}):",
                 [(target, target) for target in targets],
@@ -412,6 +424,120 @@ def _prompt_claude_models(state: dict) -> dict:
     else:
         model_config["default_model"] = _require_selection(
             f"Which of those is {display}'s overall default?", [(m, m) for m in chosen]
+        )
+    return model_config
+
+
+def _pins_family_models(targets: list[str]) -> bool:
+    """True when Claude behind a service is pinned per family at launch.
+
+    Keyed on the *behavior*, not the vendor: when a service publishes explicit Claude targets — a
+    Bedrock provider-side slug like ``us.anthropic.claude-opus-4-8-v1:0`` *or* a canonical Anthropic
+    id like ``claude-opus-4-8`` — ``render_overlay`` pins each ``ANTHROPIC_DEFAULT_<FAMILY>_MODEL`` to
+    a chosen version, so the wizard prompts one model per family, mirroring the Databricks-hosted
+    path. No Claude-family targets (``allow_all_targets`` zeroes the list, or a relayed subscription
+    lists none) means nothing is pinned — Claude Code's canonical names route fine — so it takes a
+    single default.
+
+    Takes the *enumerated* targets (``provider_service_model_options`` output), the exact list the
+    per-family prompt consumes, so the decision and the prompt can't disagree. Reading the raw
+    ``service["targets"]`` here would diverge: an ``allow_all_targets`` service that still lists
+    Claude models would test True but hand the prompt an empty list, aborting the wizard.
+    """
+    return bool(map_claude_family_models(targets))
+
+
+def _prompt_claude_provider_family_models(targets: list[str], service_name: str) -> dict:
+    """Claude family slots (and overall default) chosen from a service's own Claude target ids.
+
+    The Databricks-hosted path (:func:`_prompt_claude_models`) prompts per family because Claude
+    Code addresses models by family alias; the same holds behind a Model Provider Service, except
+    the ids are the service's own — Bedrock provider-side slugs or canonical Anthropic ids rather
+    than ``system.ai.*``. ``render_overlay`` pins each ``ANTHROPIC_DEFAULT_<FAMILY>_MODEL`` from
+    them, so a single overall default would leave the other families unpinned.
+
+    Targets are grouped by family via :func:`claude_family_for_model`, which matches the
+    ``claude-<family>-`` segment in any spelling (``anthropic.claude-…`` Bedrock or bare
+    ``claude-…`` canonical). A target that names no family is offered only as the overall default.
+    Falls back to a single default when nothing maps to a family at all.
+    """
+    display = TOOL_SPECS["claude"]["display"]
+    by_family: dict[str, list[str]] = {}
+    for target in targets:
+        family = claude_family_for_model(target)
+        if family:
+            by_family.setdefault(family, []).append(target)
+
+    if not by_family:
+        # No target maps to a Claude family (unusual for a Bedrock Claude service); the most this can
+        # honestly ask for is one overall default.
+        return {
+            "default_model": _require_selection(
+                f"Default model for {display} (from {service_name}):",
+                [(t, t) for t in targets],
+            )
+        }
+
+    # Quick setup: fill each family with the service's newest id (highest version, broadest region),
+    # the same pick a developer's own `ucode configure` would make. The alternative is choosing a
+    # specific id per family — e.g. to pin an older, validated version or a particular region.
+    # map_claude_family_models covers opus/sonnet/haiku but not fable, so a fable-only service has
+    # nothing to quick-fill — only offer quick setup when it would actually populate a slot.
+    family_models = map_claude_family_models(targets)
+    if family_models:
+        print_note(
+            "Quick setup fills each Claude family with the newest model this service offers. Answer "
+            "no to choose a specific model per family instead (pin an older version, a region)."
+        )
+    if family_models and prompt_yes_no_default("Quick setup?", default=True):
+        slots = {CLAUDE_SLOT_FOR_FAMILY[family]: model for family, model in family_models.items()}
+        # Overall default = the highest-tier family the service offers, not whichever target happened
+        # to sort first. Fable is last: it's the premium opt-in model, a poor default. `family_models`
+        # is non-empty here, so `next` always finds one.
+        default_family = next(
+            fam for fam in ("opus", "sonnet", "haiku", "fable") if fam in family_models
+        )
+        model_config = {"models": slots, "default_model": family_models[default_family]}
+        summary = ", ".join(
+            f"{fam}={slots[CLAUDE_SLOT_FOR_FAMILY[fam]]}"
+            for fam in ANTHROPIC_FAMILIES
+            if CLAUDE_SLOT_FOR_FAMILY[fam] in slots
+        )
+        print_success(f"{display}: {summary} (default: {default_family})")
+        return model_config
+
+    print_note(
+        f"Claude Code picks a model by family, so set a default per family from {service_name}. "
+        "Skip any family you don't want configured — it falls back to the overall default."
+    )
+    slots: dict[str, str] = {}
+    for family in ANTHROPIC_FAMILIES:
+        family_targets = by_family.get(family)
+        if not family_targets:
+            continue
+        choice = prompt_for_selection(
+            f"Default {family} model:",
+            [(t, t) for t in family_targets] + [(_SKIP_FAMILY, f"(skip {family})")],
+            searchable=True,
+        )
+        if choice is None:
+            raise KeyboardInterrupt
+        if choice != _SKIP_FAMILY:
+            slots[CLAUDE_SLOT_FOR_FAMILY[family]] = choice
+
+    model_config: dict = {}
+    if slots:
+        model_config["models"] = slots
+    chosen = list(dict.fromkeys(slots.values()))
+    if len(chosen) == 1:
+        model_config["default_model"] = chosen[0]
+        print_success(f"Overall default for {display}: {chosen[0]} (the only model configured)")
+    else:
+        # Offered over every target, not just the slots: `default_model` needn't be a family model,
+        # and a mixed-catalog service may expose one an admin wants as the overall default.
+        options = chosen or list(targets)
+        model_config["default_model"] = _require_selection(
+            f"Which of those is {display}'s overall default?", [(m, m) for m in options]
         )
     return model_config
 

--- a/tests/test_agents_init.py
+++ b/tests/test_agents_init.py
@@ -281,7 +281,14 @@ class TestResolveProviderModels:
         assert (models, error, relayed) == (None, None, False)
 
     def test_anthropic_returns_no_models(self, monkeypatch):
-        self._patch(monkeypatch, {"provider_type": "anthropic", "targets": []}, None)
+        # The developer-configured path is deliberately unchanged: an Anthropic service pins nothing
+        # even with explicit targets — Claude Code's canonical names route fine. (The managed path
+        # pins from authored manifest slots instead; see managed_resolve.)
+        self._patch(
+            monkeypatch,
+            {"provider_type": "anthropic", "targets": ["claude-sonnet-5", "claude-haiku-4-5"]},
+            None,
+        )
         models, error, relayed = agents_mod.resolve_provider_models(
             "claude", self._STATE, "main.a.svc"
         )

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -487,9 +487,9 @@ class TestListModelProviderServices:
         assert names == ["main.schema1.openai-svc"]
 
 
-class TestMapBedrockClaudeModels:
+class TestMapClaudeFamilyModels:
     def test_maps_families(self):
-        models = db_mod.map_bedrock_claude_models(
+        models = db_mod.map_claude_family_models(
             [
                 "us.anthropic.claude-sonnet-4-6",
                 "global.anthropic.claude-opus-4-8",
@@ -504,13 +504,13 @@ class TestMapBedrockClaudeModels:
         }
 
     def test_prefers_highest_version(self):
-        models = db_mod.map_bedrock_claude_models(
+        models = db_mod.map_claude_family_models(
             ["us.anthropic.claude-sonnet-4-5", "us.anthropic.claude-sonnet-4-6"]
         )
         assert models["sonnet"] == "us.anthropic.claude-sonnet-4-6"
 
     def test_region_tie_break_prefers_global(self):
-        models = db_mod.map_bedrock_claude_models(
+        models = db_mod.map_claude_family_models(
             [
                 "us.anthropic.claude-opus-4-8",
                 "global.anthropic.claude-opus-4-8",
@@ -519,8 +519,20 @@ class TestMapBedrockClaudeModels:
         )
         assert models["opus"] == "global.anthropic.claude-opus-4-8"
 
+    def test_maps_canonical_anthropic_ids(self):
+        # An Anthropic service publishes canonical ids (no region prefix); the same mapper groups
+        # them by family and picks the highest version, so per-family pinning works there too.
+        models = db_mod.map_claude_family_models(
+            ["claude-sonnet-5", "claude-haiku-4-5", "claude-opus-4-8"]
+        )
+        assert models == {
+            "sonnet": "claude-sonnet-5",
+            "haiku": "claude-haiku-4-5",
+            "opus": "claude-opus-4-8",
+        }
+
     def test_empty_when_no_claude(self):
-        assert db_mod.map_bedrock_claude_models(["amazon.titan-text-express-v1"]) == {}
+        assert db_mod.map_claude_family_models(["amazon.titan-text-express-v1"]) == {}
 
 
 class TestProviderServicePagination:

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -618,28 +618,27 @@ class TestModelPrompting:
 
     def test_provider_service_offers_its_targets(self):
         # The service's own targets are the model vocabulary the manifest must use, so the admin
-        # picks from them rather than typing an id from memory.
+        # picks from them rather than typing an id from memory. Uses codex here: it takes one model
+        # from any service (Claude with explicit targets is prompted per family — see the Bedrock/
+        # Anthropic per-family tests below).
         service = {
-            "name": "main.default.anthropic-mps",
-            "provider_type": "anthropic",
-            "targets": ["claude-sonnet-4-6", "claude-opus-4-8"],
+            "name": "main.default.openai-mps",
+            "provider_type": "openai",
+            "targets": ["gpt-5-6", "gpt-5-6-sol"],
             "allow_all_targets": False,
         }
         with (
-            patch.object(wizard, "prompt_for_selection", return_value="claude-opus-4-8") as select,
+            patch.object(wizard, "prompt_for_selection", return_value="gpt-5-6") as select,
             patch.object(wizard, "prompt_for_text") as text,
         ):
-            config = wizard._prompt_models_for_agent("claude", STATE, service)
+            config = wizard._prompt_models_for_agent("codex", STATE, service)
         assert config == {
-            "model_provider_service": "main.default.anthropic-mps",
-            "default_model": "claude-opus-4-8",
+            "model_provider_service": "main.default.openai-mps",
+            "default_model": "gpt-5-6",
         }
         assert not text.called, "should not fall back to free text when targets are known"
         # Offered sorted, so the picker order is stable run to run.
-        assert [value for value, _ in select.call_args[0][1]] == [
-            "claude-opus-4-8",
-            "claude-sonnet-4-6",
-        ]
+        assert [value for value, _ in select.call_args[0][1]] == ["gpt-5-6", "gpt-5-6-sol"]
 
     def test_provider_service_falls_back_to_text_when_targets_unknown(self):
         # allow_all_targets passes the provider's whole catalog through; there is nothing to list.
@@ -682,6 +681,224 @@ class TestModelPrompting:
         ):
             config = wizard._prompt_models_for_agent("pi", {}, None)
         assert config == {"default_model": "some-model"}
+
+    def test_bedrock_claude_prompts_per_family(self):
+        # render_overlay pins ANTHROPIC_DEFAULT_<FAMILY>_MODEL from a Bedrock service's provider-side
+        # ids (Claude Code can't route its canonical names there), so Claude needs a default per
+        # family — a single overall default would leave the other families unpinned.
+        service = {
+            "name": "main.default.bedrock",
+            "provider_type": "amazon_bedrock",
+            "allow_all_targets": False,
+            "targets": [
+                "anthropic.claude-opus-4-1",
+                "anthropic.claude-opus-4-8",
+                "anthropic.claude-sonnet-4-6",
+                "anthropic.claude-haiku-4-5",
+            ],
+        }
+        asked: list[str] = []
+
+        def fake_selection(prompt, options, **kwargs):
+            asked.append(prompt)
+            return options[0][0]
+
+        with (
+            # Decline quick setup to exercise the per-family prompts.
+            patch.object(wizard, "prompt_yes_no_default", return_value=False),
+            patch.object(wizard, "prompt_for_selection", side_effect=fake_selection),
+            patch.object(wizard, "print_note"),
+            patch.object(wizard, "print_success"),
+        ):
+            config = wizard._prompt_models_for_agent("claude", STATE, service)
+        assert [p for p in asked if p.startswith("Default ")] == [
+            "Default opus model:",
+            "Default sonnet model:",
+            "Default haiku model:",
+        ]
+        assert config["model_provider_service"] == "main.default.bedrock"
+        assert config["models"] == {
+            "default_opus_model": "anthropic.claude-opus-4-1",
+            "default_sonnet_model": "anthropic.claude-sonnet-4-6",
+            "default_haiku_model": "anthropic.claude-haiku-4-5",
+        }
+        # Slots carry the service's own provider-side ids, not workspace `system.ai.*` ids.
+        assert all(m.startswith("anthropic.") for m in config["models"].values())
+        assert config["default_model"] in service["targets"]
+
+    def test_bedrock_claude_skipped_family_is_omitted(self):
+        service = {
+            "name": "main.default.bedrock",
+            "provider_type": "amazon_bedrock",
+            "allow_all_targets": False,
+            "targets": ["anthropic.claude-opus-4-8", "anthropic.claude-sonnet-4-6"],
+        }
+        # pick=-1 selects the trailing "(skip <family>)" option for every family.
+        with (
+            patch.object(wizard, "prompt_yes_no_default", return_value=False),
+            patch.object(wizard, "prompt_for_selection", side_effect=lambda p, o, **k: o[-1][0]),
+            patch.object(wizard, "print_note"),
+        ):
+            config = wizard._prompt_models_for_agent("claude", STATE, service)
+        assert "models" not in config
+        assert config["default_model"] in service["targets"]
+
+    def test_bedrock_codex_still_takes_a_single_model(self):
+        # Only Claude pins per family; codex through any provider takes one model.
+        service = {
+            "name": "main.default.bedrock-oai",
+            "provider_type": "amazon_bedrock",
+            "allow_all_targets": False,
+            "targets": ["gpt-5-6", "gpt-5-6-sol"],
+        }
+        asked: list[str] = []
+        with (
+            patch.object(
+                wizard,
+                "prompt_for_selection",
+                side_effect=lambda p, o, **k: (asked.append(p), o[0][0])[1],
+            ),
+        ):
+            config = wizard._prompt_models_for_agent("codex", STATE, service)
+        assert len(asked) == 1
+        assert "models" not in config
+
+    def test_anthropic_claude_with_explicit_targets_prompts_per_family(self):
+        # An Anthropic service that publishes explicit canonical targets IS pinned per family by
+        # render_overlay (each ANTHROPIC_DEFAULT_<FAMILY>_MODEL to a chosen version), so the wizard
+        # prompts per family — same as Bedrock, just canonical ids instead of provider slugs.
+        service = {
+            "name": "main.default.ant",
+            "provider_type": "anthropic",
+            "allow_all_targets": False,
+            "targets": ["claude-opus-4-8", "claude-sonnet-4-6"],
+        }
+        asked: list[str] = []
+        with (
+            patch.object(wizard, "prompt_yes_no_default", return_value=False),
+            patch.object(
+                wizard,
+                "prompt_for_selection",
+                side_effect=lambda p, o, **k: (asked.append(p), o[0][0])[1],
+            ),
+            patch.object(wizard, "print_note"),
+            patch.object(wizard, "print_success"),
+        ):
+            config = wizard._prompt_models_for_agent("claude", STATE, service)
+        assert [p for p in asked if p.startswith("Default ")] == [
+            "Default opus model:",
+            "Default sonnet model:",
+        ]
+        assert config["models"] == {
+            "default_opus_model": "claude-opus-4-8",
+            "default_sonnet_model": "claude-sonnet-4-6",
+        }
+
+    def test_quick_setup_fills_newest_per_family_without_per_family_prompts(self):
+        # Quick setup (default yes) auto-fills each family with the service's newest id — same pick
+        # map_claude_family_models makes — and asks no per-family questions.
+        service = {
+            "name": "main.default.bedrock",
+            "provider_type": "amazon_bedrock",
+            "allow_all_targets": False,
+            "targets": [
+                "anthropic.claude-opus-4-1",
+                "anthropic.claude-opus-4-8",
+                "anthropic.claude-sonnet-4-6",
+            ],
+        }
+        selections: list[str] = []
+        with (
+            patch.object(wizard, "prompt_yes_no_default", return_value=True),
+            patch.object(
+                wizard,
+                "prompt_for_selection",
+                side_effect=lambda p, o, **k: selections.append(p) or o[0][0],
+            ),
+            patch.object(wizard, "print_note"),
+            patch.object(wizard, "print_success"),
+        ):
+            config = wizard._prompt_models_for_agent("claude", STATE, service)
+        # No per-family (or overall-default) picker was shown — quick setup asked nothing.
+        assert selections == []
+        assert config["models"] == {
+            "default_opus_model": "anthropic.claude-opus-4-8",  # newest opus, not 4-1
+            "default_sonnet_model": "anthropic.claude-sonnet-4-6",
+        }
+        # Overall default is opus (the flagship), not sonnet.
+        assert config["default_model"] == "anthropic.claude-opus-4-8"
+
+    def test_quick_setup_default_is_flagship_not_target_order(self):
+        # Regression: the overall default must be the highest-tier family (opus), not whichever
+        # target sorts first — here haiku leads the list but opus must still win.
+        service = {
+            "name": "main.default.bedrock",
+            "provider_type": "amazon_bedrock",
+            "allow_all_targets": False,
+            "targets": [
+                "us.anthropic.claude-haiku-4-5",
+                "us.anthropic.claude-sonnet-5",
+                "us.anthropic.claude-opus-5",
+            ],
+        }
+        with (
+            patch.object(wizard, "prompt_yes_no_default", return_value=True),
+            patch.object(wizard, "print_note"),
+            patch.object(wizard, "print_success"),
+        ):
+            config = wizard._prompt_models_for_agent("claude", STATE, service)
+        assert config["default_model"] == "us.anthropic.claude-opus-5"
+
+    def test_quick_setup_default_falls_to_sonnet_without_opus(self):
+        service = {
+            "name": "main.default.bedrock",
+            "provider_type": "amazon_bedrock",
+            "allow_all_targets": False,
+            "targets": ["us.anthropic.claude-haiku-4-5", "us.anthropic.claude-sonnet-5"],
+        }
+        with (
+            patch.object(wizard, "prompt_yes_no_default", return_value=True),
+            patch.object(wizard, "print_note"),
+            patch.object(wizard, "print_success"),
+        ):
+            config = wizard._prompt_models_for_agent("claude", STATE, service)
+        assert config["default_model"] == "us.anthropic.claude-sonnet-5"
+
+    def test_anthropic_claude_allow_all_takes_a_single_default(self):
+        # No explicit targets (allow_all) means nothing is pinned — Claude Code's canonical names
+        # route fine — so it falls back to a single free-text default, not per-family slots.
+        service = {
+            "name": "main.default.ant-all",
+            "provider_type": "anthropic",
+            "allow_all_targets": True,
+            "targets": [],
+        }
+        with (
+            patch.object(wizard, "prompt_for_text", return_value="claude-sonnet-5"),
+            patch.object(wizard, "print_note"),
+        ):
+            config = wizard._prompt_models_for_agent("claude", STATE, service)
+        assert "models" not in config
+        assert config["default_model"] == "claude-sonnet-5"
+
+    def test_allow_all_with_explicit_claude_targets_does_not_abort(self):
+        # Regression: a service that is allow_all_targets AND lists Claude targets. The family
+        # decision must key on the enumerated targets (which allow_all zeroes), not the raw service —
+        # otherwise it takes the per-family branch with an empty list and aborts the wizard.
+        service = {
+            "name": "main.default.weird",
+            "provider_type": "amazon_bedrock",
+            "allow_all_targets": True,
+            "targets": ["us.anthropic.claude-opus-5", "us.anthropic.claude-sonnet-5"],
+        }
+        with (
+            patch.object(wizard, "prompt_for_text", return_value="typed-model"),
+            patch.object(wizard, "print_note"),
+        ):
+            config = wizard._prompt_models_for_agent("claude", STATE, service)
+        # Falls through to the single free-text default; no per-family slots, no KeyboardInterrupt.
+        assert "models" not in config
+        assert config["default_model"] == "typed-model"
 
     def test_empty_selection_is_re_prompted(self):
         # An agent with no default_model can't be the config's default_agent (the server rejects


### PR DESCRIPTION
`ucode setup` asked for a single default when Claude Code used a Model Provider Service, but Claude addresses models by family alias, and a managed launch pins each `ANTHROPIC_DEFAULT_<FAMILY>_MODEL` from the manifest — so a lone default left the other families unpinned.

## Setup: per-family prompt + quick setup

When a service publishes explicit Claude targets (Bedrock provider-side slugs *or* canonical Anthropic ids), the wizard now prompts one model per family, gated on `_pins_family_models(targets)` — keyed on behaviour, not vendor.

After picking the service, **"Quick setup?"** (default yes) fills each family with the service's newest id, so the common case is one keystroke. Answering no runs the per-family prompts, for pinning a specific version or region. The overall default is the highest-tier family (opus → sonnet → haiku; fable is opt-in), not whichever target sorted first.

## Launch: managed honors the manifest, configure unchanged

- `resolve_provider_models` (the `ucode configure` → `ucode claude` path) is **unchanged**: only Bedrock pins, re-derived from live targets. Widening it would surprise developers who configured their own provider.
- New `managed_provider_family_models`: a **managed** launch pins Claude's families from the admin's *authored* manifest slots, so the versions chosen in `setup` win rather than being re-derived to "newest". Falls back to the single `default_model` for an `allow_all_targets` service (TODO: a list-models API would let the wizard offer per-family there too).

`map_bedrock_claude_models` → `map_claude_family_models` (it always worked on canonical ids too, now serves both paths).

## Tests

Per-family (Bedrock + Anthropic), quick setup + flagship-default regression, allow_all fallback, codex single-model, canonical-id mapping, managed-launch pinning from authored slots, and a regression for an `allow_all_targets` service that *also* lists Claude targets (must not abort the wizard). Configure-path test reasserts the unchanged Anthropic-pins-nothing behaviour.

This pull request and its description were written by Isaac.