### PR TITLE
fix: serve the newest Claude opus instead of pinning opus-4-8

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1783,20 +1783,6 @@ def discover_claude_models_unbucketed(workspace: str, token: str) -> tuple[list[
     return [m for m in ids if "claude-" in m.lower()], None
 
 
-def _prefer_opus_4_8(models: dict[str, str], all_ids: list[str]) -> None:
-    """Swap the opus slot to claude-opus-4-8 when it's available.
-
-    Discovery picks the newest opus (opus-5) but smart routing's
-    CLAUDE_ROUTE_ARMS require claude-opus-4-8. Pin to 4-8 when both
-    exist so the routing availability check passes.
-    """
-    opus = models.get("opus")
-    if opus and "claude-opus-5" in opus:
-        opus_48 = next((m for m in all_ids if "claude-opus-4-8" in m), None)
-        if opus_48:
-            models["opus"] = opus_48
-
-
 def discover_model_services(
     workspace: str, token: str
 ) -> tuple[dict[str, str], list[str], list[str], list[str], str | None]:
@@ -1827,12 +1813,6 @@ def discover_model_services(
         )
         if candidates:
             claude_models[family] = candidates[0]
-    # Smart routing's CLAUDE_ROUTE_ARMS require claude-opus-4-8, but the
-    # newest-wins sort above picks opus-5 when both exist — making the
-    # routing availability check fail. Pin opus-4-8 when it's available so
-    # routing works with the current task_v2 router. Revert to
-    # newest-wins once the router accepts opus-5 (PR databricks-eng/universe#2365446).
-    _prefer_opus_4_8(claude_models, ids)
 
     codex_models = sorted([m for m in ids if "gpt-" in m], key=model_version_sort_key)
     gemini_models = sorted([m for m in ids if "gemini-" in m], key=model_version_sort_key)
@@ -2940,8 +2920,6 @@ def discover_claude_models(workspace: str, token: str) -> tuple[dict[str, str], 
         )
         if candidates:
             result[family] = candidates[0]
-    # Same opus-4-8 pin as discover_model_services — see comment there.
-    _prefer_opus_4_8(result, raw_ids)
     if result:
         return result, None
     if not raw_ids:

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -243,6 +243,22 @@ class TestDiscoverClaudeModels:
             "sonnet": "system.ai.claude-sonnet-4-6",
         }
 
+    def test_opus_5_wins_over_opus_4_8(self, monkeypatch):
+        # The opus slot is the newest opus the workspace serves. ucode used to swap opus-5 out for
+        # opus-4-8 to satisfy a frozen smart-routing arm menu, which downgraded every user.
+        payload = {
+            "data": [
+                {"id": "databricks-claude-opus-4-8"},
+                {"id": "databricks-claude-opus-5"},
+            ]
+        }
+        monkeypatch.setattr(db_mod, "_http_get_json", lambda url, token, **kwargs: (payload, None))
+
+        models, reason = db_mod.discover_claude_models(WS, "token")
+
+        assert reason is None
+        assert models["opus"] == "databricks-claude-opus-5"
+
     def test_buckets_fable_family(self, monkeypatch):
         payload = {
             "data": [
@@ -319,6 +335,24 @@ class TestDiscoverModelServices:
             "system.ai.glm-5-2",
             "system.ai.kimi-k2-7-code",
         ]
+
+    def test_opus_5_wins_over_opus_4_8(self, monkeypatch):
+        # Same regression as the AI Gateway path: the opus slot is the newest opus, not a pinned
+        # opus-4-8.
+        payload = {
+            "model_services": [
+                _model_service("system.ai.claude-opus-4-8"),
+                _model_service("system.ai.claude-opus-5"),
+            ]
+        }
+        monkeypatch.setattr(
+            db_mod, "_http_get_json", lambda url, token, timeout=10: (payload, None)
+        )
+
+        claude, _codex, _gemini, _oss, reason = db_mod.discover_model_services(WS, "token")
+
+        assert reason is None
+        assert claude == {"opus": "system.ai.claude-opus-5"}
 
     def test_oss_allowlist_drops_unsupported_families(self, monkeypatch):
         # Only explicitly supported chat families are retained.
@@ -2707,9 +2741,8 @@ class TestModelServicesCache:
         claude, _codex, _gemini, _oss, _reason = db_mod.discover_model_services(WS, "tok")
         unbucketed, _ = db_mod.discover_claude_models_unbucketed(WS, "tok")
         assert calls["n"] == 1
-        # Both views still come back intact: newest-per-family (pinned to opus-4-8
-        # for smart-routing compatibility by _prefer_opus_4_8), and the full list.
-        assert claude["opus"] == "system.ai.claude-opus-4-8"
+        # Both views still come back intact: newest-per-family, and the full list.
+        assert claude["opus"] == "system.ai.claude-opus-5"
         assert unbucketed == ["system.ai.claude-opus-4-8", "system.ai.claude-opus-5"]
 
     def test_use_cache_false_forces_a_fresh_walk(self, monkeypatch):


### PR DESCRIPTION
## The problem

`_prefer_opus_4_8` swapped the discovered opus slot from `opus-5` to `opus-4-8`. It ran for every agent and every user. On a workspace that serves both, every Claude Code, OpenCode, pi, and Copilot user received Opus 4.8. The user could not opt out, and the program gave no sign that the swap happened.

The only reason for the swap was smart routing. The v1 arm menu `CLAUDE_ROUTE_ARMS = ("claude-opus-4-8", "claude-sonnet-5")` is frozen, and `request_routing_decision` refuses to route unless the workspace serves each arm by exact version. Discovery keeps one id per family, so an opus slot holding `opus-5` made that check fail.

Closes #382.

## The change

The pin is deleted. The opus slot is the newest opus the workspace serves.

Smart routing needs no compensation. Its v2 path (`smart_routing/v2.py`) builds `route_options` from the whole discovered Anthropic catalog and resolves the router's pick against that same catalog, so no single version is required. The v1 arm check has no production caller: `claude-router-hook route-subagent` returns early unless `smart_routing_v2.enabled()`, and it then calls `smart_routing_v2.route_claude_pre_tool_use`. `claude_routing.request_routing_decision`, `route_pre_tool_use`, and `CLAUDE_ROUTE_ARMS` are reachable only from `tests/test_claude_routing.py`.

This supersedes the earlier version of this PR, which threaded a `smart_routing_enabled` argument through `configure_shared_state`, `discover_model_services`, and `discover_claude_models` to gate the pin. That plumbing is unnecessary against current `main`, so the branch is reset onto `main` and carries one commit. It no longer borrows #385's commits either.

## Verification

`uv run pytest` gives 2275 passed, 40 skipped. `uv run ruff check .` passes. The three `tests/test_e2e_user_agent.py` failures reproduce on a clean `main` checkout with no patch applied.

Two regression tests, one per discovery path: `TestDiscoverClaudeModels::test_opus_5_wins_over_opus_4_8` and `TestDiscoverModelServices::test_opus_5_wins_over_opus_4_8`. Both fail without the change.

Live workspace, which serves `system.ai.claude-opus-4-8` and `system.ai.claude-opus-5`:

| check | result |
| --- | --- |
| `model-services?parent=schemas/system.ai` lists both opus ids | yes |
| discovery opus slot, before | `system.ai.claude-opus-4-8` |
| discovery opus slot, after | `system.ai.claude-opus-5` |
| `POST /ai-gateway/anthropic/v1/messages` on `system.ai.claude-opus-5` | 200 |

## Out of scope

The `[1m]` 1M-context suffix. `_CLAUDE_MODEL_RE` requires a two-component version, so `claude-opus-5` never matches and never gets the suffix. Widening the regex would hand `opus-5` the same breakage that #300 reports for `opus-4-8`, where the gateway rejects the suffixed name outright. I confirmed on the live workspace that the gateway rejects the literal id `system.ai.claude-opus-5[1m]` while accepting `system.ai.claude-opus-5` with the `context-1m-2025-08-07` beta header. Fixing that belongs with #300.

The dead v1 Claude routing code is left in place. Deleting `CLAUDE_ROUTE_ARMS`, `request_routing_decision`, `route_pre_tool_use`, and their tests is a separate cleanup.
