### PR TITLE
Don't install Databricks AI Tools on agent launch (configure-only)

### DIFF
--- a/src/ucode/agents/__init__.py
+++ b/src/ucode/agents/__init__.py
@@ -413,11 +413,7 @@ def _availability_failure_detail(tool: str, state: dict) -> str:
 
 
 def configure_single_tool(tool: str, state: dict) -> dict:
-    """Check availability, configure, and persist state for one tool only.
-
-    Does NOT install Databricks AI Tools — that is a `ucode configure`-only step
-    (see `install_databricks_ai_tools_for_agents` callers). The launch path auto-configures
-    through here, and launching must never install skills."""
+    """Check availability, configure, and persist state for one tool only."""
     provider = get_provider_service(state, tool)
     # A Model Provider Service routes through the same gateway and pins no
     # Databricks model, so the per-tool model availability check doesn't apply.

--- a/src/ucode/agents/__init__.py
+++ b/src/ucode/agents/__init__.py
@@ -413,7 +413,11 @@ def _availability_failure_detail(tool: str, state: dict) -> str:
 
 
 def configure_single_tool(tool: str, state: dict) -> dict:
-    """Check availability, configure, and persist state for one tool only."""
+    """Check availability, configure, and persist state for one tool only.
+
+    Does NOT install Databricks AI Tools — that is a `ucode configure`-only step
+    (see `install_ai_tools_for_agents` callers). The launch path auto-configures
+    through here, and launching must never install skills."""
     provider = get_provider_service(state, tool)
     # A Model Provider Service routes through the same gateway and pins no
     # Databricks model, so the per-tool model availability check doesn't apply.
@@ -429,7 +433,6 @@ def configure_single_tool(tool: str, state: dict) -> dict:
     available_tools = list(set((state.get("available_tools") or []) + [tool]))
     state["available_tools"] = available_tools
     save_state(state)
-    install_ai_tools_for_agents([tool], state)
     return state
 
 

--- a/src/ucode/agents/__init__.py
+++ b/src/ucode/agents/__init__.py
@@ -89,7 +89,7 @@ AITOOLS_AGENT_TOKENS = {
 }
 
 
-def install_ai_tools_for_agents(tools: list[str], state: dict) -> None:
+def install_databricks_ai_tools_for_agents(tools: list[str], state: dict) -> None:
     """Install Databricks AI Tools for the coding agents that support them
     (gemini/pi have no ``aitools`` support and are dropped)."""
     if state.get("databricks_ai_tools_enabled", True) is False:
@@ -416,7 +416,7 @@ def configure_single_tool(tool: str, state: dict) -> dict:
     """Check availability, configure, and persist state for one tool only.
 
     Does NOT install Databricks AI Tools — that is a `ucode configure`-only step
-    (see `install_ai_tools_for_agents` callers). The launch path auto-configures
+    (see `install_databricks_ai_tools_for_agents` callers). The launch path auto-configures
     through here, and launching must never install skills."""
     provider = get_provider_service(state, tool)
     # A Model Provider Service routes through the same gateway and pins no
@@ -465,7 +465,7 @@ def configure_selected_tools(state: dict, tools: list[str]) -> dict:
     existing = state.get("available_tools") or []
     state["available_tools"] = sorted(set(existing) | set(tools))
     save_state(state)
-    install_ai_tools_for_agents(tools, state)
+    install_databricks_ai_tools_for_agents(tools, state)
     return state
 
 

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -18,7 +18,7 @@ from ucode.agents import (
     configure_tool,
     ensure_bootstrap_dependencies,
     ensure_provider_state,
-    install_ai_tools_for_agents,
+    install_databricks_ai_tools_for_agents,
     install_tool_binary,
     normalize_tool,
     provider_permission_error,
@@ -773,7 +773,7 @@ def configure_workspace_command(
         # Install Databricks AI Tools here (a `ucode configure`-only step), not in
         # configure_single_tool — the launch path auto-configures through that and
         # must never install skills.
-        install_ai_tools_for_agents([tool], state)
+        install_databricks_ai_tools_for_agents([tool], state)
         spec = TOOL_SPECS[tool]
         console.print(
             Panel(

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -770,9 +770,6 @@ def configure_workspace_command(
         )
         state = states[0]
         state = configure_single_tool(tool, state)
-        # Install Databricks AI Tools here (a `ucode configure`-only step), not in
-        # configure_single_tool — the launch path auto-configures through that and
-        # must never install skills.
         install_databricks_ai_tools_for_agents([tool], state)
         spec = TOOL_SPECS[tool]
         console.print(

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -18,6 +18,7 @@ from ucode.agents import (
     configure_tool,
     ensure_bootstrap_dependencies,
     ensure_provider_state,
+    install_ai_tools_for_agents,
     install_tool_binary,
     normalize_tool,
     provider_permission_error,
@@ -769,6 +770,10 @@ def configure_workspace_command(
         )
         state = states[0]
         state = configure_single_tool(tool, state)
+        # Install Databricks AI Tools here (a `ucode configure`-only step), not in
+        # configure_single_tool — the launch path auto-configures through that and
+        # must never install skills.
+        install_ai_tools_for_agents([tool], state)
         spec = TOOL_SPECS[tool]
         console.print(
             Panel(

--- a/tests/test_agents_init.py
+++ b/tests/test_agents_init.py
@@ -14,7 +14,7 @@ from ucode.agents import (
     configure_selected_tools,
     default_model_for_tool,
     ensure_tool_binary_available,
-    install_ai_tools_for_agents,
+    install_databricks_ai_tools_for_agents,
     install_tool_binary,
     normalize_tool,
     provider_permission_error,
@@ -74,19 +74,21 @@ class TestInstallAiToolsForAgents:
     def test_maps_supported_tools_and_drops_others(self, monkeypatch):
         captured = self._capture(monkeypatch)
         # gemini and pi aren't supported by `databricks aitools`, so they drop.
-        install_ai_tools_for_agents(["claude", "codex", "gemini", "pi"], {"profile": "prof"})
+        install_databricks_ai_tools_for_agents(
+            ["claude", "codex", "gemini", "pi"], {"profile": "prof"}
+        )
         assert captured == {"agents": ["claude-code", "codex"], "profile": "prof"}
 
     def test_installed_by_default(self, monkeypatch):
         # Opt-out: absent flag means install.
         captured = self._capture(monkeypatch)
-        install_ai_tools_for_agents(["claude"], {"profile": "p"})
+        install_databricks_ai_tools_for_agents(["claude"], {"profile": "p"})
         assert captured == {"agents": ["claude-code"], "profile": "p"}
 
     def test_skipped_when_disabled(self, monkeypatch):
         # `configure --disable-databricks-ai-tools` persists this False.
         captured = self._capture(monkeypatch)
-        install_ai_tools_for_agents(
+        install_databricks_ai_tools_for_agents(
             ["claude"], {"profile": "p", "databricks_ai_tools_enabled": False}
         )
         assert captured == {}  # install_ai_tools never called

--- a/tests/test_agents_init.py
+++ b/tests/test_agents_init.py
@@ -93,7 +93,9 @@ class TestInstallAiToolsForAgents:
 
 
 class TestConfigureWiresAiToolsInstall:
-    """Both configure chokepoints must trigger AI Tools install."""
+    """AI Tools install is a `ucode configure`-only step. `configure_selected_tools`
+    (a configure-only chokepoint) triggers it; `configure_single_tool` does NOT,
+    because the launch path auto-configures through it and must never install."""
 
     def _stub_configure(self, monkeypatch):
         captured = {}
@@ -106,23 +108,17 @@ class TestConfigureWiresAiToolsInstall:
         )
         return captured
 
-    def test_configure_single_tool_triggers_install(self, monkeypatch):
+    def test_configure_single_tool_does_not_install(self, monkeypatch):
+        # Launch auto-configures through configure_single_tool, so it must not
+        # install skills — that would put skill installation on the launch path.
         captured = self._stub_configure(monkeypatch)
         agents_mod.configure_single_tool("codex", {"codex_models": ["m"], "profile": "myprof"})
-        assert captured == {"agents": ["codex"], "profile": "myprof"}
+        assert captured == {}
 
     def test_configure_selected_tools_triggers_install(self, monkeypatch):
         captured = self._stub_configure(monkeypatch)
         agents_mod.configure_selected_tools({"profile": "myprof"}, ["codex"])
         assert captured == {"agents": ["codex"], "profile": "myprof"}
-
-    def test_configure_single_tool_respects_disable(self, monkeypatch):
-        captured = self._stub_configure(monkeypatch)
-        agents_mod.configure_single_tool(
-            "codex",
-            {"codex_models": ["m"], "profile": "myprof", "databricks_ai_tools_enabled": False},
-        )
-        assert captured == {}
 
 
 class TestNormalizeTool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2183,7 +2183,9 @@ class TestConfigureSkipValidate:
         monkeypatch.setattr(cli_mod, "configure_single_tool", lambda t, s: s)
         installed: list = []
         monkeypatch.setattr(
-            cli_mod, "install_ai_tools_for_agents", lambda tools, s: installed.append(tools)
+            cli_mod,
+            "install_databricks_ai_tools_for_agents",
+            lambda tools, s: installed.append(tools),
         )
         validated: list = []
         monkeypatch.setattr(cli_mod, "validate_tool", lambda t: validated.append(t) or (True, ""))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2181,6 +2181,10 @@ class TestConfigureSkipValidate:
         state = {**MINIMAL_STATE, "workspace": "https://first.com"}
         monkeypatch.setattr(cli_mod, "configure_shared_state", lambda *a, **k: state)
         monkeypatch.setattr(cli_mod, "configure_single_tool", lambda t, s: s)
+        installed: list = []
+        monkeypatch.setattr(
+            cli_mod, "install_ai_tools_for_agents", lambda tools, s: installed.append(tools)
+        )
         validated: list = []
         monkeypatch.setattr(cli_mod, "validate_tool", lambda t: validated.append(t) or (True, ""))
 
@@ -2192,6 +2196,9 @@ class TestConfigureSkipValidate:
 
         assert result == 0
         assert validated == []
+        # `ucode configure` (single-agent) still installs AI Tools — it's the
+        # configure path, unlike launch which auto-configures without installing.
+        assert installed == [["claude"]]
 
 
 class TestConfigureSharedStateMcpCleanup:


### PR DESCRIPTION
## Problem

Running a launch command like:

```
ucode claude --provider main.jasmine.rohit-test --workspace https://<ws>
```

prints **"Installing Databricks AI Tools for claude-code..."** unprompted. Launch commands auto-configure an unseen agent through `configure_single_tool`, which also installed Databricks AI Tools (skills + plugins). That put skill installation on the **launch** path, not just the **configure** path.

## Fix

Move the install out of the shared `configure_single_tool` and into the `ucode configure` callers only:

- `configure_single_tool` no longer installs — the launch path (`_auto_configure_tool`) auto-configures through it and must never install skills.
- `configure_workspace_command` installs explicitly after `configure_single_tool` on the single-agent path; the multi-agent path already installs via `configure_selected_tools`.

## Result

- **Launch (`ucode claude`, etc.) never installs skills.** `ucode claude --provider ... --workspace ...` now just configures the agent for the provider and launches — no install step.
- **`ucode configure` still installs**, on by default, with `--disable-databricks-ai-tools` to opt out (unchanged).

## Testing

- `TestConfigureWiresAiToolsInstall`: `configure_single_tool` is now asserted to **not** install; `configure_selected_tools` still does.
- The configure single-agent cli test now asserts the configure path installs (and mocks it, so it no longer makes a real `databricks aitools` subprocess call).
- `tests/test_agents_init.py` + `tests/test_cli.py`: 288 passed. Lint + format clean.

This pull request and its description were written by Isaac.
