### PR TITLE
Model picker: show all models in a fixed scrolling viewport

### DIFF
--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -473,7 +473,7 @@ def _prompt_claude_models(state: dict) -> dict:
         family_models = candidates.get(family)
         if not family_models:
             continue
-        rows = [(model, model) for model in family_models[:_MODEL_PICKER_LIMIT]] + [
+        rows = [(model, model) for model in family_models] + [
             (_CUSTOM_MODEL, _CUSTOM_MODEL_LABEL),
             (_SKIP_FAMILY, f"(skip {family})"),
         ]
@@ -721,18 +721,17 @@ def _require_text(prompt: str) -> str:
         print_err("Please enter a model id.")
 
 
-# Discovered model lists run long (a dozen-plus ids on a real workspace), so each hosted-model picker
-# shows only the most relevant few and offers an explicit "type your own" row. Typing a model covers
-# both a discovered id past the shown few and a custom model service outside `system.ai` that
+# Discovered model lists run long (a dozen-plus ids on a real workspace), so every hosted-model
+# picker is searchable and scrolls (see `prompt_for_selection`); all discovered ids are offered, and
+# an explicit "type your own" row still covers a custom model service outside `system.ai` that
 # discovery never lists at all.
-_MODEL_PICKER_LIMIT = 5
 _CUSTOM_MODEL = "__custom_model__"
 _CUSTOM_MODEL_LABEL = "✎ Enter a custom model…"
 
 
 def _custom_option_rows(options: list[tuple[str, str]]) -> list[tuple[str, str]]:
-    """The first few model rows plus a 'type your own' row, for a hosted-model picker."""
-    return list(options[:_MODEL_PICKER_LIMIT]) + [(_CUSTOM_MODEL, _CUSTOM_MODEL_LABEL)]
+    """All discovered model rows plus a 'type your own' row, for a hosted-model picker."""
+    return list(options) + [(_CUSTOM_MODEL, _CUSTOM_MODEL_LABEL)]
 
 
 def _short_reason(reason: str | None) -> str:
@@ -792,7 +791,7 @@ def _prompt_custom_model(state: dict) -> str:
 def _select_hosted_model(
     prompt: str, options: list[str], state: dict, custom_sink: list[str]
 ) -> str:
-    """Single-select over the top few ``options`` plus a custom-entry row.
+    """Single-select over all discovered ``options`` plus a custom-entry row.
 
     Records any custom id in ``custom_sink`` so the caller can mark it in
     ``model_config.custom_models``, which keeps validation from rejecting a model discovery didn't
@@ -809,7 +808,7 @@ def _select_hosted_model(
 def _select_hosted_models_multi(
     prompt: str, options: list[str], state: dict, custom_sink: list[str]
 ) -> list[str]:
-    """Multi-select over the top few ``options`` plus a custom-entry row; requires one pick.
+    """Multi-select over all discovered ``options`` plus a custom-entry row; requires one pick.
 
     Selecting the custom row prompts for custom model ids — as many as the admin wants, since a
     multi-select agent (opencode, pi) can carry a whole list — and folds them into the picks. Records

--- a/src/ucode/ui.py
+++ b/src/ucode/ui.py
@@ -13,6 +13,9 @@ from datetime import timedelta
 from decimal import ROUND_HALF_UP, Decimal
 
 import questionary
+from prompt_toolkit.layout.containers import Window
+from prompt_toolkit.layout.dimension import Dimension
+from questionary.prompts.common import InquirerControl
 from rich.console import Console
 from rich.markup import escape
 from rich.panel import Panel
@@ -21,21 +24,48 @@ from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn
 console = Console(highlight=False)
 err_console = Console(stderr=True, highlight=False)
 
-# questionary scrolls a window over a long choice list, but doesn't advertise it. Past this many
-# options the list can't all be on screen, so the pickers append a "↑/↓ scroll" note to their
-# instruction line. Matches mcp.py's MCP_PICKER_VISIBLE_ROWS so both picker families agree.
+# Past this many options the choice list is pinned to a fixed-height scrolling viewport (see
+# `_cap_choice_viewport`) rather than growing to fill the terminal, and the pickers append a
+# "↑/↓ scroll" note to their instruction line. The value is both the boundary and the number of
+# rows shown at once; matches mcp.py's MCP_PICKER_VISIBLE_ROWS so both picker families agree.
 _SCROLL_HINT_THRESHOLD = 10
 
 
 def _with_scroll_hint(instruction: str, option_count: int) -> str:
     """Append a scroll affordance when the option list is too long to fully show at once.
 
-    The hint is discoverability only — questionary already scrolls; users just can't tell there is
+    The hint is discoverability only — the viewport already scrolls; users just can't tell there is
     more below the fold. Short lists are left alone so the instruction stays terse.
     """
     if option_count > _SCROLL_HINT_THRESHOLD:
         return f"{instruction[:-1]}, ↑/↓ scroll)" if instruction.endswith(")") else instruction
     return instruction
+
+
+def _cap_choice_viewport(question: questionary.Question, option_count: int) -> None:
+    """Pin a long choice list to a fixed ``_SCROLL_HINT_THRESHOLD``-row scrolling window.
+
+    questionary sizes the choice window to its content, bounded only by the terminal, so a tall
+    terminal shows every option and a short one scrolls — the visible count depends on the window
+    size. Capping the window height makes the picker show at most ``_SCROLL_HINT_THRESHOLD`` rows and
+    scroll through the rest, keeping the highlighted row in view (``InquirerControl`` emits a cursor
+    token at the pointer, which prompt_toolkit's ``Window`` tracks). Short lists are left untouched so
+    they render at their natural height with no empty rows.
+
+    Best-effort: it mutates questionary's internal layout, so any shape change (missing application,
+    no ``InquirerControl`` window) leaves the picker as-is rather than raising — the list still works,
+    it just falls back to terminal-fit sizing.
+    """
+    if option_count <= _SCROLL_HINT_THRESHOLD:
+        return
+    application = getattr(question, "application", None)
+    if application is None:
+        return
+    visible = Dimension(preferred=_SCROLL_HINT_THRESHOLD, max=_SCROLL_HINT_THRESHOLD)
+    for window in application.layout.find_all_windows():
+        if isinstance(window, Window) and isinstance(window.content, InquirerControl):
+            window.height = visible
+            return
 
 
 # Output verbosity. "normal" (default) renders decorative panels; "low" trades
@@ -457,7 +487,7 @@ def prompt_for_multi_selection(
     if searchable:
         instruction = "(type to filter, space to toggle, enter to confirm)"
     instruction = _with_scroll_hint(instruction, len(options))
-    answer = questionary.checkbox(
+    question = questionary.checkbox(
         prompt,
         choices=choices,
         style=style,
@@ -466,7 +496,9 @@ def prompt_for_multi_selection(
         instruction=instruction,
         use_search_filter=searchable,
         use_jk_keys=not searchable,
-    ).ask()
+    )
+    _cap_choice_viewport(question, len(options))
+    answer = question.ask()
     return None if answer is None else list(answer)
 
 
@@ -568,7 +600,7 @@ def prompt_for_selection(
     choices = [questionary.Choice(title=label, value=value) for value, label in options]
     instruction = "(type to filter, arrow keys to move)" if searchable else "(use arrow keys)"
     instruction = _with_scroll_hint(instruction, len(options))
-    answer = questionary.select(
+    question = questionary.select(
         prompt,
         choices=choices,
         style=style,
@@ -577,7 +609,9 @@ def prompt_for_selection(
         instruction=instruction,
         use_search_filter=searchable,
         use_jk_keys=not searchable,
-    ).ask()
+    )
+    _cap_choice_viewport(question, len(options))
+    answer = question.ask()
     return answer
 
 

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -1103,9 +1103,10 @@ class TestCustomModelEntry:
         assert config["default_model"] == "main.aarushi.maybe"
         assert warn.called
 
-    def test_picker_shows_only_the_top_few_plus_custom(self):
-        # A long list is truncated so the custom row is reachable without scrolling past everything.
-        state = {**STATE, "codex_models": [f"system.ai.gpt-5-{i}" for i in range(10)]}
+    def test_picker_offers_all_models_plus_custom(self):
+        # Every discovered model is offered (the searchable picker scrolls), with the custom row last.
+        models = [f"system.ai.gpt-5-{i}" for i in range(10)]
+        state = {**STATE, "codex_models": list(models)}
         offered: list[list[str]] = []
 
         def fake_sel(prompt, options, **kwargs):
@@ -1116,7 +1117,8 @@ class TestCustomModelEntry:
             wizard._prompt_models_for_agent("codex", state, None)
         rows = offered[0]
         assert rows[-1] == wizard._CUSTOM_MODEL
-        assert len(rows) == wizard._MODEL_PICKER_LIMIT + 1  # top few + the custom row
+        # All 10 discovered ids are offered — no truncation to the old top-few cap.
+        assert set(models) <= set(rows[:-1])
 
     def test_claude_family_custom_model_slots_and_validates(self):
         # A custom id chosen for a family lands in that slot, is marked custom, and survives

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -484,3 +484,43 @@ class TestFormatMeter:
     def test_width_is_constant(self):
         for fraction in (0.0, 0.13, 0.5, 0.99, 1.0):
             assert len(format_meter(fraction)) == 32
+
+
+class TestChoiceViewportCap:
+    """`_cap_choice_viewport` pins long picker lists to a fixed scrolling window."""
+
+    @staticmethod
+    def _choice_window_height(question):
+        from prompt_toolkit.layout.containers import Window
+        from questionary.prompts.common import InquirerControl
+
+        for window in question.application.layout.find_all_windows():
+            if isinstance(window, Window) and isinstance(window.content, InquirerControl):
+                return window.height
+        raise AssertionError("no InquirerControl window found")
+
+    def test_short_list_keeps_natural_height(self):
+        # At or below the threshold everything fits, so the window is left unbounded (height=None)
+        # rather than padded to a fixed size.
+        n = ui_mod._SCROLL_HINT_THRESHOLD
+        question = questionary.select("p", choices=[f"m{i}" for i in range(n)])
+        ui_mod._cap_choice_viewport(question, n)
+        assert self._choice_window_height(question) is None
+
+    def test_long_list_is_capped_to_the_threshold(self):
+        n = ui_mod._SCROLL_HINT_THRESHOLD + 15
+        question = questionary.select("p", choices=[f"m{i}" for i in range(n)])
+        ui_mod._cap_choice_viewport(question, n)
+        height = self._choice_window_height(question)
+        assert height.max == ui_mod._SCROLL_HINT_THRESHOLD
+        assert height.preferred == ui_mod._SCROLL_HINT_THRESHOLD
+
+    def test_checkbox_list_is_capped_too(self):
+        n = ui_mod._SCROLL_HINT_THRESHOLD + 15
+        question = questionary.checkbox("p", choices=[f"m{i}" for i in range(n)])
+        ui_mod._cap_choice_viewport(question, n)
+        assert self._choice_window_height(question).max == ui_mod._SCROLL_HINT_THRESHOLD
+
+    def test_missing_application_is_a_no_op(self):
+        # Best-effort: a question shape without an application must not raise.
+        ui_mod._cap_choice_viewport(object(), ui_mod._SCROLL_HINT_THRESHOLD + 5)


### PR DESCRIPTION
## Problem

In the Coding Agent config setup (`ucode setup` / `ucode configure`), the per-agent model picker only offered the **newest 5 models per family** (`_MODEL_PICKER_LIMIT = 5`). On a workspace with more (a typical one has ~6 opus versions), the rest were dropped from the list entirely — so it looked like the picker "only shows the top 5 and can't scroll." The only way to reach a dropped model was the "type a custom model" escape hatch.

## Changes

1. **Stop truncating.** Both the Claude per-family loop and `_custom_option_rows` now offer *every* discovered model, with the "✎ Enter a custom model…" row still last for ids outside `system.ai` that discovery never lists.

2. **Fixed 10-row scrolling viewport.** A full catalog can run long, so the choice list is pinned to a 10-row window that scrolls through the rest. questionary 2.1.1 has no `page_size`, so `_cap_choice_viewport` (in `ui.py`) bounds the built question's `InquirerControl` window to `Dimension(preferred=10, max=10)` when there are >10 options; lists at or below the threshold keep their natural height. The highlighted row stays in view via the pointer's cursor token. This reuses questionary's built-in select/checkbox keybindings and search rather than the heavier custom widget in `mcp.py`.

## Tests

- Updated the truncation test in `test_managed_wizard.py` to assert all discovered ids are offered (no cap).
- Added `TestChoiceViewportCap` in `test_ui.py`: short-list no-op, long-list cap for both select and checkbox, and missing-application no-op.
- Full suite passes except one pre-existing e2e failure (`test_user_agent_arrives_at_gateway`), confirmed to fail identically on a clean checkout — unrelated to this change.

This pull request and its description were written by Isaac.