### PR TITLE
Serialize concurrent configure state updates

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -113,9 +113,12 @@ from ucode.state import (
     get_provider_service,
     load_full_state,
     load_state,
+    load_workspace_state,
     save_state,
+    serialized_state_operation,
     set_current_workspace,
     set_provider_service,
+    state_operation_lock,
 )
 from ucode.tracing import configure_tracing_command
 from ucode.ui import (
@@ -1615,25 +1618,30 @@ def _register_managed_mcp_servers(managed: dict, tool: str, state: dict) -> None
     admin later removes from the config is unregistered rather than left behind. A failure here never
     blocks the launch — the agent still starts, just without the workspace's MCP servers.
     """
-    try:
-        registered = apply_managed_mcp_servers(
-            managed,
-            tool,
-            state["workspace"],
-            state.get("profile"),
-            use_pat=bool(state.get("use_pat")),
-        )
-    except RuntimeError as exc:
-        print_warning(f"Could not register your workspace's MCP servers: {exc}")
-        return
-    # Persist even when empty so a config that dropped its last server clears the prior registration.
-    others = [
-        server
-        for server in (state.get("managed_mcp_servers") or [])
-        if isinstance(server, dict) and tool not in (server.get("clients") or [])
-    ]
-    state["managed_mcp_servers"] = others + registered
-    save_state(state)
+    with state_operation_lock():
+        persisted_state = load_workspace_state(state["workspace"])
+        try:
+            registered = apply_managed_mcp_servers(
+                managed,
+                tool,
+                state["workspace"],
+                persisted_state.get("profile"),
+                use_pat=bool(persisted_state.get("use_pat")),
+            )
+        except RuntimeError as exc:
+            print_warning(f"Could not register your workspace's MCP servers: {exc}")
+            return
+        # Persist even when empty so a config that dropped its last server clears the prior
+        # registration. The operation lock keeps this fresh read and write in one transaction.
+        others = [
+            server
+            for server in (persisted_state.get("managed_mcp_servers") or [])
+            if isinstance(server, dict) and tool not in (server.get("clients") or [])
+        ]
+        managed_mcp_servers = others + registered
+        persisted_state["managed_mcp_servers"] = managed_mcp_servers
+        state["managed_mcp_servers"] = managed_mcp_servers
+        save_state(persisted_state)
     if registered:
         names = ", ".join(str(server["name"]) for server in registered)
         print_note(f"Registered workspace MCP server(s) for {TOOL_SPECS[tool]['display']}: {names}")
@@ -1681,23 +1689,28 @@ def _apply_managed_skills(managed: dict, tool: str, state: dict) -> None:
     to disk so the agent's ``/skills`` picker lists them. A failure in either step never blocks the
     launch.
     """
-    try:
-        applied = apply_managed_skills(
-            state,
-            managed,
-            tool,
-            state["workspace"],
-            state.get("profile"),
-            use_pat=bool(state.get("use_pat")),
-        )
-    except RuntimeError as exc:
-        print_warning(f"Could not register your workspace's skills: {exc}")
-    else:
-        if applied:
-            names = ", ".join(applied)
-            print_note(
-                f"Registered workspace skill schema(s) for {TOOL_SPECS[tool]['display']}: {names}"
+    with state_operation_lock():
+        persisted_state = load_workspace_state(state["workspace"])
+        try:
+            applied = apply_managed_skills(
+                persisted_state,
+                managed,
+                tool,
+                state["workspace"],
+                persisted_state.get("profile"),
+                use_pat=bool(persisted_state.get("use_pat")),
             )
+        except RuntimeError as exc:
+            print_warning(f"Could not register your workspace's skills: {exc}")
+        else:
+            state["mcp_servers"] = persisted_state.get("mcp_servers") or []
+            state["managed_skill_locations"] = persisted_state.get("managed_skill_locations") or []
+            if applied:
+                names = ", ".join(applied)
+                print_note(
+                    f"Registered workspace skill schema(s) for {TOOL_SPECS[tool]['display']}: "
+                    f"{names}"
+                )
     _download_managed_skills(managed, state)
 
 
@@ -2334,6 +2347,7 @@ def cursor_cmd(ctx: typer.Context) -> None:
 
 
 @configure_app.callback(invoke_without_command=True)
+@serialized_state_operation
 def configure(
     ctx: typer.Context,
     dry_run: Annotated[
@@ -2661,6 +2675,7 @@ def configure(
 
 
 @configure_app.command("mcp")
+@serialized_state_operation
 def configure_mcp(
     location: Annotated[
         str | None,

--- a/src/ucode/state.py
+++ b/src/ucode/state.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
+import functools
 import json
+import os
+import tempfile
+import threading
+import time
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
+from typing import BinaryIO
 
 from ucode.config_io import APP_DIR, is_dry_run
 from ucode.databricks import (
@@ -19,6 +27,118 @@ STATE_VERSION = 3
 MANAGED_OVERLAY_KEY = "_managed_overlay"
 AUTH_COMMAND_TIMEOUT_MS = 5000
 AUTH_REFRESH_INTERVAL_MS = 900_000
+
+_PROCESS_STATE_LOCK = threading.RLock()
+_STATE_LOCK_DEPTH = 0
+_STATE_LOCK_FILE: BinaryIO | None = None
+
+
+def _state_lock_path():
+    return STATE_PATH.with_name(f"{STATE_PATH.name}.lock")
+
+
+def _acquire_file_lock(lock_file: BinaryIO) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        lock_file.seek(0, os.SEEK_END)
+        if lock_file.tell() == 0:
+            lock_file.write(b"\0")
+            lock_file.flush()
+        while True:
+            try:
+                lock_file.seek(0)
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+                return
+            except OSError:
+                time.sleep(0.05)
+    else:
+        import fcntl
+
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+
+
+def _release_file_lock(lock_file: BinaryIO) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        lock_file.seek(0)
+        msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+    else:
+        import fcntl
+
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def state_operation_lock() -> Generator[None, None, None]:
+    """Serialize stateful ucode operations across threads and processes.
+
+    Lakebox provisioning can start the ESM and Omnigent ``ucode configure`` commands against the
+    same home directory concurrently. The lock is re-entrant within one process so a command can
+    hold it across the whole operation while individual state reads and writes use the same lock.
+    """
+    global _STATE_LOCK_DEPTH, _STATE_LOCK_FILE
+
+    with _PROCESS_STATE_LOCK:
+        if _STATE_LOCK_DEPTH == 0:
+            lock_path = _state_lock_path()
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            _STATE_LOCK_FILE = lock_path.open("a+b")
+            try:
+                _acquire_file_lock(_STATE_LOCK_FILE)
+            except BaseException:
+                _STATE_LOCK_FILE.close()
+                _STATE_LOCK_FILE = None
+                raise
+        _STATE_LOCK_DEPTH += 1
+        try:
+            yield
+        finally:
+            _STATE_LOCK_DEPTH -= 1
+            if _STATE_LOCK_DEPTH == 0:
+                lock_file = _STATE_LOCK_FILE
+                _STATE_LOCK_FILE = None
+                if lock_file is not None:
+                    try:
+                        _release_file_lock(lock_file)
+                    finally:
+                        lock_file.close()
+
+
+def serialized_state_operation[**P, R](func: Callable[P, R]) -> Callable[P, R]:
+    """Hold :func:`state_operation_lock` for one complete CLI operation."""
+
+    @functools.wraps(func)
+    def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        with state_operation_lock():
+            return func(*args, **kwargs)
+
+    return wrapped
+
+
+def _write_full_state(full: dict) -> None:
+    """Atomically replace ``state.json`` with ``full``."""
+    temp_path: str | None = None
+    try:
+        STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        fd, temp_path = tempfile.mkstemp(
+            prefix=f".{STATE_PATH.name}.", suffix=".tmp", dir=STATE_PATH.parent
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(full, handle, indent=2)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temp_path, STATE_PATH)
+        temp_path = None
+    except OSError as exc:
+        raise RuntimeError(f"Failed to write state file: {STATE_PATH}") from exc
+    finally:
+        if temp_path is not None:
+            try:
+                os.unlink(temp_path)
+            except FileNotFoundError:
+                pass
 
 
 def load_full_state() -> dict:
@@ -40,7 +160,16 @@ def load_state() -> dict:
     workspace = full.get("current_workspace")
     if not workspace:
         return {}
-    ws_state = full.get("workspaces", {}).get(workspace, {})
+    return _hydrate_workspace_state(full, workspace)
+
+
+def load_workspace_state(workspace: str) -> dict:
+    """Load one workspace's state without changing or depending on the current workspace."""
+    return _hydrate_workspace_state(load_full_state(), workspace)
+
+
+def _hydrate_workspace_state(full: dict, workspace: str) -> dict:
+    ws_state = dict(full.get("workspaces", {}).get(workspace, {}))
     ws_state["workspace"] = workspace
     return hydrate_state(ws_state)
 
@@ -56,16 +185,13 @@ def save_state(state: dict) -> None:
     """
     if is_dry_run():
         return
-    full = load_full_state()
-    workspace = state.get("workspace") or full.get("current_workspace")
-    if workspace:
-        full["current_workspace"] = workspace
-        full["workspaces"][workspace] = hydrate_state(_without_managed_overlay(state))
-    try:
-        APP_DIR.mkdir(parents=True, exist_ok=True)
-        STATE_PATH.write_text(json.dumps(full, indent=2), encoding="utf-8")
-    except OSError as exc:
-        raise RuntimeError(f"Failed to write state file: {STATE_PATH}") from exc
+    with state_operation_lock():
+        full = load_full_state()
+        workspace = state.get("workspace") or full.get("current_workspace")
+        if workspace:
+            full["current_workspace"] = workspace
+            full["workspaces"][workspace] = hydrate_state(_without_managed_overlay(state))
+        _write_full_state(full)
 
 
 def _without_managed_overlay(state: dict) -> dict:
@@ -95,15 +221,12 @@ def set_current_workspace(workspace: str | None) -> None:
     targets afterwards."""
     if is_dry_run():
         return
-    full = load_full_state()
-    if full.get("current_workspace") == workspace:
-        return
-    full["current_workspace"] = workspace
-    try:
-        APP_DIR.mkdir(parents=True, exist_ok=True)
-        STATE_PATH.write_text(json.dumps(full, indent=2), encoding="utf-8")
-    except OSError as exc:
-        raise RuntimeError(f"Failed to write state file: {STATE_PATH}") from exc
+    with state_operation_lock():
+        full = load_full_state()
+        if full.get("current_workspace") == workspace:
+            return
+        full["current_workspace"] = workspace
+        _write_full_state(full)
 
 
 def hydrate_state(state: dict) -> dict:
@@ -224,16 +347,16 @@ def build_agent_state(state: dict) -> dict[str, dict]:
 
 def clear_state() -> None:
     """Remove the current workspace entry from state."""
-    full = load_full_state()
-    workspace = full.get("current_workspace")
-    if workspace:
-        full.get("workspaces", {}).pop(workspace, None)
-        full["current_workspace"] = None
-    try:
-        APP_DIR.mkdir(parents=True, exist_ok=True)
-        STATE_PATH.write_text(json.dumps(full, indent=2), encoding="utf-8")
-    except OSError as exc:
-        raise RuntimeError(f"Failed to clear state file: {STATE_PATH}") from exc
+    with state_operation_lock():
+        full = load_full_state()
+        workspace = full.get("current_workspace")
+        if workspace:
+            full.get("workspaces", {}).pop(workspace, None)
+            full["current_workspace"] = None
+        try:
+            _write_full_state(full)
+        except RuntimeError as exc:
+            raise RuntimeError(f"Failed to clear state file: {STATE_PATH}") from exc
 
 
 def mark_tool_managed(state: dict, tool: str, managed_keys: list) -> dict:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -809,6 +809,44 @@ class TestApplyManagedSkills:
         mock_dl.assert_not_called()
 
 
+class TestRegisterManagedMcpServers:
+    def test_preserves_configuration_saved_after_launch_state_was_loaded(self):
+        stale_state = {
+            "workspace": "https://example.databricks.com",
+            "available_tools": ["pi"],
+            "managed_mcp_servers": [
+                {"name": "old-claude", "clients": ["claude"]},
+                {"name": "codex-server", "clients": ["codex"]},
+            ],
+        }
+        fresh_state = {
+            **stale_state,
+            "available_tools": ["claude", "codex", "pi"],
+            "managed_mcp_servers": [
+                {"name": "old-claude", "clients": ["claude"]},
+                {"name": "codex-server", "clients": ["codex"]},
+            ],
+        }
+        registered = [{"name": "new-claude", "clients": ["claude"]}]
+
+        with (
+            patch("ucode.cli.apply_managed_mcp_servers", return_value=registered),
+            patch("ucode.cli.load_workspace_state", return_value=fresh_state) as mock_load,
+            patch("ucode.cli.save_state") as mock_save,
+        ):
+            from ucode import cli
+
+            cli._register_managed_mcp_servers({}, "claude", stale_state)
+
+        mock_load.assert_called_once_with("https://example.databricks.com")
+        saved = mock_save.call_args.args[0]
+        assert saved["available_tools"] == ["claude", "codex", "pi"]
+        assert [server["name"] for server in saved["managed_mcp_servers"]] == [
+            "codex-server",
+            "new-claude",
+        ]
+
+
 class TestStatusSkillsSection:
     def _run(self, state):
         with patch("ucode.cli.load_state", return_value=state):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
+import time
 from unittest.mock import patch
 
 import pytest
@@ -16,9 +20,11 @@ from ucode.state import (
     hydrate_state,
     load_full_state,
     load_state,
+    load_workspace_state,
     mark_tool_managed,
     save_state,
     set_provider_service,
+    state_operation_lock,
 )
 
 FAKE_WS = "https://example.databricks.com"
@@ -139,6 +145,169 @@ class TestSaveLoadRoundTrip:
     def test_load_state_returns_empty_when_no_workspace(self):
         result = load_state()
         assert result == {}
+
+    def test_load_workspace_state_does_not_change_current_workspace(self):
+        other_workspace = "https://other.databricks.com"
+        save_state({"workspace": FAKE_WS, "available_tools": ["pi"]})
+        save_state({"workspace": other_workspace, "available_tools": ["claude"]})
+        state_mod.set_current_workspace(FAKE_WS)
+
+        loaded = load_workspace_state(other_workspace)
+
+        assert loaded["workspace"] == other_workspace
+        assert loaded["available_tools"] == ["claude"]
+        assert load_full_state()["current_workspace"] == FAKE_WS
+
+    def test_state_operation_lock_is_reentrant(self):
+        with state_operation_lock():
+            save_state({"workspace": FAKE_WS, "available_tools": ["claude"]})
+            assert load_state()["available_tools"] == ["claude"]
+
+    def test_state_operation_lock_serializes_processes(self, tmp_path):
+        script = """
+import sys
+import time
+from pathlib import Path
+from ucode.state import state_operation_lock
+
+acquired = Path(sys.argv[1])
+release = Path(sys.argv[2])
+with state_operation_lock():
+    acquired.write_text("acquired", encoding="utf-8")
+    deadline = time.monotonic() + 10
+    while not release.exists():
+        if time.monotonic() >= deadline:
+            raise RuntimeError("timed out waiting for release")
+        time.sleep(0.01)
+"""
+        first_acquired = tmp_path / "first-acquired"
+        first_release = tmp_path / "first-release"
+        second_acquired = tmp_path / "second-acquired"
+        second_release = tmp_path / "second-release"
+        env = os.environ.copy()
+        env["HOME"] = str(tmp_path)
+        env["USERPROFILE"] = str(tmp_path)
+        first = subprocess.Popen(
+            [sys.executable, "-c", script, str(first_acquired), str(first_release)], env=env
+        )
+        second = None
+        try:
+            deadline = time.monotonic() + 5
+            while not first_acquired.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert first_acquired.exists()
+
+            second = subprocess.Popen(
+                [sys.executable, "-c", script, str(second_acquired), str(second_release)], env=env
+            )
+            time.sleep(0.2)
+            assert not second_acquired.exists()
+
+            first_release.write_text("release", encoding="utf-8")
+            assert first.wait(timeout=5) == 0
+            deadline = time.monotonic() + 5
+            while not second_acquired.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert second_acquired.exists()
+            second_release.write_text("release", encoding="utf-8")
+            assert second.wait(timeout=5) == 0
+        finally:
+            first_release.write_text("release", encoding="utf-8")
+            second_release.write_text("release", encoding="utf-8")
+            for process in (first, second):
+                if process is not None and process.poll() is None:
+                    process.terminate()
+                    process.wait(timeout=5)
+
+    def test_concurrent_configure_processes_preserve_all_agents(self, tmp_path):
+        script = """
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+from ucode import cli
+from ucode.state import load_state, save_state
+
+workspace = "https://example.databricks.com"
+tool = sys.argv[1]
+ready_dir = Path(sys.argv[2])
+start = Path(sys.argv[3])
+
+
+class Context:
+    invoked_subcommand = None
+
+
+def configure_workspace_command(*args, selected_tools=None, **kwargs):
+    selected = selected_tools or list(args)
+    state = load_state() or {"workspace": workspace}
+    time.sleep(0.75)
+    state["available_tools"] = sorted(set(state.get("available_tools") or []) | set(selected))
+    managed = dict(state.get("managed_configs") or {})
+    managed.update({name: {"keys": []} for name in selected})
+    state["managed_configs"] = managed
+    save_state(state)
+    return 0
+
+
+ready_dir.joinpath(tool).write_text("ready", encoding="utf-8")
+deadline = time.monotonic() + 10
+while not start.exists():
+    if time.monotonic() >= deadline:
+        raise RuntimeError("timed out waiting to start")
+    time.sleep(0.01)
+
+with (
+    patch("ucode.cli.install_databricks_cli"),
+    patch("ucode.cli._parse_profiles_option", return_value=[(workspace, "TEST")]),
+    patch("ucode.cli._resolve_workspace_then_maybe_reject", side_effect=lambda entries: entries),
+    patch("ucode.cli.configure_workspace_command", side_effect=configure_workspace_command),
+):
+    cli.configure(
+        Context(),
+        agents=tool,
+        profiles="TEST",
+        use_pat=True,
+        skip_validate=True,
+        skip_unavailable=True,
+        enable_databricks_ai_tools=False,
+        skip_upgrade=True,
+    )
+"""
+        home = tmp_path / "home"
+        home.mkdir()
+        ready_dir = tmp_path / "ready"
+        ready_dir.mkdir()
+        start = tmp_path / "start"
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env["USERPROFILE"] = str(home)
+        processes = [
+            subprocess.Popen(
+                [sys.executable, "-c", script, tool, str(ready_dir), str(start)], env=env
+            )
+            for tool in ("claude", "codex", "pi")
+        ]
+        try:
+            deadline = time.monotonic() + 10
+            while len(list(ready_dir.iterdir())) != len(processes) and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert len(list(ready_dir.iterdir())) == len(processes)
+            start.write_text("start", encoding="utf-8")
+            for process in processes:
+                assert process.wait(timeout=10) == 0
+        finally:
+            start.write_text("start", encoding="utf-8")
+            for process in processes:
+                if process.poll() is None:
+                    process.terminate()
+                    process.wait(timeout=5)
+
+        full = json.loads((home / ".ucode" / "state.json").read_text(encoding="utf-8"))
+        workspace_state = full["workspaces"][FAKE_WS]
+        assert workspace_state["available_tools"] == ["claude", "codex", "pi"]
+        assert sorted(workspace_state["managed_configs"]) == ["claude", "codex", "pi"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- serialize `ucode configure`, `ucode configure mcp`, and launch-time managed-state mutations across processes with a re-entrant file lock
- atomically replace `~/.ucode/state.json` instead of truncating and rewriting it in place
- reload workspace state inside managed MCP/skills transactions so one agent's update cannot discard another process's changes
- keep the fix generic: ucode has no knowledge of Lakebox wrappers or `_UCODE_DISPATCH_ACTIVE`

## Root cause
`configure_selected_tools` already unions newly configured agents with `available_tools`, so sequential single-agent configures behave correctly. The failure is a stale-snapshot race:

1. concurrent processes load the same initial workspace state
2. each process updates its own in-memory copy
3. each `save_state` replaces the whole workspace entry
4. whichever process saves last discards agents and managed state written by the others

For session `1022893578750421` in `prod-aws-us-west-2`, ESM and MAS ran top-level configuration concurrently while a Lakebox wrapper could also start a single-agent configure. The final writer was the Pi configure, leaving managed configs for all three agents but `available_tools: [pi]`. `ucode configure mcp` then correctly rejected that Pi-only state because Pi is not an MCP-capable client.

Post5 made the race substantially easier to hit by adding a longer Databricks AI Tools phase and additional managed MCP/skills state writers, but the state-file fix should not depend on any specific launcher or wrapper implementation.

## Scope split
Lakebox wrapper routing is fixed separately in Universe. The image keeps a stable `/usr/local/bin/ucode` shim that marks ucode-owned child processes, so administrative agent probes bypass recursive self-healing dispatch. This PR only guarantees that concurrent ucode state mutations serialize and preserve one another.

## Validation
- `uv run ruff check .` — passed
- `uv run pytest tests/test_state.py -q` — **32 passed**
- full suite — **1992 passed, 39 skipped, 2 environment-dependent failures**:
  - local Claude binary did not reach the capture-server gateway in the live User-Agent test
  - the managed-wizard apply test encountered the host's pre-existing `/usr/local/bin/databricks`
- deterministic three-process regression test starts simultaneous Claude, Codex, and Pi configure operations against one HOME and verifies the final workspace retains all three agents and managed configs
- negative control against the parent commit reproduced corrupted JSON or lost agent updates
- real Lakebox image stress tests passed with 15 simultaneous mixed configure writers and with 20 simultaneous configure plus MCP writers; final `available_tools` and `managed_configs` were exactly `claude`, `codex`, and `pi`

Signed-off-by: Edwin He <41037314+Edwinhe03@users.noreply.github.com>
