### PR TITLE
Label detailed usage costs as estimated

### DIFF
--- a/src/ucode/usage.py
+++ b/src/ucode/usage.py
@@ -504,7 +504,13 @@ class ToolUsageTotals(NamedTuple):
     cost: Decimal | None
 
 
-TOOL_MODEL_TABLE_HEADERS = ["Model", "Requests", "Input (incl. cache)", "Output", "Cost (USD)"]
+TOOL_MODEL_TABLE_HEADERS = [
+    "Model",
+    "Requests",
+    "Input (incl. cache)",
+    "Output",
+    "Est. Cost (USD)",
+]
 
 
 def aggregate_tool_model_usage(records: list[dict[str, object]], tool: str) -> list[ModelUsage]:
@@ -815,6 +821,6 @@ def usage(warehouse_id: str | None = None) -> int:
         console.print(f"{label('Requests:')} {value(f'{totals.requests:,}')}")
         console.print(f"{label('Total tokens:')} {value(f'{totals.tokens:,}')}")
         if totals.cost is not None:
-            console.print(f"{label('Cost (USD):')} {value(format_cost_usd(totals.cost))}")
+            console.print(f"{label('Est. Cost (USD):')} {value(format_cost_usd(totals.cost))}")
         console.print(render_box_table(TOOL_MODEL_TABLE_HEADERS, rows, max_widths=table_widths))
     return 0

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -12,6 +12,7 @@ import ucode.usage as usage_mod
 from ucode.databricks import SqlWarehouse
 from ucode.ui import label, value
 from ucode.usage import (
+    TOOL_MODEL_TABLE_HEADERS,
     USAGE_BREAKDOWN_DAYS,
     USAGE_SUMMARY_DAYS,
     ModelPrice,
@@ -464,6 +465,9 @@ class TestBuildToolModelRows:
         records = [self._records()[1]]  # only the unpriced mystery-model
         _, totals = build_tool_model_rows(records, "claude", self._lookup())
         assert totals.cost is None
+
+    def test_cost_header_is_explicitly_estimated(self):
+        assert TOOL_MODEL_TABLE_HEADERS[-1] == "Est. Cost (USD)"
 
 
 class TestRenderBudgetLines:


### PR DESCRIPTION
## Summary
- label the per-model cost column as `Est. Cost (USD)`
- label tool-level cost totals as `Est. Cost (USD)`
- leave cost calculations unchanged

## Testing
- `uv run pytest tests/test_usage.py` (87 passed)
- `uv run ruff check src/ucode/usage.py tests/test_usage.py`

## 🥞 Stacked PR

Use this [link](https://github.com/databricks/ucode/pull/389/files) to review incremental changes.

- [feature/usage-budget-first](https://github.com/databricks/ucode/pull/373) [[Files changed](https://github.com/databricks/ucode/pull/373/files)]
- [usage-warehouse-picker](https://github.com/databricks/ucode/pull/388) [[Files changed](https://github.com/databricks/ucode/pull/388/files)]
- [**estimated-usage-cost-labels**](https://github.com/databricks/ucode/pull/389) [[Files changed](https://github.com/databricks/ucode/pull/389/files)] ← _this PR_

---------