### PR TITLE
claude: add model discovery launch flag

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -2213,6 +2213,7 @@ def claude_cmd(
         bool,
         typer.Option(
             "--enable-model-discovery",
+            hidden=True,
             help="Enable AI Gateway models in Claude Code's model picker.",
         ),
     ] = False,

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -2209,6 +2209,13 @@ def claude_cmd(
     skip_preflight: SkipPreflightOption = False,
     skip_managed_config: SkipManagedConfigOption = False,
     workspace: WorkspaceOption = None,
+    enable_model_discovery: Annotated[
+        bool,
+        typer.Option(
+            "--enable-model-discovery",
+            help="Enable AI Gateway models in Claude Code's model picker.",
+        ),
+    ] = False,
     enable_smart_routing_flag: Annotated[
         bool,
         typer.Option(
@@ -2233,6 +2240,8 @@ def claude_cmd(
         claude_agent.disable_smart_routing(load_state())
         print_success("Claude Code smart routing disabled; ucode routing hooks removed")
         return
+    if enable_model_discovery:
+        os.environ[claude_agent.GATEWAY_MODEL_DISCOVERY_ENV_VAR] = "1"
     _launch_tool(
         "claude",
         ctx,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,6 +228,12 @@ class TestSubcommandRouting:
         assert os.environ["ENABLE_CLAUDE_CODE_GATEWAY_MODEL_DISCOVERY"] == "1"
         assert mock_launch.call_args.args[1].args == []
 
+    def test_claude_enable_model_discovery_is_hidden_from_help(self):
+        result = runner.invoke(app, ["claude", "--help"])
+
+        assert result.exit_code == 0, result.output
+        assert "--enable-model-discovery" not in result.output
+
     def test_codex_disable_removes_hooks_without_launching(self):
         with (
             patch("ucode.cli.load_state", return_value=MINIMAL_STATE),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -220,6 +220,14 @@ class TestSubcommandRouting:
         assert mock_launch.call_args.kwargs["enable_smart_routing_flag"] is True
         assert mock_launch.call_args.args[1].args == []
 
+    def test_claude_enable_model_discovery_sets_ucode_env(self):
+        with patch("ucode.cli._launch_tool") as mock_launch:
+            result = runner.invoke(app, ["claude", "--enable-model-discovery"])
+
+        assert result.exit_code == 0, result.output
+        assert os.environ["ENABLE_CLAUDE_CODE_GATEWAY_MODEL_DISCOVERY"] == "1"
+        assert mock_launch.call_args.args[1].args == []
+
     def test_codex_disable_removes_hooks_without_launching(self):
         with (
             patch("ucode.cli.load_state", return_value=MINIMAL_STATE),


### PR DESCRIPTION
## Summary

- add `ucode claude --enable-model-discovery`
- enable the existing Claude gateway model discovery path for that launch
- keep the flag from being forwarded to Claude Code

## Tests

- `uv run pytest tests/test_cli.py -q`
- `uv run pytest tests/test_agent_claude.py -q`
- `uv run ruff format --check src/ tests/`
- `uv run ruff check .`
- `uv run ty check src/`