### PR TITLE
Fix SSE buffering in Claude relayed proxy

### DIFF
--- a/scripts/repro_claude_relayed.py
+++ b/scripts/repro_claude_relayed.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+r"""Reproduce intermittent Claude Code stream failures through relayed auth.
+
+The harness runs real, non-interactive ``ucode claude`` turns repeatedly. Each
+turn requests a long deterministic response, enables the relayed proxy's safe
+transport diagnostics, and saves stdout/stderr separately. It treats Claude's
+retry banner as evidence even when Claude eventually recovers and exits zero.
+
+Example:
+
+    uv run python scripts/repro_claude_relayed.py --profile <PROFILE> \
+      --workspace https://example.staging.cloud.databricks.com \
+      --provider catalog.schema.service --attempts 50
+
+Artifacts contain the synthetic prompt's model output and Claude diagnostics,
+but the proxy diagnostics never record request/response bodies or headers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import shlex
+import signal
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import uuid
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+
+from ucode.databricks import get_databricks_profiles, normalize_workspace_url
+from ucode.state import load_state, save_state, set_current_workspace
+
+PROXY_DIAGNOSTICS_ENV = "UCODE_RELAYED_PROXY_DIAGNOSTICS"
+_PROXY_PREFIX = "[ucode-relay] "
+_MARKERS = {
+    "claude_response_stopped": re.compile(r"response stopped arriving", re.IGNORECASE),
+    "claude_api_error": re.compile(r"\bapi error\b", re.IGNORECASE),
+    "claude_retry": re.compile(r"retrying in .*attempt\s+\d+", re.IGNORECASE),
+    "proxy_upstream_request_error": re.compile(r'"event":"upstream_request_error"'),
+    "proxy_upstream_stream_error": re.compile(r'"event":"upstream_stream_error"'),
+}
+
+
+def build_prompt(response_lines: int, attempt: int, input_kib: int = 0) -> str:
+    nonce = uuid.uuid4().hex
+    instructions = (
+        f"Transport test {attempt}, nonce {nonce}. Produce exactly {response_lines} lines. "
+        "Every line must be `STREAM_TEST <line number> relayed transport payload`. "
+        "Number lines consecutively from 1 with no omissions. After those lines, output "
+        "`STREAM_TEST_DONE`. Do not use tools, explain, summarize, or stop early."
+    )
+    if input_kib == 0:
+        return instructions
+    target_chars = input_kib * 1024
+    seed = "deterministic relayed-auth prefill payload 0123456789 abcdefghijklmnopqrstuvwxyz\n"
+    filler = (seed * ((target_chars // len(seed)) + 1))[:target_chars]
+    return f"{instructions}\nINPUT_PAYLOAD_BEGIN\n{filler}\nINPUT_PAYLOAD_END"
+
+
+def build_artifact_prompt(artifact_path: Path, sections: int, attempt: int) -> str:
+    nonce = uuid.uuid4().hex
+    return (
+        f"Artifact streaming test {attempt}, nonce {nonce}. Use the Write tool to create "
+        f"the Markdown document at {artifact_path}. Write exactly {sections} numbered sections. "
+        "Each section must have a descriptive heading and two substantive paragraphs about "
+        "designing, operating, testing, or debugging production HTTP/SSE streaming proxies. "
+        "Include concrete failure modes, observability signals, and mitigations; do not use "
+        "repetitive filler. Put the complete document in the Write tool call rather than in the "
+        "chat response. After the file is written, reply `ARTIFACT_TEST_DONE`."
+    )
+
+
+def select_ucode_profile(workspace: str, profile: str) -> str:
+    """Validate and persist the profile chosen for this workspace.
+
+    ``ucode claude --workspace`` has no launch-time ``--profile`` flag. Priming
+    its per-workspace state makes each auth call use the caller's explicit
+    choice instead of resolving the first profile matching the host.
+    """
+    normalized_workspace = normalize_workspace_url(workspace)
+    profile_hosts = {name: host for host, name in get_databricks_profiles()}
+    configured_host = profile_hosts.get(profile)
+    if configured_host is None:
+        available = ", ".join(sorted(profile_hosts)) or "none"
+        raise RuntimeError(
+            f"Databricks CLI profile {profile!r} was not found. Available profiles: {available}."
+        )
+    normalized_profile_host = normalize_workspace_url(configured_host)
+    if normalized_profile_host != normalized_workspace:
+        raise RuntimeError(
+            f"Profile {profile!r} targets {normalized_profile_host}, not "
+            f"{normalized_workspace}. Choose a profile for the requested workspace."
+        )
+
+    set_current_workspace(normalized_workspace)
+    state = load_state()
+    state["workspace"] = normalized_workspace
+    state["profile"] = profile
+    save_state(state)
+    return normalized_workspace
+
+
+def build_command(
+    ucode_command: list[str],
+    *,
+    workspace: str,
+    provider: str,
+    prompt: str,
+    debug_file: Path | None = None,
+    skip_preflight: bool = True,
+    safe_mode: bool = False,
+    tools: str = "",
+    add_dir: Path | None = None,
+) -> list[str]:
+    command = [
+        *ucode_command,
+        "claude",
+        "--provider",
+        provider,
+        "--workspace",
+        workspace,
+    ]
+    if skip_preflight:
+        command.append("--skip-preflight")
+    command.extend(
+        [
+            "--",
+            "-p",
+            prompt,
+            "--output-format",
+            "stream-json",
+            "--include-partial-messages",
+            "--verbose",
+            "--no-session-persistence",
+            "--permission-mode",
+            "acceptEdits" if tools else "dontAsk",
+            "--effort",
+            "low",
+        ]
+    )
+    if add_dir is not None:
+        command.extend(["--add-dir", str(add_dir)])
+    if safe_mode:
+        command.append("--safe-mode")
+    if debug_file is not None:
+        command.extend(["--debug-file", str(debug_file)])
+    # Keep this last: Claude's --tools option accepts a variable number of values.
+    command.extend(["--tools", tools])
+    return command
+
+
+def classify_output(stdout: str, stderr: str) -> tuple[dict[str, int], dict[str, int], list[int]]:
+    combined = f"{stdout}\n{stderr}"
+    markers = {name: len(pattern.findall(combined)) for name, pattern in _MARKERS.items()}
+
+    result_errors = 0
+    for line in stdout.splitlines():
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if payload.get("type") == "result" and payload.get("is_error") is True:
+            result_errors += 1
+    if result_errors:
+        markers["claude_error_result"] = result_errors
+
+    proxy_events: Counter[str] = Counter()
+    upstream_statuses: list[int] = []
+    request_paths: dict[str, str] = {}
+    message_non_2xx = 0
+    zero_byte_timeouts = 0
+    for line in stderr.splitlines():
+        if _PROXY_PREFIX not in line:
+            continue
+        raw = line.split(_PROXY_PREFIX, 1)[1].strip()
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        name = event.get("event")
+        if isinstance(name, str):
+            proxy_events[name] += 1
+        request_id = event.get("request_id")
+        if (
+            name == "request_start"
+            and isinstance(request_id, str)
+            and isinstance(event.get("path"), str)
+        ):
+            request_paths[request_id] = event["path"]
+        if name == "upstream_headers" and isinstance(event.get("status"), int):
+            status = event["status"]
+            upstream_statuses.append(status)
+            # Claude probes /api/hello without its subscription credential and
+            # may receive an expected 401 before a healthy model turn. Only a
+            # non-2xx on the actual Messages API is stream-failure evidence.
+            path = request_paths.get(request_id) if isinstance(request_id, str) else None
+            if (path is None or path == "/v1/messages") and (status < 200 or status >= 300):
+                message_non_2xx += 1
+        if (
+            name == "client_disconnect"
+            and isinstance(request_id, str)
+            and request_paths.get(request_id) == "/v1/messages"
+            and event.get("phase") == "response"
+            and event.get("bytes") == 0
+            and isinstance(event.get("elapsed_ms"), int)
+            and event["elapsed_ms"] >= 30_000
+        ):
+            zero_byte_timeouts += 1
+    if message_non_2xx:
+        markers["proxy_non_2xx"] = message_non_2xx
+    if zero_byte_timeouts:
+        markers["proxy_zero_byte_client_disconnect"] = zero_byte_timeouts
+
+    return (
+        {name: count for name, count in markers.items() if count},
+        dict(proxy_events),
+        upstream_statuses,
+    )
+
+
+def _terminate_process_group(proc: subprocess.Popen[str]) -> None:
+    if proc.poll() is not None:
+        return
+    try:
+        if os.name == "posix":
+            os.killpg(proc.pid, signal.SIGTERM)
+        else:
+            proc.terminate()
+        proc.wait(timeout=5)
+    except (ProcessLookupError, subprocess.TimeoutExpired):
+        if proc.poll() is None:
+            if os.name == "posix":
+                os.killpg(proc.pid, signal.SIGKILL)
+            else:
+                proc.kill()
+            proc.wait()
+
+
+def _pump_stream(
+    stream,
+    destination: Path,
+    *,
+    show_diagnostics: bool,
+    print_lock: threading.Lock,
+) -> None:
+    with destination.open("w", encoding="utf-8") as output:
+        for line in iter(stream.readline, ""):
+            output.write(line)
+            output.flush()
+            if show_diagnostics and (
+                _PROXY_PREFIX in line
+                or "response stopped arriving" in line.lower()
+                or "api error" in line.lower()
+                or "retrying in" in line.lower()
+            ):
+                with print_lock:
+                    print(f"    {line.rstrip()}", flush=True)
+    stream.close()
+
+
+def run_attempt(
+    command: list[str],
+    *,
+    attempt: int,
+    artifact_dir: Path,
+    timeout: float,
+) -> dict:
+    stdout_path = artifact_dir / f"attempt-{attempt:04d}.stdout.jsonl"
+    stderr_path = artifact_dir / f"attempt-{attempt:04d}.stderr.log"
+    env = os.environ.copy()
+    env[PROXY_DIAGNOSTICS_ENV] = "1"
+    env["NO_COLOR"] = "1"
+    env["FORCE_COLOR"] = "0"
+    env["PYTHONUNBUFFERED"] = "1"
+
+    started_at = datetime.now(UTC)
+    monotonic_start = time.monotonic()
+    timed_out = False
+    try:
+        proc = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            bufsize=1,
+            env=env,
+            start_new_session=os.name == "posix",
+        )
+    except OSError as exc:
+        stderr_path.write_text(f"Could not start command: {exc}\n", encoding="utf-8")
+        stdout_path.write_text("", encoding="utf-8")
+        return {
+            "attempt": attempt,
+            "started_at": started_at.isoformat(),
+            "elapsed_s": round(time.monotonic() - monotonic_start, 3),
+            "returncode": 127,
+            "timed_out": False,
+            "markers": {"launch_error": 1},
+            "proxy_events": {},
+            "upstream_statuses": [],
+            "stdout": str(stdout_path),
+            "stderr": str(stderr_path),
+        }
+
+    assert proc.stdout is not None
+    assert proc.stderr is not None
+    print_lock = threading.Lock()
+    stdout_thread = threading.Thread(
+        target=_pump_stream,
+        args=(proc.stdout, stdout_path),
+        kwargs={"show_diagnostics": False, "print_lock": print_lock},
+        daemon=True,
+    )
+    stderr_thread = threading.Thread(
+        target=_pump_stream,
+        args=(proc.stderr, stderr_path),
+        kwargs={"show_diagnostics": True, "print_lock": print_lock},
+        daemon=True,
+    )
+    stdout_thread.start()
+    stderr_thread.start()
+    try:
+        returncode = proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        _terminate_process_group(proc)
+        returncode = proc.returncode
+    except KeyboardInterrupt:
+        _terminate_process_group(proc)
+        raise
+    finally:
+        stdout_thread.join(timeout=10)
+        stderr_thread.join(timeout=10)
+
+    stdout = stdout_path.read_text(encoding="utf-8")
+    stderr = stderr_path.read_text(encoding="utf-8")
+    markers, proxy_events, upstream_statuses = classify_output(stdout, stderr)
+    if timed_out:
+        markers["timeout"] = 1
+    return {
+        "attempt": attempt,
+        "started_at": started_at.isoformat(),
+        "elapsed_s": round(time.monotonic() - monotonic_start, 3),
+        "returncode": returncode,
+        "timed_out": timed_out,
+        "markers": markers,
+        "proxy_events": proxy_events,
+        "upstream_statuses": upstream_statuses,
+        "stdout": str(stdout_path),
+        "stderr": str(stderr_path),
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--profile",
+        required=True,
+        help="explicit Databricks CLI profile whose host must match --workspace",
+    )
+    parser.add_argument("--workspace", required=True, help="Databricks workspace URL")
+    parser.add_argument("--provider", required=True, help="UC Model Provider Service name")
+    parser.add_argument(
+        "--attempts", type=int, default=20, help="number of Claude turns (default: 20)"
+    )
+    parser.add_argument(
+        "--response-lines",
+        type=int,
+        default=400,
+        help="requested lines per response; larger values hold streams open longer (default: 400)",
+    )
+    parser.add_argument(
+        "--input-kib",
+        type=int,
+        default=0,
+        help="deterministic input payload size in KiB, excluding instructions (default: 0)",
+    )
+    parser.add_argument(
+        "--artifact-sections",
+        type=int,
+        default=0,
+        help="write a Markdown artifact with this many sections instead of plain text (default: 0)",
+    )
+    parser.add_argument("--timeout", type=float, default=900, help="seconds allowed per turn")
+    parser.add_argument(
+        "--output-dir", type=Path, help="artifact directory (default: a new /tmp directory)"
+    )
+    parser.add_argument(
+        "--ucode-command",
+        default="uv run ucode",
+        help="command used to launch ucode (default: 'uv run ucode')",
+    )
+    parser.add_argument(
+        "--full-preflight",
+        action="store_true",
+        help="run ucode's gateway/model preflight on every attempt (stream path is unchanged)",
+    )
+    parser.add_argument(
+        "--safe-mode",
+        action="store_true",
+        help="disable Claude customizations to separate transport failures from hooks/plugins",
+    )
+    parser.add_argument(
+        "--claude-debug",
+        action="store_true",
+        help="also save Claude's detailed debug log (inspect it before sharing)",
+    )
+    parser.add_argument(
+        "--stop-on-repro", action="store_true", help="stop after the first suspicious attempt"
+    )
+    args = parser.parse_args()
+    if args.attempts < 1:
+        parser.error("--attempts must be at least 1")
+    if args.response_lines < 1:
+        parser.error("--response-lines must be at least 1")
+    if args.input_kib < 0:
+        parser.error("--input-kib cannot be negative")
+    if args.artifact_sections < 0:
+        parser.error("--artifact-sections cannot be negative")
+    if args.artifact_sections and args.input_kib:
+        parser.error("--artifact-sections cannot be combined with --input-kib")
+    if args.timeout <= 0:
+        parser.error("--timeout must be positive")
+    return args
+
+
+def main() -> int:
+    args = _parse_args()
+    try:
+        workspace = select_ucode_profile(args.workspace, args.profile)
+    except (RuntimeError, ValueError) as exc:
+        print(f"Profile selection failed: {exc}", file=sys.stderr)
+        return 2
+    artifact_dir = args.output_dir or Path(tempfile.mkdtemp(prefix="ucode-claude-relay-repro-"))
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    ucode_command = shlex.split(args.ucode_command)
+    if not ucode_command:
+        raise SystemExit("--ucode-command cannot be empty")
+
+    metadata = {
+        "created_at": datetime.now(UTC).isoformat(),
+        "workspace": workspace,
+        "profile": args.profile,
+        "provider": args.provider,
+        "attempts": args.attempts,
+        "response_lines": args.response_lines,
+        "input_kib": args.input_kib,
+        "artifact_sections": args.artifact_sections,
+        "timeout_s": args.timeout,
+        "ucode_command": ucode_command,
+        "full_preflight": args.full_preflight,
+        "safe_mode": args.safe_mode,
+        "claude_debug": args.claude_debug,
+        "python": sys.version,
+        "platform": platform.platform(),
+    }
+    (artifact_dir / "metadata.json").write_text(
+        json.dumps(metadata, indent=2) + "\n", encoding="utf-8"
+    )
+    summary_path = artifact_dir / "summary.jsonl"
+    suspicious_attempts = 0
+
+    print(f"Artifacts: {artifact_dir}")
+    print(f"Running {args.attempts} sequential relayed-auth turns...")
+    try:
+        for attempt in range(1, args.attempts + 1):
+            attempt_artifact_dir = None
+            if args.artifact_sections:
+                attempt_artifact_dir = artifact_dir / f"attempt-{attempt:04d}-files"
+                attempt_artifact_dir.mkdir(parents=True, exist_ok=True)
+                prompt = build_artifact_prompt(
+                    attempt_artifact_dir / "streaming-proxy-design.md",
+                    args.artifact_sections,
+                    attempt,
+                )
+            else:
+                prompt = build_prompt(args.response_lines, attempt, args.input_kib)
+            debug_file = (
+                artifact_dir / f"attempt-{attempt:04d}.claude-debug.log"
+                if args.claude_debug
+                else None
+            )
+            command = build_command(
+                ucode_command,
+                workspace=workspace,
+                provider=args.provider,
+                prompt=prompt,
+                debug_file=debug_file,
+                skip_preflight=not args.full_preflight,
+                safe_mode=args.safe_mode,
+                tools="Write" if attempt_artifact_dir is not None else "",
+                add_dir=attempt_artifact_dir,
+            )
+            print(f"[{attempt}/{args.attempts}] starting")
+            result = run_attempt(
+                command,
+                attempt=attempt,
+                artifact_dir=artifact_dir,
+                timeout=args.timeout,
+            )
+            result["prompt_sha256"] = hashlib.sha256(prompt.encode()).hexdigest()
+            result["prompt_length"] = len(prompt)
+            with summary_path.open("a", encoding="utf-8") as summary:
+                summary.write(json.dumps(result, sort_keys=True) + "\n")
+            suspicious = bool(result["timed_out"] or result["returncode"] != 0 or result["markers"])
+            suspicious_attempts += int(suspicious)
+            label = "SUSPICIOUS" if suspicious else "ok"
+            print(
+                f"[{attempt}/{args.attempts}] {label}: rc={result['returncode']} "
+                f"elapsed={result['elapsed_s']}s markers={result['markers']}"
+            )
+            if suspicious and args.stop_on_repro:
+                break
+    except KeyboardInterrupt:
+        print("\nInterrupted; completed artifacts were preserved.", file=sys.stderr)
+
+    print(f"\nSuspicious attempts: {suspicious_attempts}")
+    print(f"Summary: {summary_path}")
+    if suspicious_attempts:
+        print(
+            "Reproduction captured. Share metadata.json, summary.jsonl, and the matching attempt logs."
+        )
+        return 1
+    print("No failure observed; increase --attempts or --response-lines and try again.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ucode/gateway_proxy.py
+++ b/src/ucode/gateway_proxy.py
@@ -20,9 +20,11 @@ from __future__ import annotations
 import base64
 import binascii
 import json
+import os
 import sys
 import threading
 import time
+import uuid
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import httpx
@@ -51,7 +53,6 @@ _HOP_BY_HOP = frozenset(
 # Request headers the proxy manages itself and must never forward on: hop-by-hop
 # plus the swap header (replaced with a freshly-minted value per request).
 _STRIP_ON_FORWARD = _HOP_BY_HOP | {_SWAP_HEADER.lower()}
-_STREAM_CHUNK = 8192
 # Per-operation upstream timeouts. `read` is generous because model turns stream
 # over a single response and Anthropic emits SSE pings, so inter-chunk gaps stay
 # small; `connect`/`pool` fail fast when the gateway is unreachable.
@@ -64,6 +65,25 @@ _REFRESH_BUFFER_S = 600
 _REFRESHER_POLL_S = 120
 # Assumed lifetime when a token carries no decodable `exp` (defensive fallback).
 _DEFAULT_TTL_S = 3600
+# Opt-in transport diagnostics for intermittent streaming failures. Events only
+# contain locally-generated request ids, timings, status codes, byte counts,
+# and exception class names — never headers, bodies, or credentials.
+_DIAGNOSTICS_ENV = "UCODE_RELAYED_PROXY_DIAGNOSTICS"
+_DIAGNOSTICS_TRUE = frozenset({"1", "true", "yes", "on"})
+
+
+def _diagnostics_enabled() -> bool:
+    return os.environ.get(_DIAGNOSTICS_ENV, "").strip().lower() in _DIAGNOSTICS_TRUE
+
+
+def _diagnostic_log(event: str, **fields: object) -> None:
+    if not _diagnostics_enabled():
+        return
+    payload = {"event": event, **fields}
+    sys.stderr.write(
+        f"[ucode-relay] {json.dumps(payload, sort_keys=True, separators=(',', ':'))}\n"
+    )
+    sys.stderr.flush()
 
 
 def _jwt_exp(token: str) -> float | None:
@@ -186,15 +206,30 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             pass
 
     def _handle(self) -> None:
+        diagnostic_id = uuid.uuid4().hex[:12]
+        started = time.monotonic()
         length = int(self.headers.get("Content-Length", 0) or 0)
         body = self.rfile.read(length) if length else None
         url = self.path.lstrip("/")
+        _diagnostic_log(
+            "request_start",
+            request_id=diagnostic_id,
+            method=self.command,
+            path=self.path.split("?", 1)[0],
+        )
         try:
             # First attempt with the current token.
             headers = _forwarded_request_headers(self, self.cache.token)
             with self.client.stream(self.command, url, headers=headers, content=body) as resp:
+                _diagnostic_log(
+                    "upstream_headers",
+                    request_id=diagnostic_id,
+                    attempt=1,
+                    status=resp.status_code,
+                    elapsed_ms=round((time.monotonic() - started) * 1000),
+                )
                 if resp.status_code not in (401, 403):
-                    self._relay_response(resp)
+                    self._relay_response(resp, diagnostic_id=diagnostic_id, started=started)
                     return
                 # Auth rejected. Drain the (small) error body so the pooled
                 # connection can be reused, then fall through to one retry.
@@ -211,41 +246,106 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 pass  # refresh failed; retry with the existing token and relay whatever comes
             headers = _forwarded_request_headers(self, self.cache.token)
             with self.client.stream(self.command, url, headers=headers, content=body) as resp:
-                self._relay_response(resp)
+                _diagnostic_log(
+                    "upstream_headers",
+                    request_id=diagnostic_id,
+                    attempt=2,
+                    status=resp.status_code,
+                    elapsed_ms=round((time.monotonic() - started) * 1000),
+                )
+                self._relay_response(resp, diagnostic_id=diagnostic_id, started=started)
         except (BrokenPipeError, ConnectionResetError):
             # Client closed before/while we relayed headers — routine on cancel.
+            _diagnostic_log(
+                "client_disconnect",
+                request_id=diagnostic_id,
+                phase="request",
+                elapsed_ms=round((time.monotonic() - started) * 1000),
+            )
             return
-        except httpx.HTTPError:
+        except httpx.HTTPError as exc:
             # Upstream failed before any bytes reached the client; a 502 is still
             # sendable. (An HTTP *status* like 429 is not an error here — httpx
             # only raises for transport failures — so real gateway errors are
             # relayed verbatim by `_relay_response`.)
+            _diagnostic_log(
+                "upstream_request_error",
+                request_id=diagnostic_id,
+                error_type=type(exc).__name__,
+                elapsed_ms=round((time.monotonic() - started) * 1000),
+            )
             self._safe_send_error(502, "gateway proxy upstream error")
 
     # Streaming passthrough: forward chunks as they arrive so SSE token streaming
     # is not buffered (buffering would add full-response latency to first token).
     # `iter_raw` preserves any Content-Encoding verbatim (we relay that header),
     # so the proxy stays byte-transparent.
-    def _relay_response(self, resp: httpx.Response) -> None:
+    def _relay_response(
+        self,
+        resp: httpx.Response,
+        *,
+        diagnostic_id: str | None = None,
+        started: float | None = None,
+    ) -> None:
+        started = started if started is not None else time.monotonic()
+        chunks = 0
+        bytes_relayed = 0
+        first_byte_ms: int | None = None
         try:
             self.send_response(resp.status_code)
             for key, value in resp.headers.items():
                 if key.lower() not in _HOP_BY_HOP:
                     self.send_header(key, value)
             self.end_headers()
-            for chunk in resp.iter_raw(_STREAM_CHUNK):
+            # Do not pass a fixed chunk size here. httpx accumulates bytes until
+            # that size is reached, which can hide small SSE heartbeat frames
+            # from Claude Code for minutes during a slow artifact/tool call.
+            # With ``chunk_size=None`` (the default), raw upstream chunks are
+            # yielded as they arrive and pings keep the downstream connection
+            # alive even before the model produces a large content block.
+            for chunk in resp.iter_raw():
                 if chunk:
+                    if first_byte_ms is None:
+                        first_byte_ms = round((time.monotonic() - started) * 1000)
                     self.wfile.write(chunk)
                     self.wfile.flush()
+                    chunks += 1
+                    bytes_relayed += len(chunk)
+            _diagnostic_log(
+                "response_complete",
+                request_id=diagnostic_id,
+                status=resp.status_code,
+                chunks=chunks,
+                bytes=bytes_relayed,
+                first_byte_ms=first_byte_ms,
+                elapsed_ms=round((time.monotonic() - started) * 1000),
+            )
         except (BrokenPipeError, ConnectionResetError):
             # Client (Claude Code) closed the connection mid-response — routine on
             # cancelled turns / SSE teardown. Nothing left to relay to, so stop
             # quietly rather than crashing the handler thread.
+            _diagnostic_log(
+                "client_disconnect",
+                request_id=diagnostic_id,
+                phase="response",
+                chunks=chunks,
+                bytes=bytes_relayed,
+                elapsed_ms=round((time.monotonic() - started) * 1000),
+            )
             return
-        except httpx.HTTPError:
+        except httpx.HTTPError as exc:
             # Upstream dropped mid-stream. Headers (and status) may already be
             # sent, so we can't reliably signal a fresh error — stop and let the
             # client see a truncated stream rather than corrupt the framing.
+            _diagnostic_log(
+                "upstream_stream_error",
+                request_id=diagnostic_id,
+                error_type=type(exc).__name__,
+                status=resp.status_code,
+                chunks=chunks,
+                bytes=bytes_relayed,
+                elapsed_ms=round((time.monotonic() - started) * 1000),
+            )
             return
 
     # Forward every method: this is a transparent pass-through, so routing any

--- a/tests/test_gateway_proxy.py
+++ b/tests/test_gateway_proxy.py
@@ -64,8 +64,10 @@ class _FakeResponse:
         self.status_code = status_code
         self.headers = headers
         self._chunks = chunks
+        self.chunk_sizes = []
 
     def iter_raw(self, chunk_size=None):
+        self.chunk_sizes.append(chunk_size)
         yield from self._chunks
 
 
@@ -158,6 +160,43 @@ class TestRelayResponseClientDisconnect:
         assert b"429" in blob
         assert b"Content-Type: application/json" in blob
         assert b"Transfer-Encoding" not in blob  # hop-by-hop, stripped
+        assert resp.chunk_sizes == [None]  # relay each upstream SSE/network chunk immediately
+
+    def test_diagnostics_identify_upstream_mid_stream_drop(self, monkeypatch, capsys):
+        monkeypatch.setenv(gateway_proxy._DIAGNOSTICS_ENV, "1")
+
+        class _Ok(io.RawIOBase):
+            def write(self, data):  # type: ignore[override]
+                return len(data)
+
+            def flush(self):
+                return None
+
+        def _chunks():
+            yield b"partial"
+            raise httpx.ReadError("upstream dropped")
+
+        handler = _relay_handler(_Ok())
+        handler._relay_response(
+            _FakeResponse(200, {}, _chunks()),
+            diagnostic_id="local-id",
+            started=time.monotonic(),
+        )
+
+        line = capsys.readouterr().err.strip()
+        assert line.startswith("[ucode-relay] ")
+        event = json.loads(line.removeprefix("[ucode-relay] "))
+        assert event["event"] == "upstream_stream_error"
+        assert event["request_id"] == "local-id"
+        assert event["error_type"] == "ReadError"
+        assert event["bytes"] == len(b"partial")
+        assert "upstream dropped" not in line
+
+    def test_diagnostics_are_silent_by_default(self, monkeypatch, capsys):
+        monkeypatch.delenv(gateway_proxy._DIAGNOSTICS_ENV, raising=False)
+        handler = _relay_handler(_Collect())
+        handler._relay_response(_FakeResponse(200, {}, [b"ok"]))
+        assert capsys.readouterr().err == ""
 
 
 class TestJwtExp:

--- a/tests/test_repro_claude_relayed.py
+++ b/tests/test_repro_claude_relayed.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from scripts import repro_claude_relayed as repro
+
+
+def test_build_prompt_adds_requested_large_input_payload():
+    prompt = repro.build_prompt(response_lines=10, attempt=1, input_kib=128)
+
+    payload = prompt.split("INPUT_PAYLOAD_BEGIN\n", 1)[1].split("\nINPUT_PAYLOAD_END", 1)[0]
+    assert len(payload) == 128 * 1024
+    assert "Produce exactly 10 lines" in prompt
+
+
+def test_build_artifact_prompt_targets_write_tool_path(tmp_path):
+    artifact = tmp_path / "design.md"
+    prompt = repro.build_artifact_prompt(artifact, sections=25, attempt=2)
+
+    assert str(artifact) in prompt
+    assert "Write tool" in prompt
+    assert "exactly 25 numbered sections" in prompt
+    assert "ARTIFACT_TEST_DONE" in prompt
+
+
+def test_select_ucode_profile_persists_explicit_matching_choice(monkeypatch):
+    state = {"available_tools": ["claude"]}
+    selected = []
+    saved = []
+    monkeypatch.setattr(
+        repro,
+        "get_databricks_profiles",
+        lambda: [("https://workspace.example.com", "chosen")],
+    )
+    monkeypatch.setattr(repro, "set_current_workspace", selected.append)
+    monkeypatch.setattr(repro, "load_state", lambda: state)
+    monkeypatch.setattr(repro, "save_state", lambda value: saved.append(dict(value)))
+
+    workspace = repro.select_ucode_profile("https://workspace.example.com/", "chosen")
+
+    assert workspace == "https://workspace.example.com"
+    assert selected == ["https://workspace.example.com"]
+    assert saved[0]["profile"] == "chosen"
+    assert saved[0]["available_tools"] == ["claude"]
+
+
+def test_select_ucode_profile_rejects_host_mismatch(monkeypatch):
+    monkeypatch.setattr(
+        repro,
+        "get_databricks_profiles",
+        lambda: [("https://other.example.com", "wrong")],
+    )
+
+    with pytest.raises(RuntimeError, match="targets https://other.example.com"):
+        repro.select_ucode_profile("https://workspace.example.com", "wrong")
+
+
+def test_build_command_exercises_stream_json_through_ucode(tmp_path):
+    debug = tmp_path / "debug.log"
+    command = repro.build_command(
+        ["uv", "run", "ucode"],
+        workspace="https://workspace.example.com",
+        provider="catalog.schema.provider",
+        prompt="long response please",
+        debug_file=debug,
+    )
+
+    assert command[:4] == ["uv", "run", "ucode", "claude"]
+    assert command[command.index("--provider") + 1] == "catalog.schema.provider"
+    assert command[command.index("--workspace") + 1] == "https://workspace.example.com"
+    assert "--skip-preflight" in command
+    assert command[command.index("-p") + 1] == "long response please"
+    assert command[command.index("--output-format") + 1] == "stream-json"
+    assert "--include-partial-messages" in command
+    assert command[command.index("--debug-file") + 1] == str(debug)
+    assert command[-2:] == ["--tools", ""]
+
+
+def test_build_command_enables_write_tool_for_artifact(tmp_path):
+    command = repro.build_command(
+        ["ucode"],
+        workspace="https://workspace.example.com",
+        provider="catalog.schema.provider",
+        prompt="write the artifact",
+        tools="Write",
+        add_dir=tmp_path,
+    )
+
+    assert command[command.index("--permission-mode") + 1] == "acceptEdits"
+    assert command[command.index("--add-dir") + 1] == str(tmp_path)
+    assert command[-2:] == ["--tools", "Write"]
+
+
+def test_classify_output_finds_recovered_claude_retry_and_proxy_failure():
+    stdout = json.dumps({"type": "result", "is_error": True}) + "\n"
+    stderr = "\n".join(
+        [
+            "API Error: The response stopped arriving. The response above may be incomplete.",
+            "API error · Retrying in 0s · attempt 1/10",
+            '[ucode-relay] {"event":"upstream_headers","status":200}',
+            '[ucode-relay] {"event":"upstream_stream_error","error_type":"ReadError"}',
+            '[ucode-relay] {"event":"upstream_headers","status":503}',
+        ]
+    )
+
+    markers, events, statuses = repro.classify_output(stdout, stderr)
+
+    assert markers["claude_response_stopped"] == 1
+    assert markers["claude_api_error"] == 2
+    assert markers["claude_retry"] == 1
+    assert markers["claude_error_result"] == 1
+    assert markers["proxy_upstream_stream_error"] == 1
+    assert markers["proxy_non_2xx"] == 1
+    assert events == {"upstream_headers": 2, "upstream_stream_error": 1}
+    assert statuses == [200, 503]
+
+
+def test_classify_output_ignores_expected_hello_probe_401():
+    stderr = "\n".join(
+        [
+            '[ucode-relay] {"event":"request_start","request_id":"hello","path":"/api/hello"}',
+            '[ucode-relay] {"event":"upstream_headers","request_id":"hello","status":401}',
+            '[ucode-relay] {"event":"request_start","request_id":"turn","path":"/v1/messages"}',
+            '[ucode-relay] {"event":"upstream_headers","request_id":"turn","status":200}',
+        ]
+    )
+
+    markers, events, statuses = repro.classify_output("", stderr)
+
+    assert markers == {}
+    assert events == {"request_start": 2, "upstream_headers": 2}
+    assert statuses == [401, 200]
+
+
+def test_classify_output_flags_long_zero_byte_message_disconnect():
+    stderr = "\n".join(
+        [
+            '[ucode-relay] {"event":"request_start","request_id":"turn","path":"/v1/messages"}',
+            '[ucode-relay] {"event":"upstream_headers","request_id":"turn","status":200}',
+            '[ucode-relay] {"event":"client_disconnect","request_id":"turn",'
+            '"phase":"response","bytes":0,"elapsed_ms":284107}',
+        ]
+    )
+
+    markers, _, _ = repro.classify_output("", stderr)
+
+    assert markers == {"proxy_zero_byte_client_disconnect": 1}
+
+
+def test_run_attempt_captures_diagnostics_and_exit_zero(tmp_path):
+    fake = tmp_path / "fake.py"
+    fake.write_text(
+        "import json, os, sys\n"
+        "assert os.environ['UCODE_RELAYED_PROXY_DIAGNOSTICS'] == '1'\n"
+        "print(json.dumps({'type': 'result', 'is_error': False}))\n"
+        "print('[ucode-relay] ' + json.dumps({'event': 'response_complete', "
+        "'status': 200}), file=sys.stderr)\n",
+        encoding="utf-8",
+    )
+
+    result = repro.run_attempt(
+        [sys.executable, str(fake)], attempt=1, artifact_dir=tmp_path, timeout=10
+    )
+
+    assert result["returncode"] == 0
+    assert result["markers"] == {}
+    assert result["proxy_events"] == {"response_complete": 1}
+    assert (tmp_path / "attempt-0001.stdout.jsonl").is_file()
+    assert (tmp_path / "attempt-0001.stderr.log").is_file()


### PR DESCRIPTION
## Summary

- Forward upstream SSE/network chunks immediately instead of buffering them to 8 KiB.
- Add opt-in, metadata-only relayed-proxy transport diagnostics.
- Add an artifact-focused relayed-auth reproduction harness and focused tests.

## Root cause

Passing a fixed 8192-byte chunk size to httpx Response.iter_raw caused httpx to accumulate small SSE heartbeat frames. During long Claude artifact or document generation, Claude Code could receive no downstream bytes for minutes and report that the response stopped arriving, then retry.

Using the default raw iterator forwards each upstream network chunk as it arrives, preserving heartbeat delivery and keeping the downstream stream active.

## Validation

- Focused tests: 33 passed.
- Focused Ruff check: passed.
- Live A/B against main.jasmine.rohit-test:
  - Before: HTTP 200, zero downstream bytes, client disconnect at 284s, no artifact.
  - After: first byte at 1.263s, 1,812,360 bytes across 4,025 chunks, completed in 358.5s; valid 85 KB Markdown artifact with all 60 sections and ARTIFACT_TEST_DONE.
- Three additional fixed-proxy artifact trials completed with zero suspicious markers:
  - 333.9s, valid 86,031-byte artifact, 1,777,033 streamed bytes across 3,299 chunks.
  - 337.3s, valid 82,312-byte artifact, 1,704,030 streamed bytes across 4,195 chunks.
  - 280.1s, valid 70,102-byte artifact, 1,445,877 streamed bytes across 3,226 chunks.

Each additional artifact contains one title plus exactly 60 requested sections and the ARTIFACT_TEST_DONE marker.