### PR TITLE
claude: accept custom Messages-API MS in managed-config validation

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -2842,6 +2842,18 @@ def discover_codex_models(workspace: str, token: str) -> tuple[list[str], str | 
     return discover_endpoints_with_api_type(workspace, token, "openai/v1/responses")
 
 
+def discover_anthropic_messages_models(
+    workspace: str, token: str
+) -> tuple[list[str], str | None]:
+    """Workspace endpoints exposing the Anthropic Messages API (``anthropic/v1/messages``).
+
+    Mirrors :func:`discover_codex_models` for the Messages API, surfacing custom
+    Model Serving the name-keyed Claude discoveries miss (neither
+    ``databricks-claude-`` nor ``system.ai.claude-``).
+    """
+    return discover_endpoints_with_api_type(workspace, token, "anthropic/v1/messages")
+
+
 def fetch_gemini_models(workspace: str, token: str) -> list[str]:
     models, _ = discover_gemini_models(workspace, token)
     return models

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -2842,15 +2842,7 @@ def discover_codex_models(workspace: str, token: str) -> tuple[list[str], str | 
     return discover_endpoints_with_api_type(workspace, token, "openai/v1/responses")
 
 
-def discover_anthropic_messages_models(
-    workspace: str, token: str
-) -> tuple[list[str], str | None]:
-    """Workspace endpoints exposing the Anthropic Messages API (``anthropic/v1/messages``).
-
-    Mirrors :func:`discover_codex_models` for the Messages API, surfacing custom
-    Model Serving the name-keyed Claude discoveries miss (neither
-    ``databricks-claude-`` nor ``system.ai.claude-``).
-    """
+def discover_anthropic_messages_models(workspace: str, token: str) -> tuple[list[str], str | None]:
     return discover_endpoints_with_api_type(workspace, token, "anthropic/v1/messages")
 
 

--- a/src/ucode/managed_setup.py
+++ b/src/ucode/managed_setup.py
@@ -373,7 +373,13 @@ def _known_models(state: dict) -> set[str]:
     claude_models = state.get("claude_models")
     if isinstance(claude_models, dict):
         known.update(m for m in claude_models.values() if isinstance(m, str) and m)
-    for key in ("codex_models", "gemini_models", "oss_models", "all_claude_models"):
+    for key in (
+        "codex_models",
+        "gemini_models",
+        "oss_models",
+        "all_claude_models",
+        "anthropic_messages_models",
+    ):
         models = state.get(key)
         if isinstance(models, list):
             known.update(m for m in models if isinstance(m, str) and m)

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -25,6 +25,7 @@ from ucode.databricks import (
     all_users_can_use_schema,
     create_coding_agent_config,
     delete_coding_agent_config,
+    discover_anthropic_messages_models,
     discover_claude_models_unbucketed,
     ensure_databricks_auth,
     get_databricks_token,
@@ -1366,21 +1367,37 @@ def _with_claude_inventory(state: dict, workspace: str, profile: str | None) -> 
     what the wizard happened to leave behind, which also covers a hand-edited or ``--from-file``
     manifest authored on another machine.
 
+    Also fetches workspace endpoints exposing ``anthropic/v1/messages`` (custom Model Serving the
+    UC listing misses) onto ``state["anthropic_messages_models"]`` for the same reason.
+
     Best-effort: a failed listing returns ``state`` untouched, leaving validation on the narrower
     inventory rather than blocking a publish on a transient API error.
     """
-    if isinstance(state.get("all_claude_models"), list) and state["all_claude_models"]:
-        return state
     try:
         token = get_databricks_token(workspace, profile)
-        all_claude, _ = discover_claude_models_unbucketed(workspace, token)
     except (RuntimeError, OSError):
         # OSError covers a missing `databricks` binary: `get_databricks_token` shells out, so a
         # machine without the CLI on PATH raises FileNotFoundError rather than RuntimeError.
         return state
-    if not all_claude:
-        return state
-    return {**state, "all_claude_models": all_claude}
+    updated = state
+    if not (isinstance(state.get("all_claude_models"), list) and state["all_claude_models"]):
+        try:
+            all_claude, _ = discover_claude_models_unbucketed(workspace, token)
+        except (RuntimeError, OSError):
+            all_claude = []
+        if all_claude:
+            updated = {**updated, "all_claude_models": all_claude}
+    if not (
+        isinstance(state.get("anthropic_messages_models"), list)
+        and state["anthropic_messages_models"]
+    ):
+        try:
+            messages_models, _ = discover_anthropic_messages_models(workspace, token)
+        except (RuntimeError, OSError):
+            messages_models = []
+        if messages_models:
+            updated = {**updated, "anthropic_messages_models": messages_models}
+    return updated
 
 
 def apply_command(*, yes: bool = False) -> int:

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -1162,6 +1162,37 @@ class TestDiscoverGeminiModels:
         assert reason is None
         assert models == ["databricks-gpt-4-1", "databricks-gpt-5-2-codex"]
 
+    def test_anthropic_messages_returns_messages_api_endpoints(self, monkeypatch):
+        # Mirrors discover_codex_models but for anthropic/v1/messages — surfaces
+        # custom Model Serving the name-keyed Claude discoveries miss.
+        payload = {
+            "endpoints": [
+                {
+                    "name": name,
+                    "config": {
+                        "served_entities": [
+                            {
+                                "foundation_model": {
+                                    "ai_gateway_v2_supported": True,
+                                    "api_types": [api_type],
+                                }
+                            }
+                        ]
+                    },
+                }
+                for name, api_type in [
+                    ("main.default.my_claude_ms", "anthropic/v1/messages"),
+                    ("databricks-gpt-5-2-codex", "openai/v1/responses"),
+                ]
+            ]
+        }
+        monkeypatch.setattr(db_mod, "_http_get_json", lambda url, token: (payload, None))
+
+        models, reason = db_mod.discover_anthropic_messages_models(WS, "token")
+
+        assert reason is None
+        assert models == ["main.default.my_claude_ms"]
+
 
 class TestResolvePatToken:
     def test_reads_pat_profile_token_from_cfg(self, monkeypatch, tmp_path):

--- a/tests/test_managed_setup.py
+++ b/tests/test_managed_setup.py
@@ -582,6 +582,19 @@ class TestValidate:
         errors = validate_manifest(manifest, state)
         assert any("not available on this workspace" in e for e in errors)
 
+    def test_custom_messages_api_ms_is_accepted(self):
+        # A custom Model Serving endpoint exposing anthropic/v1/messages isn't in the
+        # UC `all_claude_models` listing, but is routable — `anthropic_messages_models`
+        # vouches for it the way `custom_models` does for a hand-typed id.
+        manifest = {
+            "default_agent": "claude",
+            "enabled_agents": {
+                "claude": {"model_config": {"default_model": "main.default.my_claude_ms"}}
+            },
+        }
+        state = {**STATE, "anthropic_messages_models": ["main.default.my_claude_ms"]}
+        assert validate_manifest(manifest, state) == []
+
     def test_custom_model_is_accepted_via_the_marker(self):
         # A hand-typed model service outside the discovered inventory is listed in `custom_models`
         # (it was verified to exist when entered), so the inventory check must not reject it.

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -2152,9 +2152,7 @@ class TestApplyCommand:
             {
                 "default_agent": "claude",
                 "enabled_agents": {
-                    "claude": {
-                        "model_config": {"default_model": "main.default.my_claude_ms"}
-                    }
+                    "claude": {"model_config": {"default_model": "main.default.my_claude_ms"}}
                 },
             },
         )

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -2142,6 +2142,41 @@ class TestApplyCommand:
         )
         assert published
 
+    def test_a_custom_messages_api_ms_publishes(self):
+        # A hand-edited manifest pinning a custom Model Serving (exposing
+        # anthropic/v1/messages) used to be rejected as unknown — the UC listing
+        # doesn't contain it. `apply` now re-fetches the Messages-API endpoints so
+        # validation accepts it.
+        managed_config_mod.save_managed_state(
+            WORKSPACE,
+            {
+                "default_agent": "claude",
+                "enabled_agents": {
+                    "claude": {
+                        "model_config": {"default_model": "main.default.my_claude_ms"}
+                    }
+                },
+            },
+        )
+        published: dict = {}
+
+        def fake_create(workspace, token, payload):
+            published["payload"] = payload
+            return {"name": "coding-agent-configs/new"}, None
+
+        assert (
+            self._run(
+                discover_claude_models_unbucketed=lambda *a, **k: ([], None),
+                discover_anthropic_messages_models=lambda *a, **k: (
+                    ["main.default.my_claude_ms"],
+                    None,
+                ),
+                create_coding_agent_config=fake_create,
+            )
+            == 0
+        )
+        assert published, "the manifest should have been published"
+
     def test_declining_the_prompt_publishes_nothing(self):
         managed_config_mod.save_managed_state(WORKSPACE, self.MANIFEST)
         created = {"called": False}


### PR DESCRIPTION
## Summary

Makes `ucode`'s managed-config validation accept custom Model Serving endpoints that expose the Anthropic Messages API (`anthropic/v1/messages`), without requiring the admin to hand-type them into `custom_models`.

## Why

Today, Claude discovery in ucode is name-based:
- `discover_claude_models` hits `/ai-gateway/anthropic/v1/models`, keeping ids matching `databricks-claude-<family>-*`.
- `discover_model_services` lists UC `system.ai.claude-*` ids.

A custom Model Serving endpoint whose name carries neither substring falls through both. When an admin pins such an endpoint in a managed config, `validate_manifest` rejects it as "not available on this workspace" — unless they manually add it to `custom_models`. Codex/Gemini already solve this with API-type-based discovery (`discover_endpoints_with_api_type`); this adds the Claude analog.

## What changed

- **`databricks.py`**: `discover_anthropic_messages_models()` — a one-line wrapper around the existing `discover_endpoints_with_api_type(..., "anthropic/v1/messages")`, mirroring `discover_codex_models` (`openai/v1/responses`).
- **`managed_setup.py`**: `_known_models()` now reads `state["anthropic_messages_models"]` so `validate_manifest` treats those ids as known/routable.
- **`managed_wizard.py`**: `_with_claude_inventory()` (the `ucode apply` validation path) best-effort fetches `discover_anthropic_messages_models` and stashes it on `state`, so a hand-edited manifest pinning a custom MS validates instead of being rejected.

## Testing

- `test_databricks.py`: `discover_anthropic_messages_models` returns only `anthropic/v1/messages` endpoints (filters out `openai/v1/responses`).
- `test_managed_setup.py`: a custom MS id is accepted when `state["anthropic_messages_models"]` carries it.
- `test_managed_wizard.py`: `apply` publishes a manifest pinning a custom MS (re-fetch surfaces it).
- Broader suite (803 tests across `test_agent_claude`, `test_managed_setup`, `test_managed_wizard`, `test_databricks`, `test_cli`) passes.

This pull request and its description were written by Isaac.