### PR TITLE
launch: don't let a local provider service override a managed config

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -1486,12 +1486,9 @@ def _launch_tool(
         if needs_auto_configure:
             _auto_configure_tool(tool)
         state = ensure_provider_state(tool)
-        # Remembered before the fallback below collapses the two cases: a managed config may not
-        # silently override a provider the user typed on the command line (it errors instead).
+        # Remembered so a managed config may not silently override a provider the user typed on the
+        # command line (it errors instead), and so the fallback below can distinguish the two.
         explicit_provider = provider
-        # An explicit --provider overrides the persisted choice; otherwise fall
-        # back to whatever `ucode configure` saved for this tool.
-        provider = provider or get_provider_service(state, tool)
         routing_agent = _ROUTING_AGENTS.get(tool)
         # Fetched before `configure_shared_state` because it decides whether this agent may launch
         # at all and whether the model discovery below can be skipped.
@@ -1501,6 +1498,28 @@ def _launch_tool(
             managed = _fetch_managed_config(state, skip_preflight=skip_preflight)
         # Checked before discovery, which can take tens of seconds, so a blocked launch fails fast.
         _reject_disabled_agent(managed, tool)
+        # Settle the provider before discovery (which keys `skip_model_discovery` off it). Under a
+        # managed config the provider comes only from the manifest, or an explicit --provider that
+        # agrees with it — never the developer's own `ucode configure` choice. Letting a locally
+        # saved provider service leak in would override the admin's model and silently reroute the
+        # agent to a provider the manifest never named (e.g. the manifest pins a Databricks model
+        # with no provider, but the developer's OpenAI service hijacks the launch). Without a
+        # managed config, fall back to the configured provider as before.
+        if managed is not None:
+            managed_provider = managed_provider_service(managed, tool)
+            if explicit_provider and managed_provider and managed_provider != explicit_provider:
+                # An explicit --provider that disagrees with the admin's is a hard error rather than
+                # a silent override: the user asked for something the managed config forbids.
+                raise RuntimeError(
+                    f"You cannot launch {TOOL_SPECS[tool]['display']} with provider "
+                    f"{explicit_provider} because your admin has specified managed provider "
+                    f"{managed_provider}."
+                )
+            provider = explicit_provider or managed_provider
+        else:
+            # An explicit --provider overrides the persisted choice; otherwise fall back to whatever
+            # `ucode configure` saved for this tool.
+            provider = explicit_provider or get_provider_service(state, tool)
         # Discovery exists to find models and isn't needed for managed config that already names them.
         managed_models_known = managed_supplies_models(managed, tool)
         # Re-fetch model lists on every launch so newly-added Databricks
@@ -1545,21 +1564,8 @@ def _launch_tool(
                     )
         elif managed_agent_config_enabled():
             print_note("No managed coding agent config found; using your own settings")
-        if managed is not None:
-            managed_provider = managed_provider_service(managed, tool)
-            if explicit_provider and managed_provider and managed_provider != explicit_provider:
-                # An explicit --provider that disagrees with the admin's is a hard error rather
-                # than a silent override: the user asked for something the managed config forbids,
-                # and quietly routing them elsewhere would hide it.
-                raise RuntimeError(
-                    f"You cannot launch {TOOL_SPECS[tool]['display']} with provider "
-                    f"{explicit_provider} because your admin has specified managed provider "
-                    f"{managed_provider}."
-                )
-            if managed_provider:
-                provider = managed_provider
-        # Checked after the managed config settles `provider`: an admin-set provider must trip this
-        # guard too, or routing would be persisted as on while a provider is active.
+        # `provider` is already settled above (including any admin-set provider), so this guard trips
+        # for a managed provider too, rather than persisting routing as on while a provider is active.
         if routing_agent is not None and enable_smart_routing_flag and provider:
             raise RuntimeError(
                 f"{TOOL_SPECS[tool]['display']} smart routing cannot be enabled with "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -357,6 +357,68 @@ class TestClaudeModelFlag:
         assert "enterprise managed settings" not in _strip_ansi(result.output)
 
 
+class TestManagedProviderResolution:
+    """Under a managed config the launch provider comes only from the manifest (or an explicit
+    --provider that agrees with it) — never the developer's own `ucode configure` choice, which
+    would otherwise override the admin's model and reroute the agent."""
+
+    # A local provider the developer configured for codex — must NOT leak into a managed launch.
+    _LOCAL_PROVIDER_STATE = {**MINIMAL_STATE, "provider_services": {"codex": "main.dev.openai_all"}}
+
+    def _run_codex(self, managed, extra_argv=None):
+        """Invoke `ucode codex` with `managed` in force, capturing the configure_tool call."""
+        state = self._LOCAL_PROVIDER_STATE
+        with (
+            patch("ucode.cli.ensure_bootstrap_dependencies"),
+            patch("ucode.cli.load_state", return_value=state),
+            patch("ucode.cli.ensure_provider_state", return_value=state),
+            patch("ucode.cli.configure_shared_state", return_value=state),
+            patch("ucode.cli.resolve_launch_model", return_value=(state, "system.ai.glm-5-2")),
+            patch("ucode.cli.resolve_provider_models", return_value=(None, None, False)),
+            patch("ucode.cli.configure_tool", return_value=state) as mock_configure,
+            patch("ucode.cli._fetch_managed_config", return_value=managed),
+            patch("ucode.cli._fetch_budget_recommendation", return_value=None),
+            patch("ucode.cli._register_managed_mcp_servers"),
+            patch("ucode.cli.launch_agent"),
+        ):
+            result = runner.invoke(app, ["codex", *(extra_argv or [])])
+        return result, mock_configure
+
+    def test_local_provider_does_not_override_managed_model(self):
+        # Manifest pins a Databricks model with no provider; the developer's local provider service
+        # must be ignored so the admin's model is what launches.
+        managed = {
+            "enabled_agents": {"codex": {"model_config": {"default_model": "system.ai.glm-5-2"}}}
+        }
+        result, mock_configure = self._run_codex(managed)
+        assert result.exit_code == 0, result.output
+        assert mock_configure.call_args.kwargs["provider"] is None
+        assert mock_configure.call_args.args[2] == "system.ai.glm-5-2"
+        # The misleading "Provider:" line is gone, since the launch pins no provider.
+        assert "main.dev.openai_all" not in _strip_ansi(result.output)
+
+    def test_managed_provider_is_used(self):
+        managed = {
+            "enabled_agents": {
+                "codex": {"model_config": {"model_provider_service": "main.admin.openai"}}
+            }
+        }
+        result, mock_configure = self._run_codex(managed)
+        assert result.exit_code == 0, result.output
+        assert mock_configure.call_args.kwargs["provider"] == "main.admin.openai"
+
+    def test_explicit_provider_conflicting_with_managed_is_rejected(self):
+        managed = {
+            "enabled_agents": {
+                "codex": {"model_config": {"model_provider_service": "main.admin.openai"}}
+            }
+        }
+        result, _ = self._run_codex(managed, ["--provider", "main.dev.other"])
+        assert result.exit_code == 1
+        assert "You cannot launch Codex with provider main.dev.other" in _strip_ansi(result.output)
+        assert "main.admin.openai" in _strip_ansi(result.output)
+
+
 class TestMcpSubcommands:
     def test_web_search_subcommand_help(self):
         result = runner.invoke(app, ["mcp", "web-search", "--help"])


### PR DESCRIPTION
## The bug

You run `ucode` under a managed config whose manifest pins Codex to `system.ai.glm-5-2` with **no** `model_provider_service`. On a machine where you'd separately run `ucode configure` and set a provider service for Codex (`main.dev.openai_all`), the launch shows:

```
Provider: main.tien_le.openai_all
```

…and Codex starts on the provider's own model (`gpt-5.6-sol`) — **not** the admin's `glm-5-2`.

## Why

`_launch_tool` resolved the provider as `provider or get_provider_service(state, tool)` and only *overrode* it with the manifest's provider **when the manifest named one** (`cli.py`). When the manifest named a model but no provider, the developer's locally-configured provider service leaked in. Because a provider service suppresses Databricks model pinning (`if provider: resolved_model = None`), the admin's model was silently dropped and the agent was rerouted through the local provider — the managed config did **not** win.

## The fix

Settle the provider **once, before model discovery**, from the managed config alone:

- the manifest's provider, or
- an explicit `--provider` that agrees with it (a disagreement is still a hard error, now raised earlier / fail-fast), or
- otherwise **none** — so the managed model gets pinned.

Only when there is **no** managed config do we fall back to the developer's configured provider, exactly as before.

## Behavior-change note

An agent enabled by a managed config that names **neither** a model nor a provider will now launch on discovered Databricks models rather than the developer's local provider service. This is intentional — the managed config is authoritative — but calling it out in case a narrower rule (only suppress the local provider when the manifest names a model) is preferred.

## Testing

- New `TestManagedProviderResolution` in `tests/test_cli.py`: local provider is ignored and the managed model is pinned; a managed provider is used; an explicit `--provider` conflicting with the manifest is rejected. Mutation-verified (the key test fails without the fix — `provider` came through as the leaked local service).
- Full non-e2e suite green; `ruff check` / `ruff format` clean.

Independent of #309 (that only consolidated the managed-config file); this is launch-time provider resolution.

This pull request and its description were written by Isaac.