### PR TITLE
setup: let admins enter a custom model in the hosted-model pickers

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1424,6 +1424,10 @@ def _model_service_id(service: dict) -> str | None:
 _MODEL_SERVICES_PAGE_SIZE = 100
 _MODEL_SERVICES_PAGE_RETRIES = 4
 
+# Substrings that mark a failure reason (`HTTP <code> <phrase>: <body>`) as a 404 / NOT_FOUND:
+# the HTTP status line and the Databricks `error_code` carried in the response body.
+_NOT_FOUND_REASON_MARKERS = ("http 404", "not_found")
+
 
 def _get_model_services_page(
     url: str, token: str, *, retries: int = _MODEL_SERVICES_PAGE_RETRIES
@@ -1547,7 +1551,7 @@ def _is_not_found_reason(reason: str | None) -> bool:
     if not reason:
         return False
     lowered = reason.lower()
-    return "http 404" in lowered or "not_found" in lowered
+    return any(marker in lowered for marker in _NOT_FOUND_REASON_MARKERS)
 
 
 def model_service_exists(

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1542,6 +1542,14 @@ def list_model_services(
     return [], last_reason or "model-services listing returned no models"
 
 
+def _is_not_found_reason(reason: str | None) -> bool:
+    """True when an HTTP reason describes a 404 / NOT_FOUND (a resource that isn't there)."""
+    if not reason:
+        return False
+    lowered = reason.lower()
+    return "http 404" in lowered or "not_found" in lowered
+
+
 def model_service_exists(
     workspace: str, token: str, full_name: str, *, max_pages: int = 100
 ) -> tuple[bool | None, str | None]:
@@ -1551,10 +1559,17 @@ def model_service_exists(
     model services in the typed name's own schema (``parent=schemas/<catalog>.<schema>``, the same
     scoped listing :func:`list_model_services` uses for ``system.ai``) and checks for the name.
 
-    Returns ``(exists, reason)``. ``exists`` is None when the check couldn't run — a name that isn't
-    a three-part UC path, or an HTTP/network error — so the caller can treat "couldn't verify" as
-    distinct from "doesn't exist" and avoid blocking a valid model on a transient failure. Never
-    cached: it targets a user schema, not the memoized ``system.ai`` walk.
+    Returns ``(exists, reason)``:
+
+    - ``True`` — the name is a model service in that schema.
+    - ``False`` — the schema exists but has no such service, or the API returned 404/NOT_FOUND (the
+      catalog or schema in the name doesn't exist, so the model can't either). Both are a definitive
+      "no" the caller can re-prompt on.
+    - ``None`` — the check couldn't run: a name that isn't a three-part UC path, or a non-404
+      HTTP/network error. The caller treats this as "couldn't verify" rather than "doesn't exist" so
+      a transient failure never blocks a valid model.
+
+    Never cached: it targets a user schema, not the memoized ``system.ai`` walk.
     """
     parts = [part.strip() for part in full_name.split(".")]
     if len(parts) != 3 or not all(parts):
@@ -1572,7 +1587,10 @@ def model_service_exists(
         url = f"https://{hostname}/api/2.1/unity-catalog/model-services?{urlencode(params)}"
         payload, reason = _get_model_services_page(url, token)
         if payload is None:
-            return None, reason
+            # A 404 means the catalog/schema in the typed name doesn't exist on this workspace, so
+            # neither can the model — a definitive "no". Every other failure (auth, 5xx, network) is
+            # inconclusive: don't block a possibly-valid model on a blip.
+            return (False, reason) if _is_not_found_reason(reason) else (None, reason)
         data = cast(dict, payload) if isinstance(payload, dict) else {}
         for service in data.get("model_services", []):
             if not isinstance(service, dict):

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1542,6 +1542,56 @@ def list_model_services(
     return [], last_reason or "model-services listing returned no models"
 
 
+def model_service_exists(
+    workspace: str, token: str, full_name: str, *, max_pages: int = 100
+) -> tuple[bool | None, str | None]:
+    """Whether ``<catalog>.<schema>.<model>`` is a UC model service on this workspace.
+
+    Used to quick-check a hand-typed custom model before an admin pins a config to it. Lists the
+    model services in the typed name's own schema (``parent=schemas/<catalog>.<schema>``, the same
+    scoped listing :func:`list_model_services` uses for ``system.ai``) and checks for the name.
+
+    Returns ``(exists, reason)``. ``exists`` is None when the check couldn't run — a name that isn't
+    a three-part UC path, or an HTTP/network error — so the caller can treat "couldn't verify" as
+    distinct from "doesn't exist" and avoid blocking a valid model on a transient failure. Never
+    cached: it targets a user schema, not the memoized ``system.ai`` walk.
+    """
+    parts = [part.strip() for part in full_name.split(".")]
+    if len(parts) != 3 or not all(parts):
+        return None, "a model service is named <catalog>.<schema>.<model>"
+    catalog, schema, _model = parts
+    normalized = f"{catalog}.{schema}.{_model}"
+    parent = f"schemas/{catalog}.{schema}"
+    hostname = workspace_hostname(workspace)
+    page_token: str | None = None
+    seen_tokens: set[str] = set()
+    for _ in range(max_pages):
+        params: dict[str, str] = {"parent": parent, "page_size": str(_MODEL_SERVICES_PAGE_SIZE)}
+        if page_token:
+            params["page_token"] = page_token
+        url = f"https://{hostname}/api/2.1/unity-catalog/model-services?{urlencode(params)}"
+        payload, reason = _get_model_services_page(url, token)
+        if payload is None:
+            return None, reason
+        data = cast(dict, payload) if isinstance(payload, dict) else {}
+        for service in data.get("model_services", []):
+            if not isinstance(service, dict):
+                continue
+            name = service.get("name")
+            if not isinstance(name, str):
+                continue
+            name = name.strip()
+            if name.startswith(_MODEL_SERVICE_NAME_PREFIX):
+                name = name[len(_MODEL_SERVICE_NAME_PREFIX) :]
+            if name == normalized:
+                return True, None
+        page_token = data.get("next_page_token") or None
+        if not page_token or page_token in seen_tokens:
+            break
+        seen_tokens.add(page_token)
+    return False, None
+
+
 def discover_claude_models_unbucketed(workspace: str, token: str) -> tuple[list[str], str | None]:
     """Every `system.ai.claude-*` id on the workspace, unbucketed.
 

--- a/src/ucode/managed_setup.py
+++ b/src/ucode/managed_setup.py
@@ -386,6 +386,11 @@ def _validate_agent_models(tool: str, agent_config: dict, known: set[str]) -> li
     Skipped entirely when the agent routes through a Model Provider Service: those model ids come
     from the provider's own catalog, not from UC model services, so the workspace inventory says
     nothing about them.
+
+    ``model_config.custom_models`` lists ids the admin typed by hand for a model discovery didn't
+    surface (a model service outside ``system.ai``). Those were verified to exist when entered (see
+    ``managed_wizard._prompt_custom_model``), so they're excluded from the inventory check — the
+    discovered inventory legitimately doesn't contain them.
     """
     model_config = agent_config.get("model_config")
     if not isinstance(model_config, dict):
@@ -393,6 +398,7 @@ def _validate_agent_models(tool: str, agent_config: dict, known: set[str]) -> li
     if model_config.get("model_provider_service"):
         return []
 
+    custom = {m for m in model_config.get("custom_models", []) if isinstance(m, str) and m}
     referenced: list[str] = []
     default_model = model_config.get("default_model")
     if isinstance(default_model, str) and default_model:
@@ -406,7 +412,7 @@ def _validate_agent_models(tool: str, agent_config: dict, known: set[str]) -> li
     return [
         f"{tool}: model '{model}' is not available on this workspace."
         for model in dict.fromkeys(referenced)
-        if model not in known
+        if model not in known and model not in custom
     ]
 
 

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -683,6 +683,19 @@ def _custom_option_rows(options: list[tuple[str, str]]) -> list[tuple[str, str]]
     return list(options[:_MODEL_PICKER_LIMIT]) + [(_CUSTOM_MODEL, _CUSTOM_MODEL_LABEL)]
 
 
+def _short_reason(reason: str | None) -> str:
+    """A one-line reason fit for a prompt, without the raw JSON body the transport appends.
+
+    HTTP failures come back as ``HTTP <code> <reason>: <body-excerpt>`` (the body is a JSON error
+    blob for gateway/UC errors); an admin at a prompt wants the status, not the payload. Keeps the
+    ``HTTP <code> <reason>`` head and drops a ``{...}`` body, leaving plain reasons (``network
+    error: ...``) untouched.
+    """
+    if not reason:
+        return "unknown error"
+    return reason.split(": {", 1)[0].strip()
+
+
 def _verify_custom_model(state: dict, model: str) -> tuple[bool | None, str | None]:
     """Whether ``model`` is a model service on the workspace; None when the check can't run.
 
@@ -714,7 +727,8 @@ def _prompt_custom_model(state: dict) -> str:
             return model
         if exists is None:
             print_warning(
-                f"Couldn't verify '{model}' on this workspace ({reason}); using it as typed."
+                f"Couldn't verify '{model}' on this workspace ({_short_reason(reason)}); "
+                "using it as typed."
             )
             return model
         print_err(

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -33,6 +33,7 @@ from ucode.databricks import (
     list_model_provider_services,
     list_workspace_budgets,
     map_claude_family_models,
+    model_service_exists,
     service_usable_for_tool,
     update_coding_agent_config,
 )
@@ -351,22 +352,22 @@ def _prompt_models_for_agent(tool: str, state: dict, provider_service: dict | No
         print_warning(f"No models were discovered for {display} on this workspace.")
         return {"default_model": _require_text(f"Default model for {display}")}
 
+    custom: list[str] = []
     if tool in SINGLE_MODEL_AGENTS:
-        return {
-            "default_model": _require_selection(
-                f"Select the default model for {display}:", [(model, model) for model in options]
-            )
-        }
+        model = _select_hosted_model(
+            f"Select the default model for {display}:", options, state, custom
+        )
+        single: dict = {"default_model": model}
+        if custom:
+            single["custom_models"] = custom
+        return single
 
     # Nothing pre-checked: the first option is whatever discovery sorted first, not a
     # recommendation — for pi it is a Claude model, for codex the oldest GPT. Pre-checking it made
     # "hit Enter" produce an arbitrary config. (A worthwhile follow-up is to pre-check the models
     # this workspace was configured with last time, which `load_managed_state` already loads for
     # the agent picker, so a re-run becomes an edit rather than a re-entry.)
-    picked = _require_multi_selection(
-        f"Select models for {display}:",
-        [(model, model) for model in options],
-    )
+    picked = _select_hosted_models_multi(f"Select models for {display}:", options, state, custom)
     if len(picked) == 1:
         model_config["default_model"] = picked[0]
     else:
@@ -375,6 +376,8 @@ def _prompt_models_for_agent(tool: str, state: dict, provider_service: dict | No
         )
 
     model_config["models"] = picked
+    if custom:
+        model_config["custom_models"] = list(dict.fromkeys(custom))
     return model_config
 
 
@@ -417,32 +420,39 @@ def _prompt_claude_models(state: dict) -> dict:
         "don't want configured — it falls back to the overall default."
     )
     slots: dict[str, str] = {}
+    custom: list[str] = []
     for family in ANTHROPIC_FAMILIES:
         family_models = candidates.get(family)
         if not family_models:
             continue
-        choice = prompt_for_selection(
-            f"Default {family} model:",
-            [(model, model) for model in family_models] + [(_SKIP_FAMILY, f"(skip {family})")],
-            searchable=True,
-        )
+        rows = [(model, model) for model in family_models[:_MODEL_PICKER_LIMIT]] + [
+            (_CUSTOM_MODEL, _CUSTOM_MODEL_LABEL),
+            (_SKIP_FAMILY, f"(skip {family})"),
+        ]
+        choice = prompt_for_selection(f"Default {family} model:", rows, searchable=True)
         if choice is None:
             raise KeyboardInterrupt
-        if choice != _SKIP_FAMILY:
-            slots[CLAUDE_SLOT_FOR_FAMILY[family]] = choice
+        if choice == _SKIP_FAMILY:
+            continue
+        if choice == _CUSTOM_MODEL:
+            choice = _prompt_custom_model(state)
+            custom.append(choice)
+        slots[CLAUDE_SLOT_FOR_FAMILY[family]] = choice
 
     if not slots:
         # Every slot skipped is a legitimate, minimal config: the proto leaves `models` optional and
         # each unset slot falls back to `default_model`, so one model covers every family. Pick it
         # from the same candidates rather than asking the admin to type an id.
         print_note(f"No families configured, so {display} will use a single model for all of them.")
-        every_model = [m for family_models in candidates.values() for m in family_models]
-        return {
-            "default_model": _require_selection(
-                f"Which model should {display} use?",
-                [(m, m) for m in dict.fromkeys(every_model)],
-            )
-        }
+        every_model = list(dict.fromkeys(m for fm in candidates.values() for m in fm))
+        fallback_custom: list[str] = []
+        model = _select_hosted_model(
+            f"Which model should {display} use?", every_model, state, fallback_custom
+        )
+        single: dict = {"default_model": model}
+        if fallback_custom:
+            single["custom_models"] = fallback_custom
+        return single
 
     chosen = list(dict.fromkeys(slots.values()))
     model_config: dict = {"models": slots}
@@ -455,6 +465,8 @@ def _prompt_claude_models(state: dict) -> dict:
         model_config["default_model"] = _require_selection(
             f"Which of those is {display}'s overall default?", [(m, m) for m in chosen]
         )
+    if custom:
+        model_config["custom_models"] = list(dict.fromkeys(custom))
     return model_config
 
 
@@ -655,6 +667,96 @@ def _require_text(prompt: str) -> str:
         if answer:
             return answer
         print_err("Please enter a model id.")
+
+
+# Discovered model lists run long (a dozen-plus ids on a real workspace), so each hosted-model picker
+# shows only the most relevant few and offers an explicit "type your own" row. Typing a model covers
+# both a discovered id past the shown few and a custom model service outside `system.ai` that
+# discovery never lists at all.
+_MODEL_PICKER_LIMIT = 5
+_CUSTOM_MODEL = "__custom_model__"
+_CUSTOM_MODEL_LABEL = "✎ Enter a custom model…"
+
+
+def _custom_option_rows(options: list[tuple[str, str]]) -> list[tuple[str, str]]:
+    """The first few model rows plus a 'type your own' row, for a hosted-model picker."""
+    return list(options[:_MODEL_PICKER_LIMIT]) + [(_CUSTOM_MODEL, _CUSTOM_MODEL_LABEL)]
+
+
+def _verify_custom_model(state: dict, model: str) -> tuple[bool | None, str | None]:
+    """Whether ``model`` is a model service on the workspace; None when the check can't run.
+
+    Mirrors how ``_claude_candidates`` reaches the workspace — a token from ``state`` — and turns a
+    missing workspace or a failed token fetch into an inconclusive result rather than an error.
+    """
+    workspace = state.get("workspace")
+    if not workspace:
+        return None, "no workspace in local state"
+    try:
+        token = get_databricks_token(workspace, state.get("profile"))
+    except (RuntimeError, OSError) as exc:
+        # OSError covers a missing `databricks` binary (get_databricks_token shells out).
+        return None, str(exc)
+    return model_service_exists(workspace, token, model)
+
+
+def _prompt_custom_model(state: dict) -> str:
+    """Prompt for a custom model-service id, re-asking until it exists on the workspace.
+
+    A typo shouldn't get baked into a published config, so the id is checked against the workspace's
+    model services and a miss is re-prompted. An inconclusive check (no workspace/token, or a
+    transient API error) is accepted with a warning rather than blocking a possibly-valid model.
+    """
+    while True:
+        model = _require_text("Custom model (catalog.schema.model)")
+        exists, reason = _verify_custom_model(state, model)
+        if exists:
+            return model
+        if exists is None:
+            print_warning(
+                f"Couldn't verify '{model}' on this workspace ({reason}); using it as typed."
+            )
+            return model
+        print_err(
+            f"'{model}' isn't a model service on this workspace. Check the name and try again "
+            "(expected catalog.schema.model, e.g. main.aarushi.claude-opus-4-5)."
+        )
+
+
+def _select_hosted_model(
+    prompt: str, options: list[str], state: dict, custom_sink: list[str]
+) -> str:
+    """Single-select over the top few ``options`` plus a custom-entry row.
+
+    Records any custom id in ``custom_sink`` so the caller can mark it in
+    ``model_config.custom_models``, which keeps validation from rejecting a model discovery didn't
+    surface.
+    """
+    choice = _require_selection(prompt, _custom_option_rows([(m, m) for m in options]))
+    if choice == _CUSTOM_MODEL:
+        model = _prompt_custom_model(state)
+        custom_sink.append(model)
+        return model
+    return choice
+
+
+def _select_hosted_models_multi(
+    prompt: str, options: list[str], state: dict, custom_sink: list[str]
+) -> list[str]:
+    """Multi-select over the top few ``options`` plus a custom-entry row; requires one pick.
+
+    Selecting the custom row prompts for one model id and folds it into the picks. Records any custom
+    id in ``custom_sink`` (see :func:`_select_hosted_model`).
+    """
+    rows = _custom_option_rows([(m, m) for m in options])
+    picked = _require_multi_selection(prompt, rows)
+    models = [p for p in picked if p != _CUSTOM_MODEL]
+    if _CUSTOM_MODEL in picked:
+        custom = _prompt_custom_model(state)
+        custom_sink.append(custom)
+        if custom not in models:
+            models.append(custom)
+    return models
 
 
 def configured_models_for_agent(agent_config: dict) -> list[str]:

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -733,7 +733,7 @@ def _prompt_custom_model(state: dict) -> str:
             return model
         print_err(
             f"'{model}' isn't a model service on this workspace. Check the name and try again "
-            "(expected catalog.schema.model, e.g. main.aarushi.claude-opus-4-5)."
+            "(expected catalog.schema.model, e.g. main.default.claude-opus-4-5)."
         )
 
 
@@ -759,17 +759,21 @@ def _select_hosted_models_multi(
 ) -> list[str]:
     """Multi-select over the top few ``options`` plus a custom-entry row; requires one pick.
 
-    Selecting the custom row prompts for one model id and folds it into the picks. Records any custom
-    id in ``custom_sink`` (see :func:`_select_hosted_model`).
+    Selecting the custom row prompts for custom model ids — as many as the admin wants, since a
+    multi-select agent (opencode, pi) can carry a whole list — and folds them into the picks. Records
+    each custom id in ``custom_sink`` (see :func:`_select_hosted_model`).
     """
     rows = _custom_option_rows([(m, m) for m in options])
     picked = _require_multi_selection(prompt, rows)
     models = [p for p in picked if p != _CUSTOM_MODEL]
     if _CUSTOM_MODEL in picked:
-        custom = _prompt_custom_model(state)
-        custom_sink.append(custom)
-        if custom not in models:
-            models.append(custom)
+        while True:
+            custom = _prompt_custom_model(state)
+            if custom not in models:
+                models.append(custom)
+                custom_sink.append(custom)
+            if not prompt_yes_no_default("Add another custom model?", default=False):
+                break
     return models
 
 

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -378,6 +378,71 @@ class TestDiscoverModelServices:
         assert calls["n"] == 3  # two failures, third succeeds
 
 
+class TestModelServiceExists:
+    def test_true_when_listed_in_its_schema(self, monkeypatch):
+        urls: list[str] = []
+
+        def fake_get(url, token, timeout=30):
+            urls.append(url)
+            return {"model_services": [_model_service("main.aarushi.claude-opus-4-5")]}, None
+
+        monkeypatch.setattr(db_mod, "_http_get_json", fake_get)
+        exists, reason = db_mod.model_service_exists(WS, "token", "main.aarushi.claude-opus-4-5")
+        assert (exists, reason) == (True, None)
+        # Scoped to the typed name's own schema, not system.ai.
+        assert all("parent=schemas%2Fmain.aarushi" in u for u in urls)
+
+    def test_false_when_schema_has_no_such_service(self, monkeypatch):
+        monkeypatch.setattr(
+            db_mod,
+            "_http_get_json",
+            lambda url, token, timeout=30: (
+                {"model_services": [_model_service("main.aarushi.some-other-model")]},
+                None,
+            ),
+        )
+        exists, reason = db_mod.model_service_exists(WS, "token", "main.aarushi.claude-opus-4-5")
+        assert (exists, reason) == (False, None)
+
+    def test_bad_name_is_inconclusive(self, monkeypatch):
+        def fail(*a, **k):
+            raise AssertionError("should not hit the API for a malformed name")
+
+        monkeypatch.setattr(db_mod, "_http_get_json", fail)
+        for bad in ("just-a-name", "main.aarushi", "main..model", "main.aarushi.model.extra"):
+            exists, reason = db_mod.model_service_exists(WS, "token", bad)
+            assert exists is None and reason
+
+    def test_http_error_is_inconclusive_not_absent(self, monkeypatch):
+        # A transient failure must read as "couldn't verify", never "doesn't exist" — the caller
+        # would otherwise reject a valid model on a blip.
+        monkeypatch.setattr(
+            db_mod,
+            "_http_get_json",
+            lambda url, token, timeout=30: (None, "HTTP 500 Server Error"),
+        )
+        exists, reason = db_mod.model_service_exists(WS, "token", "main.aarushi.claude-opus-4-5")
+        assert exists is None
+        assert "500" in reason
+
+    def test_paginates_until_found(self, monkeypatch):
+        pages = {
+            None: {
+                "model_services": [_model_service("main.aarushi.other")],
+                "next_page_token": "n",
+            },
+            "n": {"model_services": [_model_service("main.aarushi.claude-opus-4-5")]},
+        }
+
+        def fake_get(url, token, timeout=30):
+            tok = url.split("page_token=")[1].split("&")[0] if "page_token=" in url else None
+            return pages[tok], None
+
+        monkeypatch.setattr(db_mod, "_http_get_json", fake_get)
+        exists, _ = db_mod.model_service_exists(WS, "token", "main.aarushi.claude-opus-4-5")
+        assert exists is True
+
+
 class TestListModelProviderServices:
     _PAYLOAD = {
         "model_provider_services": [

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -425,6 +425,20 @@ class TestModelServiceExists:
         assert exists is None
         assert "500" in reason
 
+    def test_not_found_means_absent(self, monkeypatch):
+        # A 404 is the catalog/schema not existing, so the model can't either — a definitive "no"
+        # the caller re-prompts on, not an inconclusive "couldn't verify".
+        monkeypatch.setattr(
+            db_mod,
+            "_http_get_json",
+            lambda url, token, timeout=30: (
+                None,
+                'HTTP 404 Not Found: {"error_code":"NOT_FOUND","message":"Resource not found"}',
+            ),
+        )
+        exists, _ = db_mod.model_service_exists(WS, "token", "maikjn.default.aar")
+        assert exists is False
+
     def test_paginates_until_found(self, monkeypatch):
         pages = {
             None: {

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -573,9 +573,14 @@ class TestModelProviderLaunch:
         return names[0]
 
     @staticmethod
-    def _skip_if_no_permission(combined: str, provider: str) -> None:
+    def _skip_if_provider_unusable(combined: str, provider: str) -> None:
+        # Environmental provider-account conditions, not ucode bugs: the test only proves routing
+        # reaches the provider, so skip (rather than fail) when the account lacks a grant on the
+        # connection or has run out of credits — state outside the code under test.
         if "USE CONNECTION" in combined or "EXECUTE" in combined:
             pytest.skip(f"no permission on provider {provider}: {combined[:200]}")
+        if "Credit balance is too low" in combined:
+            pytest.skip(f"provider {provider} account is out of credits: {combined[:200]}")
 
     def test_launch_claude_through_provider(
         self, tmp_path, monkeypatch, e2e_state, e2e_workspace, e2e_token
@@ -613,7 +618,7 @@ class TestModelProviderLaunch:
         }
         result = _run_agent(claude.validate_cmd("claude"), env=env, timeout=90)
         combined = (result.stdout + result.stderr).strip()
-        self._skip_if_no_permission(combined, provider)
+        self._skip_if_provider_unusable(combined, provider)
         assert result.returncode == 0 and combined, (
             f"provider={provider} rc={result.returncode} "
             f"stdout={result.stdout[:300]!r} stderr={result.stderr[:300]!r}"
@@ -650,7 +655,7 @@ class TestModelProviderLaunch:
         except subprocess.TimeoutExpired:
             pytest.fail(f"provider={provider} timed out after {timeout_seconds}s")
         combined = (result.stdout + result.stderr).strip()
-        self._skip_if_no_permission(combined, provider)
+        self._skip_if_provider_unusable(combined, provider)
         assert result.returncode == 0 and combined, (
             f"provider={provider} rc={result.returncode} "
             f"stdout={result.stdout[:300]!r} stderr={result.stderr[:300]!r}"

--- a/tests/test_managed_setup.py
+++ b/tests/test_managed_setup.py
@@ -582,6 +582,33 @@ class TestValidate:
         errors = validate_manifest(manifest, state)
         assert any("not available on this workspace" in e for e in errors)
 
+    def test_custom_model_is_accepted_via_the_marker(self):
+        # A hand-typed model service outside the discovered inventory is listed in `custom_models`
+        # (it was verified to exist when entered), so the inventory check must not reject it.
+        manifest = {
+            "default_agent": "codex",
+            "enabled_agents": {
+                "codex": {
+                    "model_config": {
+                        "default_model": "main.aarushi.gpt-5-custom",
+                        "custom_models": ["main.aarushi.gpt-5-custom"],
+                    }
+                }
+            },
+        }
+        assert validate_manifest(manifest, STATE) == []
+
+    def test_unmarked_custom_model_is_still_rejected(self):
+        # Without the marker the same id is an unknown model — the marker is what vouches for it.
+        manifest = {
+            "default_agent": "codex",
+            "enabled_agents": {
+                "codex": {"model_config": {"default_model": "main.aarushi.gpt-5-custom"}}
+            },
+        }
+        errors = validate_manifest(manifest, STATE)
+        assert any("not available on this workspace" in e for e in errors)
+
     def test_model_check_skipped_without_state(self):
         manifest = {
             "default_agent": "claude",

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -1056,6 +1056,23 @@ class TestCustomModelEntry:
         assert config["default_model"] == "main.real.model"
         assert err.called
 
+    def test_multi_select_agent_can_add_several_custom_models(self):
+        # opencode/pi carry a model list, so the custom row keeps prompting until the admin declines.
+        with (
+            patch.object(wizard, "prompt_for_multi_selection", return_value=[wizard._CUSTOM_MODEL]),
+            patch.object(
+                wizard, "prompt_for_text", side_effect=["main.default.a", "main.default.b"]
+            ),
+            patch.object(wizard, "prompt_yes_no_default", side_effect=[True, False]),
+            patch.object(wizard, "prompt_for_selection", return_value="main.default.a"),
+            patch.object(wizard, "get_databricks_token", lambda *a, **k: "tok"),
+            patch.object(wizard, "model_service_exists", return_value=(True, None)),
+        ):
+            config = wizard._prompt_models_for_agent("pi", STATE, None)
+        assert config["models"] == ["main.default.a", "main.default.b"]
+        assert config["custom_models"] == ["main.default.a", "main.default.b"]
+        assert config["default_model"] == "main.default.a"
+
     def test_short_reason_drops_the_json_body(self):
         # The warning for an inconclusive check should show the status, not the raw error blob.
         assert (

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -500,11 +500,13 @@ class TestModelPrompting:
         assert config == {"default_model": "system.ai.claude-opus-4-8"}
         assert "models" not in config
         assert not text.called, "should pick from candidates, not ask for free text"
-        # The final prompt offers every candidate across all families.
+        # The final prompt offers every candidate across all families (all fit under the picker
+        # limit here), plus the custom-entry row.
         assert set(offered[-1]) == {
             "system.ai.claude-opus-5",
             "system.ai.claude-opus-4-8",
             "system.ai.claude-sonnet-5",
+            wizard._CUSTOM_MODEL,
         }
 
     def test_older_claude_version_passes_validation(self):
@@ -1018,6 +1020,103 @@ OPENAI_SERVICE = {
     "allow_all_targets": False,
     "relayed": False,
 }
+
+
+class TestCustomModelEntry:
+    """The hosted-model pickers let an admin type a model service discovery didn't list."""
+
+    def test_single_agent_can_enter_a_verified_custom_model(self):
+        # Selecting the custom row prompts for a path, verifies it exists, and records it so
+        # validation won't reject a model outside the discovered inventory.
+        with (
+            patch.object(wizard, "prompt_for_selection", return_value=wizard._CUSTOM_MODEL),
+            patch.object(wizard, "prompt_for_text", return_value="main.aarushi.gpt-5-custom"),
+            patch.object(wizard, "get_databricks_token", lambda *a, **k: "tok"),
+            patch.object(wizard, "model_service_exists", return_value=(True, None)) as exists,
+        ):
+            config = wizard._prompt_models_for_agent("codex", STATE, None)
+        assert config == {
+            "default_model": "main.aarushi.gpt-5-custom",
+            "custom_models": ["main.aarushi.gpt-5-custom"],
+        }
+        exists.assert_called_once_with(WORKSPACE, "tok", "main.aarushi.gpt-5-custom")
+
+    def test_custom_model_reprompts_until_it_exists(self):
+        # A typo shouldn't get baked into a published config — a miss re-asks.
+        with (
+            patch.object(wizard, "prompt_for_selection", return_value=wizard._CUSTOM_MODEL),
+            patch.object(
+                wizard, "prompt_for_text", side_effect=["main.typo.model", "main.real.model"]
+            ),
+            patch.object(wizard, "get_databricks_token", lambda *a, **k: "tok"),
+            patch.object(wizard, "model_service_exists", side_effect=[(False, None), (True, None)]),
+            patch.object(wizard, "print_err") as err,
+        ):
+            config = wizard._prompt_models_for_agent("codex", STATE, None)
+        assert config["default_model"] == "main.real.model"
+        assert err.called
+
+    def test_unverifiable_custom_model_is_accepted_with_a_warning(self):
+        # An inconclusive check (transient error / no token) must not block a possibly-valid model.
+        with (
+            patch.object(wizard, "prompt_for_selection", return_value=wizard._CUSTOM_MODEL),
+            patch.object(wizard, "prompt_for_text", return_value="main.aarushi.maybe"),
+            patch.object(wizard, "get_databricks_token", lambda *a, **k: "tok"),
+            patch.object(wizard, "model_service_exists", return_value=(None, "HTTP 500")),
+            patch.object(wizard, "print_warning") as warn,
+        ):
+            config = wizard._prompt_models_for_agent("codex", STATE, None)
+        assert config["default_model"] == "main.aarushi.maybe"
+        assert warn.called
+
+    def test_picker_shows_only_the_top_few_plus_custom(self):
+        # A long list is truncated so the custom row is reachable without scrolling past everything.
+        state = {**STATE, "codex_models": [f"system.ai.gpt-5-{i}" for i in range(10)]}
+        offered: list[list[str]] = []
+
+        def fake_sel(prompt, options, **kwargs):
+            offered.append([v for v, _ in options])
+            return options[0][0]
+
+        with patch.object(wizard, "prompt_for_selection", side_effect=fake_sel):
+            wizard._prompt_models_for_agent("codex", state, None)
+        rows = offered[0]
+        assert rows[-1] == wizard._CUSTOM_MODEL
+        assert len(rows) == wizard._MODEL_PICKER_LIMIT + 1  # top few + the custom row
+
+    def test_claude_family_custom_model_slots_and_validates(self):
+        # A custom id chosen for a family lands in that slot, is marked custom, and survives
+        # validation even though discovery never listed it.
+        candidates = {"opus": ["system.ai.claude-opus-5"]}
+
+        def fake_sel(prompt, options, **kwargs):
+            values = [v for v, _ in options]
+            if wizard._CUSTOM_MODEL in values:
+                return wizard._CUSTOM_MODEL
+            return values[0]
+
+        with (
+            patch.object(wizard, "_claude_candidates", return_value=candidates),
+            patch.object(wizard, "prompt_for_selection", side_effect=fake_sel),
+            patch.object(wizard, "prompt_for_text", return_value="main.aarushi.claude-opus-4-5"),
+            patch.object(wizard, "get_databricks_token", lambda *a, **k: "tok"),
+            patch.object(wizard, "model_service_exists", return_value=(True, None)),
+            patch.object(wizard, "print_note"),
+            patch.object(wizard, "print_success"),
+        ):
+            config = wizard._prompt_models_for_agent("claude", STATE, None)
+        assert config["models"]["default_opus_model"] == "main.aarushi.claude-opus-4-5"
+        assert config["custom_models"] == ["main.aarushi.claude-opus-4-5"]
+        assert (
+            validate_manifest(
+                {
+                    "default_agent": "claude",
+                    "enabled_agents": {"claude": {"model_config": config}},
+                },
+                STATE,
+            )
+            == []
+        )
 
 
 class TestProviderServiceSpinner:

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -1056,6 +1056,15 @@ class TestCustomModelEntry:
         assert config["default_model"] == "main.real.model"
         assert err.called
 
+    def test_short_reason_drops_the_json_body(self):
+        # The warning for an inconclusive check should show the status, not the raw error blob.
+        assert (
+            wizard._short_reason('HTTP 500 Server Error: {"error_code":"INTERNAL"}')
+            == "HTTP 500 Server Error"
+        )
+        assert wizard._short_reason("network error: timed out") == "network error: timed out"
+        assert wizard._short_reason(None) == "unknown error"
+
     def test_unverifiable_custom_model_is_accepted_with_a_warning(self):
         # An inconclusive check (transient error / no token) must not block a possibly-valid model.
         with (


### PR DESCRIPTION
  Discovery only lists system.ai.* models, so an admin whose workspace serves a coding model somewhere else
  (main.default.claude-opus-4-5) had no way to pick it in ucode setup.

  Each Databricks-hosted model picker now shows the top few discovered models plus an "✎ Enter a custom model…" row. A
  typed catalog.schema.model is verified against the workspace's model services and re-prompted on a miss (a 404 means the
  catalog/schema doesn't exist → re-prompt; only transient errors like 5xx/network are accepted as typed, with a short
  warning). Multi-select agents (opencode, pi) can add several custom models; single-model agents take one.

  Custom ids are marked in model_config.custom_models so validation doesn't reject a model the discovered inventory
  legitimately doesn't contain. The marker is local to the manifest — it's dropped from the published proto, so the server
  just sees default_model and validates it itself.

  Tests cover the existence check (found / absent / 404 / transient / pagination), the picker's custom row + truncation,
  multi-add, and validation acceptance.


https://github.com/user-attachments/assets/9f9560fe-85fa-4c9d-9f4a-7401ed9d1bf4


