### PR TITLE
Hide relayed services from Claude setup

### DIFF
--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -262,14 +262,10 @@ def _select_provider_service(tool: str, workspace: str, token: str) -> dict | No
             print_note("Falling back to Databricks-hosted models.")
         return None
 
-    usable = [
-        service
-        for service in services
-        if service_usable_for_tool(tool, service)
-        # Claude Max/Team/Enterprise subscription relays are not reliable enough for managed
-        # configurations yet. Keep them out of the External Models picker until that path is ready.
-        and not (tool == "claude" and service.get("relayed"))
-    ]
+    usable = [service for service in services if service_usable_for_tool(tool, service)]
+    if tool == "claude":
+        # Claude subscription relays are not reliable enough for managed configurations yet.
+        usable = [service for service in usable if not service.get("relayed")]
     if not usable:
         if services:
             # Services exist but none match this agent's dialect — say so, since "no picker appeared"

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -262,7 +262,14 @@ def _select_provider_service(tool: str, workspace: str, token: str) -> dict | No
             print_note("Falling back to Databricks-hosted models.")
         return None
 
-    usable = [service for service in services if service_usable_for_tool(tool, service)]
+    usable = [
+        service
+        for service in services
+        if service_usable_for_tool(tool, service)
+        # Claude Max/Team/Enterprise subscription relays are not reliable enough for managed
+        # configurations yet. Keep them out of the External Models picker until that path is ready.
+        and not (tool == "claude" and service.get("relayed"))
+    ]
     if not usable:
         if services:
             # Services exist but none match this agent's dialect — say so, since "no picker appeared"

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -1309,6 +1309,43 @@ class TestProviderServiceSelection:
         offered = [value for value, _ in select.call_args_list[1][0][1]]
         assert offered == ["main.default.lilly-anthropic"]
 
+    def test_relayed_services_are_not_offered_for_claude(self):
+        relayed = {
+            **ANTHROPIC_SERVICE,
+            "name": "main.default.claude-enterprise",
+            "targets": [],
+            "relayed": True,
+        }
+        with (
+            patch.object(
+                wizard,
+                "list_model_provider_services",
+                return_value=([relayed, ANTHROPIC_SERVICE], None),
+            ),
+            patch.object(
+                wizard,
+                "prompt_for_selection",
+                side_effect=["mps", "main.default.lilly-anthropic"],
+            ) as select,
+            patch.object(wizard, "all_users_can_use_schema", return_value=True),
+        ):
+            service = wizard._select_provider_service("claude", WORKSPACE, "token")
+        assert service == ANTHROPIC_SERVICE
+        offered = [value for value, _ in select.call_args_list[1][0][1]]
+        assert offered == ["main.default.lilly-anthropic"]
+
+    def test_only_relayed_services_falls_back_to_databricks_for_claude(self):
+        relayed = {**ANTHROPIC_SERVICE, "targets": [], "relayed": True}
+        with (
+            patch.object(
+                wizard, "list_model_provider_services", return_value=([relayed], None)
+            ),
+            patch.object(wizard, "prompt_for_selection") as select,
+            patch.object(wizard, "print_note"),
+        ):
+            assert wizard._select_provider_service("claude", WORKSPACE, "token") is None
+        assert not select.called
+
     def test_warns_when_all_users_lack_schema_access(self):
         # The picked MPS's schema isn't granted to all workspace users, so developers who pull the
         # config may hit "does not have USE_SCHEMA"; warn but still return the service (never block).

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -1337,9 +1337,7 @@ class TestProviderServiceSelection:
     def test_only_relayed_services_falls_back_to_databricks_for_claude(self):
         relayed = {**ANTHROPIC_SERVICE, "targets": [], "relayed": True}
         with (
-            patch.object(
-                wizard, "list_model_provider_services", return_value=([relayed], None)
-            ),
+            patch.object(wizard, "list_model_provider_services", return_value=([relayed], None)),
             patch.object(wizard, "prompt_for_selection") as select,
             patch.object(wizard, "print_note"),
         ):


### PR DESCRIPTION
## Summary
- exclude relayed-auth model provider services from the Claude External Models picker
- continue offering non-relayed Anthropic and Bedrock provider services
- fall back to Databricks-hosted models when only relayed Claude services are available

## Testing
- `uv run pytest` (1927 passed, 37 skipped)
- `uv run pytest tests/test_managed_wizard.py -q` (191 passed after rebasing)
- `uv run ruff check .`