### PR TITLE
Apply managed config's skills on launch

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -83,6 +83,7 @@ from ucode.mcp import (
     MCP_CLIENTS,
     SKILLS_MCP_KIND,
     apply_managed_mcp_servers,
+    apply_managed_skills,
     configure_mcp_command,
     configure_skills_mcp_command,
     purge_cross_workspace_mcp_residue,
@@ -1452,6 +1453,33 @@ def _register_managed_mcp_servers(managed: dict, tool: str, state: dict) -> None
         print_note(f"Registered workspace MCP server(s) for {TOOL_SPECS[tool]['display']}: {names}")
 
 
+def _apply_managed_skills(managed: dict, tool: str, state: dict) -> None:
+    """Register the managed config's skill schemas on ``tool``'s skills MCP connection.
+
+    Sibling of :func:`_register_managed_mcp_servers` for the skills registry: the managed config
+    lists the skill schemas the admin published, and nothing else on the launch path routes them to
+    the agent. ``apply_managed_skills`` persists the connection (and the applied set, for diffing a
+    later removal) into ``state`` itself. A failure here never blocks the launch.
+    """
+    try:
+        applied = apply_managed_skills(
+            state,
+            managed,
+            tool,
+            state["workspace"],
+            state.get("profile"),
+            use_pat=bool(state.get("use_pat")),
+        )
+    except RuntimeError as exc:
+        print_warning(f"Could not register your workspace's skills: {exc}")
+        return
+    if applied:
+        names = ", ".join(applied)
+        print_note(
+            f"Registered workspace skill schema(s) for {TOOL_SPECS[tool]['display']}: {names}"
+        )
+
+
 def _launch_tool(
     tool_name: str,
     ctx: typer.Context,
@@ -1702,6 +1730,7 @@ def _launch_tool(
         # unmanaged) and --dry-run (writes nothing).
         if managed is not None and not skip_preflight and not is_dry_run():
             _register_managed_mcp_servers(managed, tool, state)
+            _apply_managed_skills(managed, tool, state)
         print_success(f"Starting {TOOL_SPECS[tool]['display']}")
         launch_agent(tool, state, ctx.args)
     except RuntimeError as exc:

--- a/src/ucode/mcp.py
+++ b/src/ucode/mcp.py
@@ -1155,6 +1155,63 @@ def apply_managed_mcp_servers(
     return working
 
 
+def apply_managed_skills(
+    state: dict,
+    managed: dict,
+    tool: str,
+    workspace: str,
+    profile: str | None = None,
+    *,
+    use_pat: bool = False,
+) -> list[str]:
+    """Register the managed config's skill schemas on ``tool``'s skills MCP connection.
+
+    The managed config lists skill schemas the admin published as ``catalog.schema`` locations under
+    ``skills.names``; nothing else on the launch path routes them to the agent, so without this a
+    workspace-published skill schema never reaches the agent's skills registry. Merges them into the
+    developer's own ``skill_locations`` (preserving those), diffs against what ucode applied on a
+    prior launch — tracked under ``managed_skill_locations`` — so a schema the admin later drops is
+    removed, and registers the single skills connection for the launching tool.
+
+    Mutates and persists ``state`` in place (the skills connection lives in ``state['mcp_servers']``).
+    Returns the managed locations applied (for the caller's note), or ``[]`` when nothing changed —
+    the config names none and none were applied before, or the connection was already current.
+
+    When the admin drops their last schema and the developer configured none of their own, the
+    connection is rebuilt with no ``skill_locations`` (the schema-less, utility-only form), matching
+    ``configure skills --mcp`` with no location, rather than being removed outright.
+    """
+    if tool not in MCP_CLIENTS:
+        return []
+    desired = [
+        loc
+        for loc in ((managed.get("skills") or {}).get("names") or [])
+        if isinstance(loc, str) and loc
+    ]
+    prev_managed = [
+        loc for loc in (state.get("managed_skill_locations") or []) if isinstance(loc, str) and loc
+    ]
+    if not desired and not prev_managed:
+        return []
+    # Preserve the developer's own locations, drop previously-managed ones no longer in the config,
+    # and add the current managed set. dict.fromkeys dedupes while keeping first-seen order.
+    current = _skill_mcp_locations(state)
+    developer_own = [loc for loc in current if loc not in prev_managed]
+    new_locations = list(dict.fromkeys([*developer_own, *desired]))
+
+    original = list(state.get("mcp_servers") or [])
+    working = _resolve_skills_mcp_servers(workspace, [tool], new_locations, original)
+    changed = apply_mcp_server_changes(
+        original, working, [tool], workspace, profile, use_pat=use_pat
+    )
+    if not (changed or original != working or prev_managed != desired):
+        return []
+    state["mcp_servers"] = working
+    state["managed_skill_locations"] = desired
+    save_state(state)
+    return desired
+
+
 def _resolve_mcp_selection(
     selection: str,
     workspace: str,

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2497,6 +2497,103 @@ class TestApplyManagedMcpServers:
         assert registered == []
 
 
+class TestApplyManagedSkills:
+    def _managed(self, *names):
+        return {"skills": {"names": list(names)}} if names else {}
+
+    def _skills_entry(self, servers):
+        return next(s for s in servers if s.get("kind") == mcp.SKILLS_MCP_KIND)
+
+    def _patch_apply(self, monkeypatch):
+        """Stub out the config-file writes and report whether a change was applied."""
+        monkeypatch.setattr(mcp, "save_state", lambda state: None)
+        monkeypatch.setattr(
+            mcp, "apply_mcp_server_changes", lambda orig, working, *a, **k: orig != working
+        )
+
+    def test_registers_managed_locations_for_the_launching_tool(self, monkeypatch):
+        self._patch_apply(monkeypatch)
+        state = {"workspace": WS, "mcp_servers": []}
+        applied = mcp.apply_managed_skills(state, self._managed("cat.sch"), "claude", WS)
+        assert applied == ["cat.sch"]
+        entry = self._skills_entry(state["mcp_servers"])
+        assert entry["skill_locations"] == ["cat.sch"]
+        assert entry["clients"] == ["claude"]
+        assert state["managed_skill_locations"] == ["cat.sch"]
+
+    def test_preserves_developer_locations_and_drops_removed_managed_ones(self, monkeypatch):
+        self._patch_apply(monkeypatch)
+        # The developer configured `mine.own`; a prior launch applied `old.managed`, now dropped from
+        # the config in favor of `new.managed`.
+        state = {
+            "workspace": WS,
+            "managed_skill_locations": ["old.managed"],
+            "mcp_servers": [
+                {
+                    "name": mcp.SKILLS_MCP_SERVER_NAME,
+                    "kind": mcp.SKILLS_MCP_KIND,
+                    "skill_locations": ["mine.own", "old.managed"],
+                    "clients": ["claude"],
+                }
+            ],
+        }
+        applied = mcp.apply_managed_skills(state, self._managed("new.managed"), "claude", WS)
+        assert applied == ["new.managed"]
+        entry = self._skills_entry(state["mcp_servers"])
+        assert entry["skill_locations"] == ["mine.own", "new.managed"]
+        assert state["managed_skill_locations"] == ["new.managed"]
+
+    def test_removed_managed_schema_leaves_developer_locations(self, monkeypatch):
+        self._patch_apply(monkeypatch)
+        state = {
+            "workspace": WS,
+            "managed_skill_locations": ["gone.managed"],
+            "mcp_servers": [
+                {
+                    "name": mcp.SKILLS_MCP_SERVER_NAME,
+                    "kind": mcp.SKILLS_MCP_KIND,
+                    "skill_locations": ["mine.own", "gone.managed"],
+                    "clients": ["claude"],
+                }
+            ],
+        }
+        applied = mcp.apply_managed_skills(state, self._managed(), "claude", WS)
+        assert applied == []  # nothing managed now, but the removal still applied
+        entry = self._skills_entry(state["mcp_servers"])
+        assert entry["skill_locations"] == ["mine.own"]
+        assert state["managed_skill_locations"] == []
+
+    def test_nothing_managed_and_none_before_is_a_noop(self, monkeypatch):
+        monkeypatch.setattr(mcp, "save_state", lambda state: pytest.fail("should not persist"))
+        monkeypatch.setattr(
+            mcp, "apply_mcp_server_changes", lambda *a, **k: pytest.fail("should not apply")
+        )
+        state = {"workspace": WS, "mcp_servers": []}
+        assert mcp.apply_managed_skills(state, self._managed(), "claude", WS) == []
+        assert "mcp_servers" in state and state["mcp_servers"] == []
+        assert "managed_skill_locations" not in state
+
+    def test_unchanged_managed_set_returns_empty(self, monkeypatch):
+        self._patch_apply(monkeypatch)
+        # Build the stored entry exactly as a re-resolve would, so an unchanged config is a true
+        # no-op rather than differing on the derived url/auth fields.
+        entry = mcp._resolve_skills_mcp_servers(WS, ["claude"], ["cat.sch"], [])[0]
+        state = {
+            "workspace": WS,
+            "managed_skill_locations": ["cat.sch"],
+            "mcp_servers": [entry],
+        }
+        # Same config, same tool already registered: no change, so no note-worthy locations returned.
+        assert mcp.apply_managed_skills(state, self._managed("cat.sch"), "claude", WS) == []
+
+    def test_non_client_tool_returns_empty(self, monkeypatch):
+        monkeypatch.setattr(
+            mcp, "apply_mcp_server_changes", lambda *a, **k: pytest.fail("should not apply")
+        )
+        state = {"workspace": WS, "mcp_servers": []}
+        assert mcp.apply_managed_skills(state, self._managed("cat.sch"), "not-a-client", WS) == []
+
+
 class TestPromptForMcpSearchSourcesExclusion:
     def _values(self, monkeypatch, exclude):
         captured: dict = {}


### PR DESCRIPTION
Managed configs already record skill schemas under `skills.names`, but nothing on the launch path routed them to the agent — they only showed as "(pending)". Wire them in like managed MCP servers: `apply_managed_skills` merges the admin's `catalog.schema` locations into the developer's skills MCP connection for the launching tool, preserving the developer's own locations and diffing against `managed_skill_locations` so a schema the admin later drops is removed.

Registration only (skills served over the proxy) — no disk download.

Co-authored-by: Isaac