### PR TITLE
Cap mcp below 2.0 so `ucode mcp-proxy` imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,10 @@ dependencies = [
   # `ucode mcp-proxy` bridges a client's stdio MCP transport to a Databricks
   # streamable-HTTP MCP endpoint, injecting a freshly-minted OAuth bearer per
   # request. Uses the official MCP SDK's stdio server + streamable-HTTP client.
-  "mcp>=1.28.0",
+  # Capped below 2.0: mcp 2.x swaps httpx for httpx2 and renames
+  # `streamablehttp_client` to `streamable_http_client`, so `ucode.mcp_proxy`
+  # fails to import against it. Lift once the proxy is ported.
+  "mcp>=1.28.0,<2",
   "questionary>=2.0.0",
   "tomlkit>=0.13.0",
   "typer>=0.12.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3182,7 +3182,7 @@ dev = [
 requires-dist = [
     { name = "databricks-sql-connector", specifier = ">=3.6.0" },
     { name = "httpx", specifier = ">=0.27.1" },
-    { name = "mcp", specifier = ">=1.28.0" },
+    { name = "mcp", specifier = ">=1.28.0,<2" },
     { name = "mlflow", extras = ["databricks"], marker = "extra == 'tracing'", specifier = ">=3.4" },
     { name = "questionary", specifier = ">=2.0.0" },
     { name = "tomlkit", specifier = ">=0.13.0" },


### PR DESCRIPTION
## Problem

`ucode mcp-proxy` — the stdio bridge every Databricks MCP server ucode configures points at — crashes on startup:

```
File ".../ucode/mcp_proxy.py", line 33, in <module>
    from mcp.client.streamable_http import streamablehttp_client
ImportError: cannot import name 'streamablehttp_client' from 'mcp.client.streamable_http'
```

The dependency was pinned `mcp>=1.28.0` with **no upper bound**, so once `mcp` 2.0.0 published, fresh `uv tool install`s resolved to it. mcp 2.x renamed `streamablehttp_client` -> `streamable_http_client` and swapped `httpx` for `httpx2`, so `ucode.mcp_proxy` fails at import, before the MCP handshake. Because the crash is at module import, **every** Databricks MCP server routed through the proxy fails identically; clients surface it as the generic `Failed to reconnect ... -32000`.

## Fix

Cap the constraint at `mcp>=1.28.0,<2`. The resolved version stays `1.28.1`, so this is a pure constraint change with no code or transitive-resolution change (only the specifier line in `uv.lock`).

Porting the proxy to mcp 2.x is deliberately **not** in scope: 2.0 dropped the `auth=` kwarg the proxy relies on, requiring a rewrite of the per-request token-refresh path onto `httpx2.AsyncClient`, plus a new `httpx2` dependency. The proxy is transport-only and gains nothing functional from 2.0, so that port should be a separate, deliberately-tested change (and should land as `>=2,<3`, keeping an upper bound).

## Testing

- Reproduced the crash against `mcp==2.0.0`; confirmed `mcp==1.28.1` imports `ucode.mcp_proxy` cleanly.

This pull request and its description were written by Isaac.
