### PR TITLE
Surface a re-auth hint when the relayed-proxy 401 refresh fails

### DIFF
--- a/src/ucode/gateway_proxy.py
+++ b/src/ucode/gateway_proxy.py
@@ -242,8 +242,13 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             # instead of surfacing to Claude Code as a spurious Anthropic prompt.
             try:
                 self.cache.refresh()
-            except RuntimeError:
-                pass  # refresh failed; retry with the existing token and relay whatever comes
+            except RuntimeError as exc:
+                # Refresh failed: the Databricks OAuth session is dead (not just the
+                # access token) and can't be re-minted non-interactively. Surface the
+                # `databricks auth login` hint rather than silently relaying a bare 401,
+                # which otherwise reads as an Anthropic `/login` prompt and sends the
+                # user to the wrong re-auth. Still retry + relay with the existing token.
+                _log_refresh_failure(exc)
             headers = _forwarded_request_headers(self, self.cache.token)
             with self.client.stream(self.command, url, headers=headers, content=body) as resp:
                 _diagnostic_log(


### PR DESCRIPTION
## Problem

The relayed Claude Max/Enterprise proxy (`gateway_proxy.py`) carries two independently-expiring credentials: Claude Code's Anthropic subscription OAuth in `Authorization`, and a short-lived Databricks token that this proxy mints into `X-Databricks-AI-Gateway-Token`.

On a `401/403`, `_ProxyHandler._handle` force-refreshes the Databricks swap token and retries once — a stale-*access-token* 401 self-heals. But when `cache.refresh()` itself fails (the underlying Databricks OAuth **session** is dead, not just the access token — e.g. after a long idle/overnight gap), the branch did `except RuntimeError: pass`, silently swallowing it. The user is then handed a bare relayed 401 with no guidance, which surfaces in Claude Code as a generic auth error → they try `/login` (which only re-does the Anthropic OAuth) instead of the actual fix, `databricks auth login`.

## Fix

Call the existing `_log_refresh_failure(exc)` in that branch instead of `pass`. It already prints the actionable `databricks auth login` hint to stderr and is designed not to leak tokens. Behavior is otherwise unchanged: we still retry with the existing token and relay whatever comes back.

## Testing

- `ruff check` passes.
- No happy-path change: the hint prints only when a 401-triggered forced refresh raises.

This pull request and its description were written by Isaac.