### PR TITLE
ucode: require Databricks CLI 1.11.0+ for all skills commands

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -46,6 +46,7 @@ from ucode.agents.codex import revert_legacy_shared_config
 from ucode.agents.pi import PI_SETTINGS_BACKUP_PATH, PI_SETTINGS_PATH
 from ucode.config_io import is_dry_run, restore_file, set_dry_run
 from ucode.databricks import (
+    SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION,
     apply_pat_environment,
     build_shared_base_urls,
     discover_claude_models,
@@ -1311,6 +1312,7 @@ def skills_add(
     ``<catalog>.<schema>.<name>``.
     """
     try:
+        install_databricks_cli(minimum=SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION)
         locations = _parse_skill_locations(location)
         requested_skills = (
             None if skills is None else {s.strip() for s in skills.split(",") if s.strip()}
@@ -1421,6 +1423,7 @@ def skills_remove(
                 "Removing downloaded skills is not supported yet. Pass --mcp to remove "
                 "schemas from the skills MCP connection."
             )
+        install_databricks_cli(minimum=SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION)
         requested_agents = (
             None
             if agents is None
@@ -3192,6 +3195,7 @@ def configure_skills(
     ``--location``).
     """
     try:
+        install_databricks_cli(minimum=SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION)
         locations = _parse_skill_locations(location)
         # `--skill` absent -> None (whole schema); present (even empty) -> the
         # explicit subset, so `--skill ""` downloads nothing.
@@ -3303,7 +3307,7 @@ def setup_skills_cmd(
 ) -> None:
     """Choose the skills the managed config gives developers (admins only)."""
     try:
-        install_databricks_cli()
+        install_databricks_cli(minimum=SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION)
         # None means "prompt"; an explicit `--location` is parsed to the list to publish.
         locations = None if location is None else _parse_skill_locations(location)
         code = setup_skills_command(locations)

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -54,6 +54,8 @@ AI_GATEWAY_DOCS_URL = "https://docs.databricks.com/aws/en/ai-gateway/overview-be
 ANTHROPIC_MODELS_PATH = "/ai-gateway/anthropic/v1/models"
 # v1.0.0 is the release that ships `databricks aitools`.
 MIN_DATABRICKS_CLI_VERSION = (1, 0, 0)
+# v1.11.0 fixes `fs cp` (create -> finalize), which the skills MCP uploads rely on.
+SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION = (1, 11, 0)
 TOKEN_REFRESH_INTERVAL_SECONDS = 1800
 # Substrings the Databricks CLI emits when it loses the token-cache write lock
 # to a concurrent `databricks auth token` (e.g. another ucode helper process or
@@ -774,7 +776,9 @@ def _run_databricks_cli_installer(brew_subcommand: str = "install") -> None:
         raise RuntimeError("Failed to install/upgrade Databricks CLI automatically.") from exc
 
 
-def ensure_databricks_cli_version() -> None:
+def ensure_databricks_cli_version(
+    minimum: tuple[int, int, int] = MIN_DATABRICKS_CLI_VERSION,
+) -> None:
     try:
         result = run(
             ["databricks", "--version"],
@@ -793,14 +797,14 @@ def ensure_databricks_cli_version() -> None:
         raise RuntimeError(
             f"Could not parse Databricks CLI version from `databricks --version` output: {output!r}"
         )
-    if version < MIN_DATABRICKS_CLI_VERSION:
+    if version < minimum:
         current = ".".join(str(n) for n in version)
-        required = ".".join(str(n) for n in MIN_DATABRICKS_CLI_VERSION)
+        required = ".".join(str(n) for n in minimum)
         print_warning(
             f"Databricks CLI v{current} is too old (need v{required} or newer). Upgrading..."
         )
         _run_databricks_cli_installer(brew_subcommand="upgrade")
-        ensure_databricks_cli_version()
+        ensure_databricks_cli_version(minimum)
 
 
 def databricks_cli_version() -> tuple[int, int, int] | None:
@@ -835,9 +839,11 @@ def upgrade_databricks_cli() -> bool:
     return True
 
 
-def install_databricks_cli() -> None:
+def install_databricks_cli(
+    minimum: tuple[int, int, int] = MIN_DATABRICKS_CLI_VERSION,
+) -> None:
     if shutil.which("databricks"):
-        ensure_databricks_cli_version()
+        ensure_databricks_cli_version(minimum)
         return
 
     print_section("Bootstrap")
@@ -848,7 +854,7 @@ def install_databricks_cli() -> None:
         raise RuntimeError(
             "Databricks CLI install completed, but `databricks` is still not on PATH."
         )
-    ensure_databricks_cli_version()
+    ensure_databricks_cli_version(minimum)
 
 
 def install_ai_tools(agent_tokens: list[str], profile: str | None = None) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1287,6 +1287,19 @@ class TestStatus:
 
 
 class TestConfigureSkillsCommand:
+    @pytest.fixture(autouse=True)
+    def _stub_install_cli(self):
+        with patch("ucode.cli.install_databricks_cli") as mock_install:
+            yield mock_install
+
+    def test_requires_skills_mcp_cli_floor(self, _stub_install_cli):
+        from ucode.databricks import SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION
+
+        with patch("ucode.cli.configure_skills_mcp_command"):
+            result = runner.invoke(app, ["configure", "skills", "--location", "a.b", "--mcp"])
+        assert result.exit_code == 0, result.output
+        _stub_install_cli.assert_called_once_with(minimum=SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION)
+
     def test_mcp_flag_dispatches_location_set(self):
         with patch("ucode.cli.configure_skills_mcp_command") as mock_mcp:
             result = runner.invoke(app, ["configure", "skills", "--location", "a.b", "--mcp"])
@@ -1416,6 +1429,19 @@ class TestConfigureSkillsCommand:
 class TestSkillsAddCommand:
     """`ucode skill add` is the additive sibling of `configure skills`: `--mcp`
     unions schemas into the connection scope, the default mode downloads."""
+
+    @pytest.fixture(autouse=True)
+    def _stub_install_cli(self):
+        with patch("ucode.cli.install_databricks_cli") as mock_install:
+            yield mock_install
+
+    def test_requires_skills_mcp_cli_floor(self, _stub_install_cli):
+        from ucode.databricks import SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION
+
+        with patch("ucode.cli.add_skills_command"):
+            result = runner.invoke(app, ["skill", "add", "--location", "a.b", "--mcp"])
+        assert result.exit_code == 0, result.output
+        _stub_install_cli.assert_called_once_with(minimum=SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION)
 
     def test_mcp_flag_unions_locations(self):
         with patch("ucode.cli.add_skills_command") as mock_add:
@@ -1599,6 +1625,19 @@ class TestConfigureAgentsForMcp:
 
 
 class TestSkillsRemoveCommand:
+    @pytest.fixture(autouse=True)
+    def _stub_install_cli(self):
+        with patch("ucode.cli.install_databricks_cli") as mock_install:
+            yield mock_install
+
+    def test_requires_skills_mcp_cli_floor(self, _stub_install_cli):
+        from ucode.databricks import SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION
+
+        with patch("ucode.cli.remove_skills_command"):
+            result = runner.invoke(app, ["skill", "remove", "--mcp"])
+        assert result.exit_code == 0, result.output
+        _stub_install_cli.assert_called_once_with(minimum=SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION)
+
     def test_requires_mcp_until_download_removal_is_supported(self):
         with patch("ucode.cli.remove_skills_command") as remove:
             result = runner.invoke(app, ["skill", "remove"])

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -2284,6 +2284,30 @@ class TestEnsureDatabricksCliVersion:
         with pytest.raises(RuntimeError, match="Could not parse"):
             ensure_databricks_cli_version()
 
+    def test_custom_minimum_upgrades_version_below_it(self, tmp_path, monkeypatch):
+        import ucode.databricks as db_mod
+
+        # v1.8.0 clears the default floor but not the skills-MCP floor (1.11.0).
+        env = self._fake_databricks(tmp_path, "Databricks CLI v1.8.0")
+        monkeypatch.setattr("os.environ", env)
+        upgraded = []
+        monkeypatch.setattr(
+            db_mod,
+            "_run_databricks_cli_installer",
+            lambda brew_subcommand="install": upgraded.append(brew_subcommand),
+        )
+        call_count = [0]
+        original = db_mod.ensure_databricks_cli_version
+
+        def once(*a, **kw):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                original(*a, **kw)
+
+        monkeypatch.setattr(db_mod, "ensure_databricks_cli_version", once)
+        once(db_mod.SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION)
+        assert upgraded == ["upgrade"]
+
 
 class TestDatabricksCliVersion:
     def test_none_when_absent(self, monkeypatch):

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -2959,6 +2959,16 @@ class TestCliWiring:
             runner.invoke(app, ["setup", "skills", "--location", "main.a,main.b"])
         assert fn.call_args.args[0] == ["main.a", "main.b"]
 
+    def test_setup_skills_requires_cli_floor(self):
+        from ucode.databricks import SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION
+
+        with (
+            patch("ucode.cli.install_databricks_cli") as install,
+            patch("ucode.cli.setup_skills_command", return_value=0),
+        ):
+            runner.invoke(app, ["setup", "skills", "--location", "main.a"])
+        install.assert_called_once_with(minimum=SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION)
+
     def test_setup_help_needs_no_auth(self):
         # `ug setup help` reads the local draft only — it must not shell out to install the CLI.
         with (


### PR DESCRIPTION
## Summary

The skills commands register the skills MCP connection and drive skill uploads, which the MCP performs with `databricks fs cp`. That create then finalize sequence only writes correctly on Databricks CLI v1.11.0 and later, so a customer on an older CLI can run a skills command and then have uploads silently fail at finalize.

None of the skills commands currently provision or version check the CLI. This change gates every skills command in the CLI on a shared v1.11.0 floor, so no skills entry point can be reached on a CLI too old for the uploads it sets up.

## What changed

* `databricks.py`: added `SKILLS_MCP_MIN_DATABRICKS_CLI_VERSION = (1, 11, 0)` and parameterized `ensure_databricks_cli_version(minimum=...)` / `install_databricks_cli(minimum=...)`, defaulting to the global v1.0.0 floor so every non-skills command is unchanged.
* Gated every skills command on the skills floor. The check sits at the top of each command, so all invocation paths (`--mcp`, download, and the interactive pickers) are covered:
  * `ug skill add`
  * `ug skill remove`
  * `ug configure skills`

The installer upgrades transparently, so affected users get a single automatic CLI upgrade rather than a hard failure.

## Testing

* Added floor assertions for `skill add`, `skill remove`, and `configure skills`.
* Autouse installer stubs on the skills test classes so their dispatch tests do not shell out to the real installer.
* `tests/test_cli.py` and `tests/test_databricks.py` pass; ruff clean.

## Note

The v1.11.0 requirement reflects where `fs cp` writes correctly. The upload itself runs agent side through the skills MCP tools, outside this repo, so please confirm 1.11.0 is the exact fix version before merging.

This pull request and its description were written by Isaac.
