### PR TITLE
Treat FEATURE_DISABLED as no managed config

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -44,6 +44,7 @@ from ucode.databricks import (
     ensure_ai_gateway_v2,
     ensure_databricks_auth,
     ensure_pat_bearer,
+    fetch_managed_coding_agent_configs,
     find_profile_name_for_host,
     get_databricks_profiles,
     get_databricks_token,
@@ -63,6 +64,7 @@ from ucode.managed_budget import (
 )
 from ucode.managed_config import (
     get_model_recommendation,
+    is_feature_disabled,
     load_managed_state,
     managed_agent_config_enabled,
     refresh_managed_config,
@@ -1851,6 +1853,14 @@ def _launch_managed_default(
             print_warning(
                 "No managed coding agent config is saved locally yet, so there is nothing to "
                 "dry-run. Run `ucode` without --dry-run to pull your workspace's config first."
+            )
+            return
+        token = get_databricks_token(current, state.get("profile"))
+        _, reason = fetch_managed_coding_agent_configs(current, token)
+        if reason is not None and is_feature_disabled(reason):
+            print_warning(
+                "Managed coding agent config is not enabled for your workspace. Please launch "
+                "ucode with a specific agent, ex. `ucode codex` or `ucode claude`."
             )
             return
         _print_no_managed_config_guidance(current, state.get("profile"))

--- a/src/ucode/managed_config.py
+++ b/src/ucode/managed_config.py
@@ -276,6 +276,10 @@ def get_model_recommendation(workspace: str, token: str) -> tuple[dict | None, s
     """
     payload, reason = fetch_model_recommendation(workspace, token)
     if reason is not None:
+        # A disabled feature means the workspace behaves as though no config existed: fall back to
+        # the default model silently instead of warning about a budget we couldn't read.
+        if _is_feature_disabled(reason):
+            return None, None
         return None, reason
     agent = AGENT_ENUM_TO_TOOL.get(_str(payload.get("recommended_agent")) or "")
     model = _str(payload.get("recommended_model"))
@@ -311,7 +315,10 @@ def get_managed_config(workspace: str, token: str) -> tuple[dict | None, str | N
     configs, reason = fetch_managed_coding_agent_configs(workspace, token)
     if reason is not None:
         # A NOT_FOUND means the admin hasn't defined a config for this workspace — not a failure.
-        if _is_not_found(reason):
+        # A FEATURE_DISABLED means the feature is switched off server-side; either way the workspace
+        # has no config in effect, so both collapse to the authoritative (None, None) that clears a
+        # previously cached config rather than a warning that would reapply it.
+        if _is_not_found(reason) or _is_feature_disabled(reason):
             return None, None
         return None, reason
     if not configs:
@@ -326,6 +333,15 @@ def _is_not_found(reason: str) -> bool:
     as an ``HTTP 404`` there (and the API's error body carries ``NOT_FOUND``)."""
     lowered = reason.lower()
     return "http 404" in lowered or "not_found" in lowered
+
+
+def _is_feature_disabled(reason: str) -> bool:
+    """True when a read failure means the coding-agent config feature is switched off server-side.
+
+    The gateway gates the feature behind a SAFE flag; when it is off, reads fail with a
+    ``FEATURE_DISABLED`` error whose body carries that ``error_code``. A disabled feature is not a
+    failure to report — the workspace behaves exactly as though no managed config existed."""
+    return "feature_disabled" in reason.lower()
 
 
 def _is_permission_denied(reason: str) -> bool:

--- a/src/ucode/managed_config.py
+++ b/src/ucode/managed_config.py
@@ -276,9 +276,7 @@ def get_model_recommendation(workspace: str, token: str) -> tuple[dict | None, s
     """
     payload, reason = fetch_model_recommendation(workspace, token)
     if reason is not None:
-        # A disabled feature means the workspace behaves as though no config existed: fall back to
-        # the default model silently instead of warning about a budget we couldn't read.
-        if _is_feature_disabled(reason):
+        if is_feature_disabled(reason):
             return None, None
         return None, reason
     agent = AGENT_ENUM_TO_TOOL.get(_str(payload.get("recommended_agent")) or "")
@@ -314,11 +312,7 @@ def get_managed_config(workspace: str, token: str) -> tuple[dict | None, str | N
     """
     configs, reason = fetch_managed_coding_agent_configs(workspace, token)
     if reason is not None:
-        # A NOT_FOUND means the admin hasn't defined a config for this workspace — not a failure.
-        # A FEATURE_DISABLED means the feature is switched off server-side; either way the workspace
-        # has no config in effect, so both collapse to the authoritative (None, None) that clears a
-        # previously cached config rather than a warning that would reapply it.
-        if _is_not_found(reason) or _is_feature_disabled(reason):
+        if _is_not_found(reason) or is_feature_disabled(reason):
             return None, None
         return None, reason
     if not configs:
@@ -335,12 +329,7 @@ def _is_not_found(reason: str) -> bool:
     return "http 404" in lowered or "not_found" in lowered
 
 
-def _is_feature_disabled(reason: str) -> bool:
-    """True when a read failure means the coding-agent config feature is switched off server-side.
-
-    The gateway gates the feature behind a SAFE flag; when it is off, reads fail with a
-    ``FEATURE_DISABLED`` error whose body carries that ``error_code``. A disabled feature is not a
-    failure to report — the workspace behaves exactly as though no managed config existed."""
+def is_feature_disabled(reason: str) -> bool:
     return "feature_disabled" in reason.lower()
 
 

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -28,6 +28,7 @@ from ucode.databricks import (
     delete_coding_agent_config,
     discover_claude_models_unbucketed,
     ensure_databricks_auth,
+    fetch_managed_coding_agent_configs,
     get_databricks_token,
     has_cached_model_provider_services,
     is_model_provider_feature_unavailable,
@@ -39,6 +40,7 @@ from ucode.databricks import (
     update_coding_agent_config,
 )
 from ucode.managed_config import (
+    _is_feature_disabled,
     get_managed_config,
     load_managed_state,
     managed_state_workspace,
@@ -860,6 +862,25 @@ def _render_summary(workspace: str, manifest: dict) -> None:
     print_panel("Configuration summary", lines)
 
 
+def _require_feature_enabled(workspace: str, token: str) -> None:
+    """Stop unless managed coding-agent config is enabled for this workspace.
+
+    When the server has the feature gated off it rejects every config read and write with
+    FEATURE_DISABLED, so authoring one can't work. Detect that here — with the same list read the
+    wizard makes next — and fail with a clear message instead of walking the admin through a setup
+    that could never publish. Mirrors the server's own order: the feature gate precedes the admin
+    check. A read that fails for any other reason is allowed through; the API still enforces the gate
+    at publish time.
+    """
+    with spinner("Checking whether managed coding-agent config is enabled..."):
+        _, reason = fetch_managed_coding_agent_configs(workspace, token)
+    if reason is not None and _is_feature_disabled(reason):
+        raise RuntimeError(
+            f"Managed coding-agent config is not enabled for {workspace}. Reach out to your "
+            "account admin to enable the Enhanced Unity AI Gateway Preview."
+        )
+
+
 def _require_admin(workspace: str, token: str) -> None:
     """Stop unless the caller is a workspace admin.
 
@@ -1032,6 +1053,7 @@ def setup_command(from_file: str | None = None) -> int:
     ensure_databricks_auth(workspace, profile, quiet=True)
     token = get_databricks_token(workspace, profile)
 
+    _require_feature_enabled(workspace, token)
     _require_admin(workspace, token)
     if not _handle_existing_config(workspace, token):
         return 0

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -40,8 +40,8 @@ from ucode.databricks import (
     update_coding_agent_config,
 )
 from ucode.managed_config import (
-    _is_feature_disabled,
     get_managed_config,
+    is_feature_disabled,
     load_managed_state,
     managed_state_workspace,
     save_managed_state,
@@ -863,18 +863,9 @@ def _render_summary(workspace: str, manifest: dict) -> None:
 
 
 def _require_feature_enabled(workspace: str, token: str) -> None:
-    """Stop unless managed coding-agent config is enabled for this workspace.
-
-    When the server has the feature gated off it rejects every config read and write with
-    FEATURE_DISABLED, so authoring one can't work. Detect that here — with the same list read the
-    wizard makes next — and fail with a clear message instead of walking the admin through a setup
-    that could never publish. Mirrors the server's own order: the feature gate precedes the admin
-    check. A read that fails for any other reason is allowed through; the API still enforces the gate
-    at publish time.
-    """
     with spinner("Checking whether managed coding-agent config is enabled..."):
         _, reason = fetch_managed_coding_agent_configs(workspace, token)
-    if reason is not None and _is_feature_disabled(reason):
+    if reason is not None and is_feature_disabled(reason):
         raise RuntimeError(
             f"Managed coding-agent config is not enabled for {workspace}. Reach out to your "
             "account admin to enable the Enhanced Unity AI Gateway Preview."

--- a/tests/test_managed_config.py
+++ b/tests/test_managed_config.py
@@ -186,8 +186,6 @@ class TestGetManagedConfig:
         ],
     )
     def test_feature_disabled_is_treated_as_no_config(self, monkeypatch, disabled_reason):
-        # A FEATURE_DISABLED means the feature is switched off server-side — the workspace behaves as
-        # though no config existed, so it collapses to (None, None) and clears any cached config.
         monkeypatch.setattr(
             mc_mod,
             "fetch_managed_coding_agent_configs",
@@ -512,7 +510,6 @@ class TestGetModelRecommendation:
         assert mc_mod.get_model_recommendation("https://w", "tok") == (None, "HTTP 500")
 
     def test_feature_disabled_is_no_recommendation(self, monkeypatch):
-        # A disabled feature reads as no recommendation, not a failure to warn the developer about.
         self._stub(
             monkeypatch, {}, reason='HTTP 400 Bad Request: {"error_code":"FEATURE_DISABLED"}'
         )

--- a/tests/test_managed_config.py
+++ b/tests/test_managed_config.py
@@ -178,6 +178,25 @@ class TestGetManagedConfig:
         assert cfg is None
         assert reason is None
 
+    @pytest.mark.parametrize(
+        "disabled_reason",
+        [
+            'HTTP 400 Bad Request: {"error_code":"FEATURE_DISABLED","message":"..."}',
+            'HTTP 403 Forbidden: {"error_code":"FEATURE_DISABLED"}',
+        ],
+    )
+    def test_feature_disabled_is_treated_as_no_config(self, monkeypatch, disabled_reason):
+        # A FEATURE_DISABLED means the feature is switched off server-side — the workspace behaves as
+        # though no config existed, so it collapses to (None, None) and clears any cached config.
+        monkeypatch.setattr(
+            mc_mod,
+            "fetch_managed_coding_agent_configs",
+            lambda ws, tok: ([], disabled_reason),
+        )
+        cfg, reason = get_managed_config("https://ws", "tok")
+        assert cfg is None
+        assert reason is None
+
 
 class TestPersistence:
     @pytest.fixture(autouse=True)
@@ -491,6 +510,13 @@ class TestGetModelRecommendation:
     def test_failed_read_surfaces_the_reason(self, monkeypatch):
         self._stub(monkeypatch, {}, reason="HTTP 500")
         assert mc_mod.get_model_recommendation("https://w", "tok") == (None, "HTTP 500")
+
+    def test_feature_disabled_is_no_recommendation(self, monkeypatch):
+        # A disabled feature reads as no recommendation, not a failure to warn the developer about.
+        self._stub(
+            monkeypatch, {}, reason='HTTP 400 Bad Request: {"error_code":"FEATURE_DISABLED"}'
+        )
+        assert mc_mod.get_model_recommendation("https://w", "tok") == (None, None)
 
     def test_unparseable_decimals_become_none(self, monkeypatch):
         self._stub(

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -213,6 +213,29 @@ class TestAdminGate:
         assert warn.called
 
 
+class TestFeatureGate:
+    def test_feature_disabled_is_rejected(self):
+        disabled = 'HTTP 400 Bad Request: {"error_code":"FEATURE_DISABLED"}'
+        with patch.object(
+            wizard, "fetch_managed_coding_agent_configs", return_value=([], disabled)
+        ):
+            with pytest.raises(RuntimeError, match="Enhanced Unity AI Gateway Preview"):
+                wizard._require_feature_enabled(WORKSPACE, "token")
+
+    def test_feature_enabled_passes(self):
+        with patch.object(wizard, "fetch_managed_coding_agent_configs", return_value=([], None)):
+            wizard._require_feature_enabled(WORKSPACE, "token")  # must not raise
+
+    def test_transient_read_failure_is_allowed_through(self):
+        # A non-FEATURE_DISABLED read failure must not block setup — the API still gates writes.
+        with patch.object(
+            wizard,
+            "fetch_managed_coding_agent_configs",
+            return_value=([], "HTTP 500 Server Error"),
+        ):
+            wizard._require_feature_enabled(WORKSPACE, "token")  # must not raise
+
+
 class TestExistingConfigHandling:
     RICH_CONFIG = {
         "name": "coding-agent-configs/abc",

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -227,7 +227,6 @@ class TestFeatureGate:
             wizard._require_feature_enabled(WORKSPACE, "token")  # must not raise
 
     def test_transient_read_failure_is_allowed_through(self):
-        # A non-FEATURE_DISABLED read failure must not block setup — the API still gates writes.
         with patch.object(
             wizard,
             "fetch_managed_coding_agent_configs",


### PR DESCRIPTION
## What

When the coding-agent config feature is gated off server-side, the AI Gateway returns a `FEATURE_DISABLED` error on the config reads. This treats that exactly like the existing `NOT_FOUND` handling — as "the workspace has no managed config in effect", not a failure to warn about.

- `get_managed_config`: `FEATURE_DISABLED` now collapses to `(None, None)` alongside `NOT_FOUND`. `(None, None)` is the authoritative "no config" result that also clears any previously cached config, rather than the failure path that warns *and* reapplies the cached config.
- `get_model_recommendation`: `FEATURE_DISABLED` collapses to `(None, None)`, so the budget/recommendation read falls back silently to the workspace's default model instead of printing a "Could not check your budget…" warning.

Net effect: with the feature disabled, ucode behaves exactly as though no coding-agent config existed — no warnings, no stale config reapplied.

## Testing

- `uv run pytest tests/test_managed_config.py` — added `test_feature_disabled_is_treated_as_no_config` (parametrized) and `test_feature_disabled_is_no_recommendation`, mirroring the existing `NOT_FOUND` tests. 54 passed.
- `uv run ruff check` — clean.

This pull request and its description were written by Isaac.
