### PR TITLE
configure: show admin an FYI instead of hijacking into `ucode setup`

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -247,10 +247,13 @@ def _resolve_workspace_then_maybe_reject(
     # cache is empty until the first launch, so a cache read would miss a config the workspace does
     # publish and wrongly fall through to the local configure flow. `refresh_managed_config` reaches
     # the workspace and never raises — it falls back to the persisted copy, then None, on failure.
-    with spinner("Checking for a managed coding agent config..."):
-        managed = refresh_managed_config({"workspace": workspace, "profile": profile})
-    if not managed:
+    with spinner("Loading..."):
+        managed, coding_agent_config_feature_disabled = refresh_managed_config(
+            {"workspace": workspace, "profile": profile}
+        )
+    if not managed and not coding_agent_config_feature_disabled:
         _maybe_offer_admin_setup(workspace, profile)
+    if not managed:
         return entries
     print_success("A managed config has been detected for your workspace — you're all set.")
     _print_managed_summary(managed, load_state(), tool=None)
@@ -1422,15 +1425,16 @@ def _reject_disabled_agent(managed: dict | None, tool: str) -> None:
         )
 
 
-def _fetch_managed_config(state: dict) -> dict | None:
-    """The workspace's managed config for this launch, or None when there is none.
+def _fetch_managed_config(state: dict) -> tuple[dict | None, bool]:
+    """The workspace's managed config for this launch, or ``(None, _)`` when there is none.
 
-    Returns None when managed configs are switched off — either the feature is disabled or the launch
-    passed ``--skip-managed-config`` (which clears the enabling env var for the process).
+    Returns ``(None, False)`` when managed configs are switched off — either the feature is disabled
+    or the launch passed ``--skip-managed-config`` (which clears the enabling env var for the process).
     """
+
     if not managed_agent_config_enabled():
-        return None
-    with spinner("Checking for a managed coding agent config..."):
+        return None, False
+    with spinner("Loading..."):
         return refresh_managed_config(state)
 
 
@@ -1639,7 +1643,7 @@ def _launch_tool(
         # Bare `ucode` already fetched one to choose the agent; refetching would double the
         # control-plane round trip and any fallback warning it printed.
         if managed is None:
-            managed = _fetch_managed_config(state)
+            managed, _coding_agent_config_feature_disabled = _fetch_managed_config(state)
         # Checked before discovery, which can take tens of seconds, so a blocked launch fails fast.
         _reject_disabled_agent(managed, tool)
         # Discovery exists to find models and isn't needed for managed config that already names them.
@@ -1981,10 +1985,11 @@ def _launch_managed_default(
     if dry_run:
         managed = load_managed_state(current)
     else:
-        with spinner("Checking for a managed coding agent config..."):
-            managed = refresh_managed_config(state)
-    if not managed:
+        with spinner("Loading..."):
+            managed, coding_agent_config_feature_disabled = refresh_managed_config(state)
+    if not managed and not coding_agent_config_feature_disabled:
         _print_no_managed_config_guidance(current, state.get("profile"))
+    if not managed:
         return
     # The budget tier can move the org to a cheaper agent, so it outranks the config's
     # default_agent. Fetched here and handed to _launch_tool so it is read once per launch.

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -232,9 +232,11 @@ def _resolve_workspace_then_maybe_reject(
     locally would be overridden at launch anyway: show the admin's config and point the developer
     at `ucode`.
 
-    Returns the resolved entries to configure when there is no managed config so the caller reuses
-    them instead of prompting again. Without the feature enabled it returns ``workspace_entries``
-    unchanged and prompts nothing.
+    When there is no managed config the developer's own ``configure`` always proceeds — an admin
+    just sees an FYI that they could publish one with ``ucode setup`` (never a prompt, never a
+    diversion). Returns the resolved entries to configure so the caller reuses them instead of
+    prompting again. Without the feature enabled it returns ``workspace_entries`` unchanged and
+    prompts nothing.
     """
     if not managed_agent_config_enabled():
         return workspace_entries
@@ -257,13 +259,13 @@ def _resolve_workspace_then_maybe_reject(
 
 
 def _maybe_offer_admin_setup(workspace: str, profile: str | None) -> None:
-    """When a workspace admin runs ``configure`` on a workspace with no managed config, offer to
-    bail out so they can publish one with ``ucode setup`` instead.
+    """When a workspace admin runs ``configure`` on a workspace with no managed config, drop an FYI
+    that they could publish one with ``ucode setup`` — without interrupting the configure flow.
 
-    Admins are the ones who'd want a managed config; a plain developer just gets the normal
-    configure flow. If they accept, exit cleanly (assuming they'll run `ucode setup`); if they
-    decline, fall through to configure their own local settings. The check is best-effort: any
-    failure to determine admin status (auth or SCIM unreachable) silently skips the prompt.
+    Admins are the ones who'd want a managed config, so the note is only shown to them; a plain
+    developer sees nothing. This never prompts and never diverts the command: the developer's own
+    ``configure`` always runs to completion, with the note printed alongside it. The check is
+    best-effort: any failure to determine admin status (auth or SCIM unreachable) silently skips it.
     """
     try:
         token = get_databricks_token(workspace, profile)
@@ -274,23 +276,10 @@ def _maybe_offer_admin_setup(workspace: str, profile: str | None) -> None:
     if not is_admin:
         return
     print_note(
-        "✨ New: as a workspace admin you can publish a managed config with `ucode setup` — set the "
-        "agents and models once (then MCP servers and skills with `ucode setup mcps` / `skills`), and "
-        "every developer picks them up automatically."
+        "✨ New: run `ucode setup` to publish a managed config to a workspace — set agents, models, mcps "
+        "and skills once, and every developer inherits them when running `ucode`. This scales "
+        "delivery of coding agents to all developers without each one setting up ucode themselves."
     )
-    if prompt_yes_no("Set one up now with `ucode setup`?"):
-        # Launch the setup flow in place rather than telling them to re-run a command. Reuse the
-        # workspace/profile we already resolved and authenticated against so setup doesn't prompt
-        # for them again.
-        try:
-            code = setup_command(workspace=workspace, profile=profile)
-        except RuntimeError as exc:
-            print_err(str(exc))
-            raise typer.Exit(1) from None
-        except KeyboardInterrupt:
-            print_err("Interrupted.")
-            raise typer.Exit(130) from None
-        raise typer.Exit(code or 0)
 
 
 def _print_discovery_diagnostics(state: dict) -> None:

--- a/src/ucode/managed_config.py
+++ b/src/ucode/managed_config.py
@@ -310,6 +310,8 @@ def get_managed_config(workspace: str, token: str) -> tuple[dict | None, str | N
     """
     configs, reason = fetch_managed_coding_agent_configs(workspace, token)
     if reason is not None:
+        if _is_feature_disabled(reason):
+            return None, reason
         # A NOT_FOUND means the admin hasn't defined a config for this workspace — not a failure.
         if _is_not_found(reason):
             return None, None
@@ -403,38 +405,47 @@ def managed_state_workspace() -> str | None:
     return workspace if isinstance(workspace, str) and workspace else None
 
 
-def refresh_managed_config(state: dict) -> dict | None:
-    """Fetch the workspace's managed config and persist it, returning the normalized manifest.
+def refresh_managed_config(state: dict) -> tuple[dict | None, bool]:
+    """Fetch the workspace's managed config and persist it, returning ``(manifest, coding_agent_config_feature_disabled)``.
 
     Runs on every launch so a developer picks up an admin's edits without re-running
-    ``ucode configure``. Returns None when the workspace has no managed config — the normal case for
-    a workspace whose admin hasn't published one.
+    ``ucode configure``. The manifest is None when the workspace has no managed config — the normal
+    case for a workspace whose admin hasn't published one.
 
     A failed fetch never blocks the launch: an unreachable control plane shouldn't stop someone from
     coding. Instead it falls back to the last config persisted for this workspace, so the admin's
     most recent known policy still applies; only when there is no persisted config either does the
     launch fall through to the developer's own settings.
+
+    ``coding_agent_config_feature_disabled`` is True when the gateway returned ``FEATURE_DISABLED`` and there was no
+    persisted config to fall back on — the coding-agent-configs feature isn't enabled server-side,
+    so callers suppress the ``ucode setup`` recommendation.
     """
     workspace = state.get("workspace")
     if not workspace:
-        return None
+        return None, False
     try:
         token = get_databricks_token(workspace, state.get("profile"))
     except RuntimeError as exc:
-        return _persisted_fallback(workspace, str(exc))
+        return _persisted_fallback(workspace, str(exc)), False
     managed, reason = get_managed_config(workspace, token)
     if reason is not None:
         # A refused read leaves the cached config alone: it says nothing about whether the admin's
         # config still exists, unlike a successful "no config" answer below.
-        return _persisted_fallback(workspace, reason, refused=_is_permission_denied(reason))
+        fallback = _persisted_fallback(workspace, reason, refused=_is_permission_denied(reason))
+        return fallback, _is_feature_disabled(reason) and fallback is None
     if managed is None:
         # Record that this workspace has no config, rather than leaving an earlier one on disk:
         # the file doubles as the fallback above, so a removed policy would otherwise come back
         # into force after the next transient outage.
         save_managed_state(workspace, {})
-        return None
+        return None, False
     save_managed_state(workspace, managed)
-    return managed
+    return managed, False
+
+
+def _is_feature_disabled(reason: str) -> bool:
+    return "feature_disabled" in reason.lower()
 
 
 def _persisted_fallback(workspace: str, reason: str, *, refused: bool = False) -> dict | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2951,7 +2951,7 @@ class TestBudgetRecommendationAtLaunch:
             patch("ucode.cli.configure_shared_state", return_value=state),
             patch("ucode.cli.configure_tool", return_value=state) as cfg,
             patch("ucode.cli.get_databricks_token", return_value="tok"),
-            patch("ucode.cli._fetch_managed_config", return_value=managed),
+            patch("ucode.cli._fetch_managed_config", return_value=(managed, False)),
             patch("ucode.cli.launch_agent"),
         ):
             result = runner.invoke(app, [tool])
@@ -3027,7 +3027,7 @@ class TestBudgetRecommendationAtLaunch:
             patch("ucode.cli.get_databricks_token", side_effect=RuntimeError("token expired")),
             patch(
                 "ucode.cli._fetch_managed_config",
-                return_value={"enabled_agents": {"claude": {}}},
+                return_value=({"enabled_agents": {"claude": {}}}, False),
             ),
             patch("ucode.cli.launch_agent"),
         ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2590,84 +2590,53 @@ class TestConfigureDeprecation:
         entries = self._resolve([("https://w", None)])
         assert entries == [("https://w", None)]
 
-    def test_admin_who_declines_proceeds_with_configure(self, monkeypatch):
-        # An admin on a config-less workspace is offered `ucode setup`; declining continues the
-        # normal configure flow and returns the resolved workspace.
+    def test_admin_sees_fyi_note_and_is_not_hijacked(self, monkeypatch):
+        # An admin on a config-less workspace gets an FYI that they could publish one with
+        # `ucode setup`, but the command is never diverted: no prompt, no in-place setup launch —
+        # the normal configure flow runs to completion and returns the resolved workspace.
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
         monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
         monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
         monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: True)
-        monkeypatch.setattr("ucode.cli.prompt_yes_no", lambda prompt: False)
+        monkeypatch.setattr(
+            "ucode.cli.prompt_yes_no",
+            lambda prompt: pytest.fail("configure must not prompt to launch setup"),
+        )
+        monkeypatch.setattr(
+            "ucode.cli.setup_command",
+            lambda **kwargs: pytest.fail("configure must not launch setup in place"),
+        )
+        notes: list[str] = []
+        monkeypatch.setattr("ucode.cli.print_note", lambda msg: notes.append(msg))
         entries = self._resolve([("https://w", None)])
         assert entries == [("https://w", None)]
+        assert any("ucode setup" in note for note in notes)
 
-    def test_admin_who_accepts_launches_setup_in_place(self, monkeypatch):
-        # Accepting the offer runs `setup_command` right there — reusing the workspace/profile we
-        # already resolved so setup doesn't re-prompt for them — then exits with its code.
-        import typer
-
-        monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
-        monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
-        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
-        monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
-        monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: True)
-        monkeypatch.setattr("ucode.cli.prompt_yes_no", lambda prompt: True)
-        calls = {}
-        monkeypatch.setattr(
-            "ucode.cli.setup_command",
-            lambda **kwargs: calls.update(kwargs) or 0,
-        )
-        with pytest.raises(typer.Exit) as exc:
-            self._resolve([("https://w", None)])
-        assert exc.value.exit_code == 0
-        assert calls == {"workspace": "https://w", "profile": None}
-
-    def test_admin_who_accepts_propagates_setup_failure(self, monkeypatch):
-        # A RuntimeError from setup (e.g. discovery failed) surfaces as a non-zero exit, not a stack
-        # trace bubbling out of configure.
-        import typer
-
-        monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
-        monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
-        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
-        monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
-        monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: True)
-        monkeypatch.setattr("ucode.cli.prompt_yes_no", lambda prompt: True)
-        monkeypatch.setattr(
-            "ucode.cli.setup_command",
-            lambda **kwargs: (_ for _ in ()).throw(RuntimeError("no agents")),
-        )
-        with pytest.raises(typer.Exit) as exc:
-            self._resolve([("https://w", None)])
-        assert exc.value.exit_code == 1
-
-    def test_non_admin_is_never_prompted_for_setup(self, monkeypatch):
+    def test_non_admin_sees_no_setup_note(self, monkeypatch):
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
         monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
         monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
         monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: False)
-        monkeypatch.setattr(
-            "ucode.cli.prompt_yes_no",
-            lambda prompt: pytest.fail("non-admins must not be prompted for setup"),
-        )
+        notes: list[str] = []
+        monkeypatch.setattr("ucode.cli.print_note", lambda msg: notes.append(msg))
         entries = self._resolve([("https://w", None)])
         assert entries == [("https://w", None)]
+        assert notes == []
 
-    def test_admin_check_failure_skips_the_setup_prompt(self, monkeypatch):
-        # `is_workspace_admin` returns None when the check itself fails; treat as "don't prompt".
+    def test_admin_check_failure_shows_no_setup_note(self, monkeypatch):
+        # `is_workspace_admin` returns None when the check itself fails; treat as "not an admin".
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
         monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
         monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
         monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: None)
-        monkeypatch.setattr(
-            "ucode.cli.prompt_yes_no",
-            lambda prompt: pytest.fail("must not prompt when admin status is unknown"),
-        )
+        notes: list[str] = []
+        monkeypatch.setattr("ucode.cli.print_note", lambda msg: notes.append(msg))
         entries = self._resolve([("https://w", None)])
         assert entries == [("https://w", None)]
+        assert notes == []
 
     def test_configure_command_exits_zero_without_erroring(self, monkeypatch):
         # `typer.Exit(0)` subclasses RuntimeError, so the command's own RuntimeError handler must

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,7 +143,7 @@ def _patch_launch(tool: str):
             "ucode.cli.configure_tool",
             return_value=MINIMAL_STATE,
         ),
-        patch("ucode.cli._fetch_managed_config", return_value=None),
+        patch("ucode.cli._fetch_managed_config", return_value=(None, False)),
         patch("ucode.cli.launch_agent"),
     ]
 
@@ -267,7 +267,7 @@ class TestSubcommandRouting:
                 return_value=(decision, None),
             ),
             patch("ucode.cli.configure_tool", return_value=state) as mock_configure,
-            patch("ucode.cli._fetch_managed_config", return_value=None),
+            patch("ucode.cli._fetch_managed_config", return_value=(None, False)),
             patch("ucode.cli.launch_agent"),
         ):
             result = runner.invoke(app, ["codex"])
@@ -299,7 +299,7 @@ class TestClaudeModelFlag:
             patch("ucode.cli.configure_shared_state", return_value=MINIMAL_STATE),
             patch("ucode.cli.resolve_launch_model", return_value=(MINIMAL_STATE, "system.ai.opus")),
             patch("ucode.cli.configure_tool", return_value=MINIMAL_STATE) as mock_configure,
-            patch("ucode.cli._fetch_managed_config", return_value=None),
+            patch("ucode.cli._fetch_managed_config", return_value=(None, False)),
             patch("ucode.cli.launch_agent"),
         ):
             result = runner.invoke(app, ["claude", "--model", "cat.schema.claude-opus-5"])
@@ -328,7 +328,7 @@ class TestClaudeModelFlag:
             patch("ucode.cli.configure_shared_state", return_value=MINIMAL_STATE),
             patch("ucode.cli.resolve_launch_model", return_value=(MINIMAL_STATE, "system.ai.opus")),
             patch("ucode.cli.configure_tool", return_value=MINIMAL_STATE),
-            patch("ucode.cli._fetch_managed_config", return_value=None),
+            patch("ucode.cli._fetch_managed_config", return_value=(None, False)),
             patch(
                 "ucode.cli.claude_agent.managed_settings_model_overrides",
                 return_value=Path("/etc/claude-code/managed-settings.json"),
@@ -348,7 +348,7 @@ class TestClaudeModelFlag:
             patch("ucode.cli.configure_shared_state", return_value=MINIMAL_STATE),
             patch("ucode.cli.resolve_launch_model", return_value=(MINIMAL_STATE, "system.ai.opus")),
             patch("ucode.cli.configure_tool", return_value=MINIMAL_STATE),
-            patch("ucode.cli._fetch_managed_config", return_value=None),
+            patch("ucode.cli._fetch_managed_config", return_value=(None, False)),
             patch("ucode.cli.claude_agent.managed_settings_model_overrides", return_value=None),
             patch("ucode.cli.launch_agent"),
         ):
@@ -880,7 +880,7 @@ class TestAutoConfigureOnFirstRun:
                 return_value=(configured_state, "databricks-claude-sonnet-4"),
             ),
             patch("ucode.cli.configure_tool", return_value=configured_state),
-            patch("ucode.cli._fetch_managed_config", return_value=None),
+            patch("ucode.cli._fetch_managed_config", return_value=(None, False)),
             patch("ucode.cli.launch_agent"),
         ):
             result = runner.invoke(app, ["claude"])
@@ -905,7 +905,7 @@ class TestAutoConfigureOnFirstRun:
                 return_value=(MINIMAL_STATE, "databricks-claude-sonnet-4"),
             ),
             patch("ucode.cli.configure_tool", return_value=MINIMAL_STATE),
-            patch("ucode.cli._fetch_managed_config", return_value=None),
+            patch("ucode.cli._fetch_managed_config", return_value=(None, False)),
             patch("ucode.cli.launch_agent"),
         ):
             result = runner.invoke(app, ["claude"])
@@ -929,7 +929,7 @@ class TestAutoConfigureOnFirstRun:
                 return_value=(MINIMAL_STATE, "databricks-claude-sonnet-4"),
             ),
             patch("ucode.cli.configure_tool", return_value=MINIMAL_STATE),
-            patch("ucode.cli._fetch_managed_config", return_value=None),
+            patch("ucode.cli._fetch_managed_config", return_value=(None, False)),
             patch("ucode.cli.launch_agent"),
         ):
             runner.invoke(app, ["claude"])
@@ -1617,7 +1617,7 @@ class TestConfigureAgentsSelection:
             return {**MINIMAL_STATE, "workspace": workspace, "profile": profile}
 
         monkeypatch.setattr(cli_mod, "configure_shared_state", fake_configure_shared_state)
-        monkeypatch.setattr(cli_mod, "save_state", lambda state: None)
+        monkeypatch.setattr(cli_mod, "save_state", lambda state: (None, False))
         monkeypatch.setattr(cli_mod, "check_gateway_endpoint", lambda state, tool: True)
         monkeypatch.setattr(cli_mod, "prompt_for_tools", lambda available: ["claude"])
         monkeypatch.setattr(cli_mod, "_maybe_select_provider_service", lambda tool, state: state)
@@ -2389,7 +2389,7 @@ class TestSkipPreflightFlag:
                 return_value=(MINIMAL_STATE, "databricks-claude-sonnet-4"),
             ),
             patch("ucode.cli.configure_tool", return_value=MINIMAL_STATE),
-            patch("ucode.cli._fetch_managed_config", return_value=None),
+            patch("ucode.cli._fetch_managed_config", return_value=(None, False)),
             patch("ucode.cli.launch_agent"),
         ]
 
@@ -2450,9 +2450,9 @@ class TestFetchManagedConfig:
     def test_fetches_fresh_when_enabled(self, monkeypatch):
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr(
-            "ucode.cli.refresh_managed_config", lambda state: {"enabled_agents": {}}
+            "ucode.cli.refresh_managed_config", lambda state: ({"enabled_agents": {}}, False)
         )
-        assert self._fetch({"workspace": "https://w"}) == {"enabled_agents": {}}
+        assert self._fetch({"workspace": "https://w"}) == ({"enabled_agents": {}}, False)
 
     @pytest.mark.parametrize("env_value", [None, "", "0", "off", "no"])
     def test_disabled_reads_nothing_at_all(self, monkeypatch, env_value):
@@ -2466,7 +2466,7 @@ class TestFetchManagedConfig:
                 f"ucode.cli.{name}",
                 lambda *a, called=name, **k: pytest.fail(f"{called} must not run when disabled"),
             )
-        assert self._fetch({"workspace": "https://w"}) is None
+        assert self._fetch({"workspace": "https://w"}) == (None, False)
 
     def test_skip_managed_config_makes_the_fetch_a_no_op(self, monkeypatch):
         # --skip-managed-config clears the enabling env var, so the read behaves as feature-off:
@@ -2478,7 +2478,7 @@ class TestFetchManagedConfig:
         import ucode.cli as cli_mod
 
         cli_mod._disable_managed_config_if_requested(True)
-        assert self._fetch({"workspace": "https://w"}) is None
+        assert self._fetch({"workspace": "https://w"}) == (None, False)
 
 
 class TestManagedConfigDecidesDiscoveryFromFreshRead:
@@ -2495,7 +2495,7 @@ class TestManagedConfigDecidesDiscoveryFromFreshRead:
         }
         fresh = {"enabled_agents": {"claude": {"model_config": {}}}}
         monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: stale_cache)
-        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: fresh)
+        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: (fresh, False))
 
         state = dict(MINIMAL_STATE)
         with (
@@ -2532,7 +2532,7 @@ class TestConfigureDeprecation:
         monkeypatch.setattr("ucode.cli.load_state", lambda: {"workspace": "https://w"})
         monkeypatch.setattr(
             "ucode.cli.refresh_managed_config",
-            lambda state: {"enabled_agents": {"claude": {}}},
+            lambda state: ({"enabled_agents": {"claude": {}}}, False),
         )
         with pytest.raises(typer.Exit) as exc:
             self._resolve([("https://w", None)])
@@ -2553,7 +2553,7 @@ class TestConfigureDeprecation:
         monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: None)
         monkeypatch.setattr(
             "ucode.cli.refresh_managed_config",
-            lambda state: {"enabled_agents": {"claude": {}}},
+            lambda state: ({"enabled_agents": {"claude": {}}}, False),
         )
         with pytest.raises(typer.Exit) as exc:
             self._resolve([("https://w", None)])
@@ -2574,7 +2574,7 @@ class TestConfigureDeprecation:
             "ucode.cli._prompt_for_configuration", lambda tool=None: ("https://picked", None)
         )
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: picked.append(ws))
-        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
+        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: (None, False))
         self._stub_not_admin(monkeypatch)
         entries = self._resolve(None)
         assert picked == ["https://picked"]
@@ -2585,7 +2585,7 @@ class TestConfigureDeprecation:
         # workspace back to the caller instead of re-prompting.
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
-        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
+        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: (None, False))
         self._stub_not_admin(monkeypatch)
         entries = self._resolve([("https://w", None)])
         assert entries == [("https://w", None)]
@@ -2596,7 +2596,7 @@ class TestConfigureDeprecation:
         # the normal configure flow runs to completion and returns the resolved workspace.
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
-        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
+        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: (None, False))
         monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
         monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: True)
         monkeypatch.setattr(
@@ -2616,7 +2616,7 @@ class TestConfigureDeprecation:
     def test_non_admin_sees_no_setup_note(self, monkeypatch):
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
-        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
+        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: (None, False))
         monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
         monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: False)
         notes: list[str] = []
@@ -2629,9 +2629,26 @@ class TestConfigureDeprecation:
         # `is_workspace_admin` returns None when the check itself fails; treat as "not an admin".
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
-        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: None)
+        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: (None, False))
         monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
         monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: None)
+        notes: list[str] = []
+        monkeypatch.setattr("ucode.cli.print_note", lambda msg: notes.append(msg))
+        entries = self._resolve([("https://w", None)])
+        assert entries == [("https://w", None)]
+        assert notes == []
+
+    def test_admin_sees_no_setup_fyi_when_feature_is_disabled(self, monkeypatch):
+        # The coding-agent-configs feature isn't enabled server-side, so `ucode setup` can't
+        # publish. An admin should not be told to run it.
+        monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
+        monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
+
+        monkeypatch.setattr(
+            "ucode.cli.refresh_managed_config", lambda state: (None, True)
+        )
+        monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
+        monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: True)
         notes: list[str] = []
         monkeypatch.setattr("ucode.cli.print_note", lambda msg: notes.append(msg))
         entries = self._resolve([("https://w", None)])
@@ -2646,7 +2663,7 @@ class TestConfigureDeprecation:
         monkeypatch.setattr("ucode.cli.load_state", lambda: {"workspace": "https://w"})
         monkeypatch.setattr(
             "ucode.cli.refresh_managed_config",
-            lambda state: {"enabled_agents": {"claude": {}}},
+            lambda state: ({"enabled_agents": {"claude": {}}}, False),
         )
         with (
             patch("ucode.cli.install_databricks_cli"),
@@ -2740,13 +2757,20 @@ class TestBareUcode:
     MANAGED = {"default_agent": "claude", "enabled_agents": {"claude": {}, "opencode": {}}}
 
     @staticmethod
-    def _run(monkeypatch, *, managed, is_admin=False, args=None, cached=None):
+    def _run(
+        monkeypatch, *, managed, is_admin=False, args=None, cached=None, coding_agent_config_feature_disabled=False
+    ):
         launched: list[tuple] = []
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.install_databricks_cli", lambda *a, **k: None)
         monkeypatch.setattr("ucode.cli.apply_pat_environment", lambda *a, **k: None)
         monkeypatch.setattr("ucode.cli.load_state", lambda: {"workspace": "https://w"})
-        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: managed)
+
+        if coding_agent_config_feature_disabled:
+            monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: (None, True))
+        else:
+            monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: (managed, False))
+
         monkeypatch.setattr("ucode.cli.load_managed_state", lambda ws: cached)
         monkeypatch.setattr("ucode.cli.get_databricks_token", lambda *a, **k: "tok")
         monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda *a, **k: is_admin)
@@ -2782,6 +2806,22 @@ class TestBareUcode:
         assert launched == []
         assert "Ask a workspace admin" in result.output
 
+    def test_admin_without_a_config_sees_no_setup_when_feature_disabled(self, monkeypatch):
+        result, launched = self._run(
+            monkeypatch, managed=None, is_admin=True, coding_agent_config_feature_disabled=True
+        )
+        assert result.exit_code == 0, result.output
+        assert launched == []
+        assert "ucode setup" not in result.output
+
+    def test_non_admin_without_a_config_sees_no_setup_when_feature_disabled(self, monkeypatch):
+        result, launched = self._run(
+            monkeypatch, managed=None, is_admin=False, coding_agent_config_feature_disabled=True
+        )
+        assert result.exit_code == 0, result.output
+        assert launched == []
+        assert "ucode setup" not in result.output
+
     def test_dry_run_uses_the_cache_and_does_not_fetch(self, monkeypatch):
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.install_databricks_cli", lambda *a, **k: None)
@@ -2812,7 +2852,7 @@ class TestBareUcode:
             "default_agent": "claude",
             "enabled_agents": {"claude": {"model_config": {"default_model": "m"}}},
         }
-        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: managed)
+        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: (managed, False))
         monkeypatch.setattr("ucode.cli._fetch_budget_recommendation", lambda state, m: None)
         monkeypatch.setattr("ucode.cli._print_managed_summary", lambda *a, **k: None)
         seen: dict = {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2644,9 +2644,7 @@ class TestConfigureDeprecation:
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")
         monkeypatch.setattr("ucode.cli.set_current_workspace", lambda ws: None)
 
-        monkeypatch.setattr(
-            "ucode.cli.refresh_managed_config", lambda state: (None, True)
-        )
+        monkeypatch.setattr("ucode.cli.refresh_managed_config", lambda state: (None, True))
         monkeypatch.setattr("ucode.cli.get_databricks_token", lambda ws, profile=None: "tok")
         monkeypatch.setattr("ucode.cli.is_workspace_admin", lambda ws, tok: True)
         notes: list[str] = []
@@ -2758,7 +2756,13 @@ class TestBareUcode:
 
     @staticmethod
     def _run(
-        monkeypatch, *, managed, is_admin=False, args=None, cached=None, coding_agent_config_feature_disabled=False
+        monkeypatch,
+        *,
+        managed,
+        is_admin=False,
+        args=None,
+        cached=None,
+        coding_agent_config_feature_disabled=False,
     ):
         launched: list[tuple] = []
         monkeypatch.setenv("ENABLE_MANAGED_AGENT_CONFIG", "1")

--- a/tests/test_managed_config.py
+++ b/tests/test_managed_config.py
@@ -178,6 +178,18 @@ class TestGetManagedConfig:
         assert cfg is None
         assert reason is None
 
+    def test_feature_disabled_is_not_swallowed_as_not_found(self, monkeypatch):
+        reason = (
+            'HTTP 404 Not Found: {"error_code":"FEATURE_DISABLED",'
+            '"message":"Coding agent config APIs are not enabled for this workspace."}'
+        )
+        monkeypatch.setattr(
+            mc_mod, "fetch_managed_coding_agent_configs", lambda ws, tok: ([], reason)
+        )
+        cfg, reason_out = get_managed_config("https://ws", "tok")
+        assert cfg is None
+        assert reason_out == reason
+
 
 class TestPersistence:
     @pytest.fixture(autouse=True)
@@ -318,13 +330,14 @@ class TestRefreshManagedConfig:
         saved: list[tuple] = []
         monkeypatch.setattr(mc_mod, "get_managed_config", lambda ws, tok: (MANAGED, None))
         monkeypatch.setattr(mc_mod, "save_managed_state", lambda ws, cfg: saved.append((ws, cfg)))
-        assert refresh_managed_config(_state()) == MANAGED
+        assert refresh_managed_config(_state()) == (MANAGED, False)
         assert saved == [(WORKSPACE, MANAGED)]
 
     def test_no_managed_config_returns_none(self, monkeypatch):
         monkeypatch.setattr(mc_mod, "get_managed_config", lambda ws, tok: (None, None))
         monkeypatch.setattr(mc_mod, "save_managed_state", lambda ws, cfg: None)
-        assert refresh_managed_config(_state()) is None
+        result, _ = refresh_managed_config(_state())
+        assert result is None
 
     def test_read_failure_falls_back_to_the_persisted_config(self, monkeypatch):
         # The admin's last known policy beats no policy, so a failed fetch reuses what we saved.
@@ -332,7 +345,7 @@ class TestRefreshManagedConfig:
         monkeypatch.setattr(mc_mod, "get_managed_config", lambda ws, tok: (None, "HTTP 500"))
         monkeypatch.setattr(mc_mod, "load_managed_state", lambda ws: MANAGED)
         monkeypatch.setattr(mc_mod, "print_warning", lambda msg: warnings.append(msg))
-        assert refresh_managed_config(_state()) == MANAGED
+        assert refresh_managed_config(_state()) == (MANAGED, False)
         assert "HTTP 500" in warnings[0]
         assert "last one saved" in warnings[0]
 
@@ -344,7 +357,8 @@ class TestRefreshManagedConfig:
         monkeypatch.setattr(
             mc_mod, "print_warning", lambda msg: pytest.fail(f"should not warn: {msg}")
         )
-        assert refresh_managed_config(_state()) is None
+        result, _ = refresh_managed_config(_state())
+        assert result is None
 
     def test_auth_failure_falls_back_to_the_persisted_config(self, monkeypatch):
         warnings: list[str] = []
@@ -355,7 +369,7 @@ class TestRefreshManagedConfig:
         monkeypatch.setattr(mc_mod, "get_databricks_token", boom)
         monkeypatch.setattr(mc_mod, "load_managed_state", lambda ws: MANAGED)
         monkeypatch.setattr(mc_mod, "print_warning", lambda msg: warnings.append(msg))
-        assert refresh_managed_config(_state()) == MANAGED
+        assert refresh_managed_config(_state()) == (MANAGED, False)
         assert "no token" in warnings[0]
 
     def test_auth_failure_without_persisted_config_is_silent(self, monkeypatch):
@@ -367,7 +381,8 @@ class TestRefreshManagedConfig:
         monkeypatch.setattr(
             mc_mod, "print_warning", lambda msg: pytest.fail(f"should not warn: {msg}")
         )
-        assert refresh_managed_config(_state()) is None
+        result, _ = refresh_managed_config(_state())
+        assert result is None
 
     def test_permission_denied_without_cache_is_silent(self, monkeypatch):
         # A refusal is no evidence a config exists, so with nothing cached there is no managed
@@ -378,7 +393,8 @@ class TestRefreshManagedConfig:
         monkeypatch.setattr(
             mc_mod, "print_warning", lambda msg: pytest.fail(f"should not warn: {msg}")
         )
-        assert refresh_managed_config(_state()) is None
+        result, _ = refresh_managed_config(_state())
+        assert result is None
 
     def test_permission_denied_warns_and_keeps_the_cached_config(self, monkeypatch):
         # A refused read is worth surfacing: an admin may have published a config that isn't
@@ -391,7 +407,7 @@ class TestRefreshManagedConfig:
         monkeypatch.setattr(
             mc_mod, "save_managed_state", lambda ws, cfg: pytest.fail("must not clear the cache")
         )
-        assert refresh_managed_config(_state()) == MANAGED
+        assert refresh_managed_config(_state()) == (MANAGED, False)
         assert "not readable by you" in warnings[0]
 
     def test_no_config_on_the_server_does_not_use_a_stale_persisted_file(self, monkeypatch):
@@ -402,7 +418,8 @@ class TestRefreshManagedConfig:
         monkeypatch.setattr(
             mc_mod, "load_managed_state", lambda ws: pytest.fail("must not fall back")
         )
-        assert refresh_managed_config(_state()) is None
+        result, _ = refresh_managed_config(_state())
+        assert result is None
 
     def test_no_config_on_the_server_clears_the_persisted_one(self, monkeypatch):
         # Without this, removing the config server-side would leave the old one on disk and the next
@@ -411,7 +428,8 @@ class TestRefreshManagedConfig:
         monkeypatch.setattr(mc_mod, "get_managed_config", lambda ws, tok: (None, None))
         monkeypatch.setattr(mc_mod, "save_managed_state", lambda ws, cfg: saved.append((ws, cfg)))
         monkeypatch.setattr(mc_mod, "load_managed_state", lambda ws: None)
-        assert refresh_managed_config(_state()) is None
+        result, _ = refresh_managed_config(_state())
+        assert result is None
         assert saved == [(WORKSPACE, {})]
 
     def test_empty_persisted_config_is_not_treated_as_a_fallback(self, monkeypatch):
@@ -422,13 +440,56 @@ class TestRefreshManagedConfig:
         monkeypatch.setattr(
             mc_mod, "print_warning", lambda msg: pytest.fail(f"should not warn: {msg}")
         )
-        assert refresh_managed_config(_state()) is None
+        result, _ = refresh_managed_config(_state())
+        assert result is None
 
     def test_no_workspace_is_a_noop(self, monkeypatch):
         monkeypatch.setattr(
             mc_mod, "get_managed_config", lambda ws, tok: pytest.fail("should not fetch")
         )
-        assert refresh_managed_config({}) is None
+        result, _ = refresh_managed_config({})
+        assert result is None
+
+    def test_feature_disabled_sets_flag_when_there_is_no_fallback(self, monkeypatch):
+        # The workspace hasn't enabled coding-agent-configs server-side, so `ucode setup` can't
+        # publish anything yet. The flag lets callers suppress the setup recommendation.
+        reason = 'HTTP 400 Bad Request: {"error_code":"FEATURE_DISABLED"}'
+        monkeypatch.setattr(mc_mod, "get_managed_config", lambda ws, tok: (None, reason))
+        monkeypatch.setattr(mc_mod, "load_managed_state", lambda ws: None)
+        monkeypatch.setattr(mc_mod, "print_warning", lambda msg: None)
+        state = _state()
+        result, flag = refresh_managed_config(state)
+        assert result is None
+        assert flag is True
+
+    def test_feature_disabled_with_a_fallback_does_not_set_the_flag(self, monkeypatch):
+        # A cached config means the launch uses it (not the "no config" branch), so the
+        # feature-off flag is irrelevant and must not be set.
+        reason = 'HTTP 400 Bad Request: {"error_code":"FEATURE_DISABLED"}'
+        monkeypatch.setattr(mc_mod, "get_managed_config", lambda ws, tok: (None, reason))
+        monkeypatch.setattr(mc_mod, "load_managed_state", lambda ws: MANAGED)
+        monkeypatch.setattr(mc_mod, "print_warning", lambda msg: None)
+        state = _state()
+        result, flag = refresh_managed_config(state)
+        assert result == MANAGED
+        assert flag is False
+
+    def test_transient_failure_does_not_set_the_flag(self, monkeypatch):
+        monkeypatch.setattr(mc_mod, "get_managed_config", lambda ws, tok: (None, "HTTP 500"))
+        monkeypatch.setattr(mc_mod, "load_managed_state", lambda ws: None)
+        monkeypatch.setattr(mc_mod, "print_warning", lambda msg: None)
+        state = _state()
+        result, flag = refresh_managed_config(state)
+        assert result is None
+        assert flag is False
+
+    def test_successful_no_config_clears_the_flag(self, monkeypatch):
+        monkeypatch.setattr(mc_mod, "get_managed_config", lambda ws, tok: (None, None))
+        monkeypatch.setattr(mc_mod, "save_managed_state", lambda ws, cfg: None)
+        state = _state()
+        result, flag = refresh_managed_config(state)
+        assert result is None
+        assert flag is False
 
 
 class TestGetModelRecommendation:


### PR DESCRIPTION
## What

When `ENABLE_MANAGED_AGENT_CONFIG` is on but the workspace has **no** managed config, `ucode configure` used to prompt a workspace admin `"Set one up now with \`ucode setup\`?"` and, on yes, launch `setup_command` in place and exit — diverting the command the developer actually ran.

This keeps the managed-config check and the admin SCIM check, but drops the prompt and the in-place launch. Admins now just see an FYI note; the developer's own `configure` always runs to completion. Non-admins see nothing, as before.

## Behavior after this change (flag on, no managed config)

- **Non-admins:** normal `configure` flow, unchanged (only the two silent network checks).
- **Admins:** an FYI note, then the normal `configure` flow — no prompt, no diversion:

  > ✨ New: run `ucode setup` to publish a managed config to a workspace — set agents, models, mcps and skills once, and every developer inherits them when running `ucode`. This scales delivery of coding agents to all developers without each one setting up ucode themselves.

The short-circuit when a managed config **does** exist (`configure` → "you're all set" + exit) is intentionally left as-is.

## Tests

- Removed the two obsolete tests that asserted the accept/launch/propagate-failure behavior.
- Reworked the remaining tests to assert on the FYI note (present for admins, absent for non-admins and on failed admin checks).
- Full suite: 1893 passed, 36 skipped, plus one pre-existing environmental e2e failure unrelated to this change (`test_user_agent_arrives_at_gateway`, fails identically on the base).

This pull request and its description were written by Isaac.