### PR TITLE
gateway_proxy: shorten upstream read timeout and surface stream interruptions

### DIFF
--- a/src/ucode/gateway_proxy.py
+++ b/src/ucode/gateway_proxy.py
@@ -52,10 +52,14 @@ _HOP_BY_HOP = frozenset(
 # plus the swap header (replaced with a freshly-minted value per request).
 _STRIP_ON_FORWARD = _HOP_BY_HOP | {_SWAP_HEADER.lower()}
 _STREAM_CHUNK = 8192
-# Per-operation upstream timeouts. `read` is generous because model turns stream
-# over a single response and Anthropic emits SSE pings, so inter-chunk gaps stay
-# small; `connect`/`pool` fail fast when the gateway is unreachable.
-_UPSTREAM_TIMEOUT = httpx.Timeout(connect=10.0, read=600.0, write=600.0, pool=10.0)
+# Per-operation upstream timeouts. On the relayed path the pings the proxy sees
+# are AIGW's keep-alive frames (~every 10s), which cover only healthy streams;
+# AIGW itself aborts a genuine stall at ~60s and closes cleanly, so `read` only
+# needs to catch a dark upstream (pod crash / network partition, where neither
+# tokens nor pings arrive) — 120s catches that in ~2 min while staying well above
+# the 10s keep-alive so slow-but-healthy streams never trip it. `connect`/`pool`
+# fail fast when the gateway is unreachable.
+_UPSTREAM_TIMEOUT = httpx.Timeout(connect=10.0, read=120.0, write=600.0, pool=10.0)
 # Refresh once the token has less than this many seconds of life left. Databricks
 # access tokens live ~1h; a 10-min buffer leaves ample headroom for a retry.
 _REFRESH_BUFFER_S = 600
@@ -243,9 +247,28 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             # quietly rather than crashing the handler thread.
             return
         except httpx.HTTPError:
-            # Upstream dropped mid-stream. Headers (and status) may already be
-            # sent, so we can't reliably signal a fresh error — stop and let the
-            # client see a truncated stream rather than corrupt the framing.
+            # Upstream dropped mid-stream after the head was already sent. For an
+            # *uncompressed SSE* body we can emit a terminal Anthropic error frame
+            # so the client retries cleanly instead of rendering a silent
+            # truncation as "incomplete". But this path also relays non-streaming
+            # JSON and (since Accept-Encoding is forwarded) possibly-gzipped
+            # bodies byte-for-byte — injecting plaintext SSE framing into either
+            # would corrupt it, which is strictly worse than a clean truncation.
+            # So gate on content-type + content-encoding, and lead with a double
+            # CRLF to force an SSE event boundary in case the drop landed
+            # mid-line. Also guard for the client already being gone.
+            ctype = resp.headers.get("content-type", "")
+            cenc = resp.headers.get("content-encoding", "")
+            if "text/event-stream" in ctype and cenc in ("", "identity"):
+                try:
+                    self.wfile.write(
+                        b"\r\n\r\nevent: error\r\n"
+                        b'data: {"type":"error","error":{"type":"overloaded_error",'
+                        b'"message":"gateway proxy: upstream stream interrupted"}}\r\n\r\n'
+                    )
+                    self.wfile.flush()
+                except OSError:
+                    pass
             return
 
     # Forward every method: this is a transparent pass-through, so routing any


### PR DESCRIPTION
## What

Two changes to the ucode loopback refresh proxy (`src/ucode/gateway_proxy.py`) so a stalled/interrupted upstream stream degrades cleanly instead of hanging for 10 minutes or rendering as a silent truncation.

**B1 — lower the upstream `read` timeout 600s → 120s.** On the relayed path, the pings the proxy sees are AIGW's keep-alive frames (~10s) that cover only *healthy* streams; AIGW aborts a genuine stall at ~60s and closes cleanly (proxy sees EOF and relays it). The proxy read timeout then only needs to catch a *dark* upstream — pod crash / network partition, where neither tokens nor pings arrive — and 120s catches that in ~2 min instead of 10. It stays well above the 10s keep-alive interval so slow-but-healthy streams never trip it. `connect`/`write`/`pool` unchanged.

**B2 — emit a terminal SSE error frame on mid-stream drop.** When `iter_raw` raises `httpx.HTTPError` after the head is already sent, write a well-formed Anthropic `event: error` frame before closing so Claude Code retries cleanly rather than rendering "incomplete".

**B3 — corrected the timeout-rationale comment** to reflect the relayed path (AIGW keep-alive frames, not Anthropic's own pings).

## Correctness guard on B2

`_relay_response` handles *every* response and is byte-transparent over `Content-Encoding`. So the error frame is gated on the body being **uncompressed `text/event-stream`** — injecting plaintext SSE framing into a partial gzip body or a non-streaming JSON body would corrupt it, which is strictly worse than a clean truncation. The frame also leads with a double CRLF to force an SSE event boundary in case the drop landed mid-line.

## Caveat — this does not fully fix the customer hang

With AIGW keep-alive on, each `: ping` resets httpx's read timer, so B1 only shortens the *dark-upstream* case. A keep-alive-fed stall is still bounded only by AIGW's ~600s `webClientRequestTimeoutMs` until #2390858 (A1) lands. B1/B2 are necessary but not sufficient; A1 remains the primary lever.

## Testing

- `uv run ruff check .` — clean
- `uv run ruff format --check` — clean
- `uv run pytest tests/test_gateway_proxy.py` — 21 passed

This pull request and its description were written by Isaac.