### PR TITLE
setup: show per-user spend threshold when picking budget tiers

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -428,13 +428,37 @@ def _has_per_user_block(entry: dict) -> bool:
     return False
 
 
+def _per_user_block_threshold(entry: dict) -> Decimal | None:
+    """The dollar amount a per-user hard block trips at, or None when there isn't one.
+
+    Reads ``quantity_threshold`` off the same per-user ``BLOCK_USAGE`` alert that
+    :func:`_has_per_user_block` gates on (``quantity_type`` is ``LIST_PRICE_DOLLARS_USD`` and
+    ``time_period`` is ``MONTH``, so it's a per-user monthly dollar cap). Budget tiers are picked as
+    percentages of this, so surfacing it lets the admin see the dollars a percentage stands for. A
+    block alert without a parseable threshold yields None — the wizard just omits the dollar hint.
+    """
+    for alert in entry.get("alert_configurations") or []:
+        if not isinstance(alert, dict) or alert.get("scope_type") != _PER_USER_ALERT_SCOPE:
+            continue
+        blocks = any(
+            isinstance(action, dict) and action.get("action_type") == _BLOCK_ACTION_TYPE
+            for action in alert.get("action_configurations") or []
+        )
+        if blocks:
+            return _parse_decimal(alert.get("quantity_threshold"))
+    return None
+
+
 def list_workspace_budgets(workspace: str, token: str) -> tuple[list[dict], str | None]:
     """List the AI Gateway budgets that apply to this workspace.
 
-    Returns ``(budgets, reason)`` where each budget is ``{"id", "display_name", "has_per_user_block"}``.
-    ``reason`` is None on success, otherwise it explains why the list is empty. ucode never creates
-    budgets — an admin picks an existing one to attach a spend-routing policy to. ``has_per_user_block``
-    lets the picker hide budgets that can't enforce spend routing (see ``_has_per_user_block``).
+    Returns ``(budgets, reason)`` where each budget is
+    ``{"id", "display_name", "has_per_user_block", "per_user_threshold"}``. ``reason`` is None on
+    success, otherwise it explains why the list is empty. ucode never creates budgets — an admin picks
+    an existing one to attach a spend-routing policy to. ``has_per_user_block`` lets the picker hide
+    budgets that can't enforce spend routing (see ``_has_per_user_block``); ``per_user_threshold`` is
+    the per-user monthly dollar cap (a ``Decimal``, or None when it can't be read) so the tier prompt
+    can show what a tier percentage works out to in dollars.
     """
     hostname = workspace_hostname(workspace)
     url = f"https://{hostname}{_WORKSPACE_BUDGETS_API_PATH}"
@@ -459,6 +483,7 @@ def list_workspace_budgets(workspace: str, token: str) -> tuple[list[dict], str 
                 "id": budget_id,
                 "display_name": display_name if isinstance(display_name, str) else "",
                 "has_per_user_block": _has_per_user_block(entry),
+                "per_user_threshold": _per_user_block_threshold(entry),
             }
         )
     if not budgets:

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -15,6 +15,7 @@ back out of ``state.json``, so there is exactly one picker per concern in the co
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 from pathlib import Path
 from typing import cast
 
@@ -54,6 +55,7 @@ from ucode.managed_setup import (
 from ucode.state import load_state
 from ucode.ui import (
     console,
+    format_usd,
     kv_line,
     print_err,
     print_heading,
@@ -747,6 +749,16 @@ def _prompt_budget_policy(
     if display_name:
         policy["display_name"] = display_name
 
+    # The per-user monthly cap the budget was created with. Tiers are picked as percentages of it, so
+    # showing the dollar amount (and what each percentage works out to) tells the admin what the total
+    # possible per-user spend even is. None when the listing couldn't read it — then we just skip the
+    # dollar hints and prompt in percent as before.
+    threshold = next(
+        (budget.get("per_user_threshold") for budget in usable if budget["id"] == budget_id), None
+    )
+    if threshold is not None:
+        print_note(f"This budget's per-user limit is {format_usd(threshold)} per month.")
+
     tiers: list[dict] = []
     seen_percentages: set[float] = set()
     seen_combos: set[tuple[str, str]] = set()
@@ -760,6 +772,13 @@ def _prompt_budget_policy(
         if fraction in seen_percentages:
             print_err("That percentage is already used by another tier; pick a different one.")
             continue
+        if threshold is not None:
+            # Echo the dollars this percentage stands for, so the admin can sanity-check the tier
+            # against the real per-user cap instead of reasoning about percentages in a vacuum.
+            print_note(
+                f"  {fraction * 100:g}% of {format_usd(threshold)} is "
+                f"{format_usd(threshold * Decimal(str(fraction)))}."
+            )
         agent = prompt_for_selection(
             f"Tier {index}: which agent becomes the default?",
             [(tool, TOOL_SPECS[tool]["display"]) for tool in enabled_agents],

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -2733,6 +2733,68 @@ class TestListWorkspaceBudgets:
         budgets, _ = list_workspace_budgets("https://ws", "token")
         assert budgets[0]["has_per_user_block"] is False
 
+    def test_extracts_per_user_block_threshold(self, monkeypatch):
+        # The per-user hard block's `quantity_threshold` is the monthly dollar cap; it's read off the
+        # same alert `has_per_user_block` gates on so the tier prompt can show it. A per-user alert
+        # without a block action (email only) contributes no threshold.
+        self._stub(
+            monkeypatch,
+            {
+                "workspace_ai_gateway_budgets": [
+                    {
+                        "budget_configuration_id": "capped",
+                        "display_name": "capped",
+                        "alert_configurations": [
+                            {
+                                "scope_type": self.PER_USER,
+                                "quantity_threshold": "500.00",
+                                "action_configurations": [{"action_type": self.BLOCK}],
+                            }
+                        ],
+                    },
+                    {
+                        "budget_configuration_id": "email_only",
+                        "display_name": "email only",
+                        "alert_configurations": [
+                            {
+                                "scope_type": self.PER_USER,
+                                "quantity_threshold": "500.00",
+                                "action_configurations": [{"action_type": self.EMAIL}],
+                            }
+                        ],
+                    },
+                ]
+            },
+        )
+        budgets, _ = list_workspace_budgets("https://ws", "token")
+        by_id = {b["id"]: b for b in budgets}
+        assert by_id["capped"]["per_user_threshold"] == Decimal("500.00")
+        assert by_id["email_only"]["per_user_threshold"] is None
+
+    def test_missing_threshold_is_none_but_block_still_flagged(self, monkeypatch):
+        # A hard block with no (or unparseable) `quantity_threshold` still enforces routing, so the
+        # budget stays offerable — the tier prompt just omits the dollar hint.
+        self._stub(
+            monkeypatch,
+            {
+                "workspace_ai_gateway_budgets": [
+                    {
+                        "budget_configuration_id": "b",
+                        "display_name": "x",
+                        "alert_configurations": [
+                            {
+                                "scope_type": self.PER_USER,
+                                "action_configurations": [{"action_type": self.BLOCK}],
+                            }
+                        ],
+                    }
+                ]
+            },
+        )
+        budgets, _ = list_workspace_budgets("https://ws", "token")
+        assert budgets[0]["has_per_user_block"] is True
+        assert budgets[0]["per_user_threshold"] is None
+
 
 class TestDiscoverSqlWarehouses:
     def _payload(self, *entries: dict) -> dict:

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -8,6 +8,7 @@ managed-config types, the admin gate, and the per-agent model-config shapes.
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
@@ -1295,6 +1296,54 @@ class TestBudgetPolicy:
                 "default_model": "system.ai.claude-opus-4-8",
             }
         ]
+
+    def test_shows_per_user_threshold_and_tier_dollars(self):
+        # The admin picks tiers as percentages, so surface the budget's per-user monthly cap and what
+        # each percentage works out to in dollars — otherwise a percentage is a number in a vacuum.
+        budgets = [
+            {
+                "id": BUDGET_ID,
+                "display_name": "eng",
+                "has_per_user_block": True,
+                "per_user_threshold": Decimal("500.00"),
+            }
+        ]
+        with (
+            patch.object(wizard, "prompt_yes_no_default", side_effect=[True, False]),
+            patch.object(wizard, "list_workspace_budgets", return_value=(budgets, None)),
+            patch.object(
+                wizard,
+                "prompt_for_selection",
+                side_effect=[BUDGET_ID, "claude", "system.ai.claude-opus-4-8"],
+            ),
+            patch.object(wizard, "prompt_for_text", return_value="tiered"),
+            patch.object(wizard, "prompt_for_percentage", return_value=0.8),
+            patch.object(wizard, "print_note") as note,
+        ):
+            wizard._prompt_budget_policy(WORKSPACE, "token", CLAUDE_ONLY, STATE)
+        notes = " ".join(str(call.args[0]) for call in note.call_args_list)
+        assert "$500" in notes  # the per-user monthly cap
+        assert "$400" in notes  # 80% of $500
+
+    def test_missing_threshold_skips_the_dollar_hints(self):
+        # A budget whose threshold couldn't be read still works; the prompt just omits the dollars.
+        budgets = [{"id": BUDGET_ID, "display_name": "eng", "has_per_user_block": True}]
+        with (
+            patch.object(wizard, "prompt_yes_no_default", side_effect=[True, False]),
+            patch.object(wizard, "list_workspace_budgets", return_value=(budgets, None)),
+            patch.object(
+                wizard,
+                "prompt_for_selection",
+                side_effect=[BUDGET_ID, "claude", "system.ai.claude-opus-4-8"],
+            ),
+            patch.object(wizard, "prompt_for_text", return_value="tiered"),
+            patch.object(wizard, "prompt_for_percentage", return_value=0.8),
+            patch.object(wizard, "print_note") as note,
+        ):
+            policy = wizard._prompt_budget_policy(WORKSPACE, "token", CLAUDE_ONLY, STATE)
+        notes = " ".join(str(call.args[0]) for call in note.call_args_list)
+        assert "$" not in notes
+        assert policy is not None and policy["tiers"][0]["spending_percentage"] == 0.8
 
     def test_offers_only_the_models_the_agent_was_configured_with(self):
         # Pi's catalog spans every family, so offering the workspace catalog would present four


### PR DESCRIPTION
Tiers are picked as percentages of a budget's per-user cap, but the cap was never shown, so a percentage was a number in a vacuum. Extract the per-user hard block's quantity_threshold in list_workspace_budgets and, in the tier prompt, show the monthly cap plus what each percentage works out to in dollars. Falls back to prompting in percent when the threshold can't be read.

<img width="1058" height="118" alt="Screenshot 2026-08-13 at 12 26 08 PM" src="https://github.com/user-attachments/assets/fd6fba6d-8e0c-41e5-a1fc-a29fec8e4baa" />


Co-authored-by: Isaac