### PR TITLE
Add ucode publish with optional config file input

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ ucode setup                 # agents and models (start here)
 ucode setup mcps            # managed MCP servers
 ucode setup skills          # managed skills
 ucode setup spend-tiers     # spend-based routing
-ucode apply                 # publish it to the workspace
+ucode publish                 # publish it to the workspace
 ```
 
 `ucode setup` walks through the agents to enable and which one bare `ucode` launches, then per agent:
@@ -256,12 +256,12 @@ command also offers to publish right away, so you can apply changes incrementall
 section prompts also runs the matching `ucode configure` step, which does configure this machine.
 
 Everything is written to `~/.ucode/managed-state.json` — the one local managed-config file — which
-`ucode apply` publishes. Re-running `ucode setup` keeps the MCP servers, skills, tracing table, and
+`ucode publish` publishes. Re-running `ucode setup` keeps the MCP servers, skills, tracing table, and
 tiered spend policy already authored, rather than clearing them; to drop one, edit the file and reload
 it with `ucode setup --from-file`.
 
 ```bash
-# Review the manifest and the exact payload `ucode apply` would publish.
+# Review the manifest and the exact payload `ucode publish` would publish.
 ucode setup show
 
 # Skip the prompts and load a hand-written config instead (validated before saving).
@@ -272,34 +272,45 @@ Once the manifest looks right, publish it:
 
 ```bash
 # Validate, show a diff against what's live, and ask before publishing.
-ucode apply
+ucode publish
 
 # Publish without the confirmation prompt (for CI).
-ucode apply --yes
+ucode publish --yes
+
+# Publish a config file exported with `ucode export` instead of the locally authored one.
+ucode publish -f ./managed-config.json
+ucode publish --file ./managed-config.json --yes
 ```
 
-`apply` updates the workspace's existing config in place rather than replacing it, so a failed
+`publish` updates the workspace's existing config in place rather than replacing it, so a failed
 publish leaves the current config intact. It shows a diff of exactly what changes against the
 published config before asking to confirm, and does nothing when the two already match. It is a
 whole-manifest write — every field ucode authors is sent — but because `ucode setup` carries the
 other sections forward, a re-run no longer silently drops them. Developers pick the new config up on
 their next ucode run.
 
+With `-f`/`--file`, `publish` reads a config file produced by `ucode export` and publishes it through
+the same validation, diff, and confirmation flow. The file's `workspace` must match the configured
+workspace (it can never redirect publication elsewhere) and its `spec_version` must be a supported
+integer; server-owned fields (resource name, workspace ids, timestamps, user ids) and unknown fields
+are rejected rather than silently dropped.
+
 ### Exporting the config
 
 Any user (not only admins) can print the workspace's managed config as portable JSON with `ucode
 export`. The output leads with the source `workspace` URL and a `spec_version` (the export format
 version), followed by the canonical external config; credentials and server-assigned fields (the
-resource name, timestamps, user ids) are excluded. Without `--output` the JSON is written to stdout;
-with `--output`/`-o` the same bytes are written to a file (atomically, and the destination's parent
-directory must already exist) while stdout stays empty.
+resource name, timestamps, user ids) are excluded. Without `--file` the JSON is written to stdout;
+with `--file`/`-f` the same bytes are written to a file (atomically, and the destination's parent
+directory must already exist) while stdout stays empty. The exported file is exactly what `ucode
+publish -f <file>` consumes.
 
 ```bash
 # Print the managed config as JSON.
 ucode export
 
 # Write it to a file; stdout stays empty.
-ucode export --output ./managed-config.json
+ucode export --file ./managed-config.json
 ```
 
 The output looks like:
@@ -320,7 +331,7 @@ The output looks like:
 | Command | Description |
 |---------|-------------|
 | `ucode status` | Show current workspace, base URLs, managed config files, and selected models |
-| `ucode export` | Print the workspace's managed config as portable JSON (`--output <file>` / `-o` to write a file) |
+| `ucode export` | Print the workspace's managed config as portable JSON (`--file <file>` / `-f` to write a file) |
 | `ucode usage` | Show AI Gateway usage summary, plus your budget spend against its alert threshold when the workspace reports one |
 | `ucode usage --warehouse-id <id>` | Query a specific SQL warehouse instead of discovering one |
 | `ucode revert` | Clear saved state and restore backed-up config files |
@@ -350,10 +361,11 @@ The output looks like:
 | `ucode setup skills [--location a.b,c.d]` | Add or change the managed config's skills |
 | `ucode setup spend-tiers` | Set the managed config's tiered spend routing policy |
 | `ucode setup help` | Walk through the whole setup sequence, marking what's already configured |
-| `ucode setup show` | Print the authored config and the payload `ucode apply` would publish |
+| `ucode setup show` | Print the authored config and the payload `ucode publish` would publish |
 | `ucode setup --from-file <file>` | Load a hand-written managed config instead of running the prompts |
-| `ucode apply` | Publish the authored managed config to the workspace, after a diff and confirmation (admins only) |
-| `ucode apply --yes` | Publish without the confirmation prompt |
+| `ucode publish` | Publish the authored managed config to the workspace, after a diff and confirmation (admins only) |
+| `ucode publish -f <file>` | Publish a config file exported with `ucode export` instead of the locally authored one |
+| `ucode publish --yes` | Publish without the confirmation prompt |
 
 ## Managed Local Files
 

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -82,7 +82,7 @@ from ucode.managed_resolve import (
     resolve_state,
 )
 from ucode.managed_wizard import (
-    apply_command,
+    publish_command,
     setup_budget_policy_command,
     setup_command,
     setup_help_command,
@@ -2132,7 +2132,7 @@ def _print_no_managed_config_guidance(workspace: str, profile: str | None) -> No
         print_note("Ask a workspace admin to set one up with `ucode setup`.")
     else:
         # None means the admin check itself failed; point at setup rather than a dead end.
-        print_note("Run `ucode setup` to configure one for your workspace, then `ucode apply`.")
+        print_note("Run `ucode setup` to configure one for your workspace, then `ucode publish`.")
 
 
 @app.command("codex", context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
@@ -2885,7 +2885,7 @@ def setup_help_cmd() -> None:
 
 @setup_app.command("show")
 def setup_show_cmd() -> None:
-    """Print the authored managed config and the payload `ucode apply` would publish."""
+    """Print the authored managed config and the payload `ucode publish` would publish."""
     try:
         code = show_command()
     except RuntimeError as exc:
@@ -2895,8 +2895,17 @@ def setup_show_cmd() -> None:
         raise typer.Exit(code)
 
 
-@app.command("apply")
-def apply_cmd(
+@app.command("publish")
+def publish_cmd(
+    file_path: Annotated[
+        str | None,
+        typer.Option(
+            "--file",
+            "-f",
+            help="Publish a config file exported with `ucode export` instead of the locally "
+            "authored config. Its `workspace` must match the configured workspace.",
+        ),
+    ] = None,
     yes: Annotated[
         bool,
         typer.Option("--yes", "-y", help="Publish without the confirmation prompt."),
@@ -2912,7 +2921,7 @@ def apply_cmd(
     # the try block or the handler below would report a successful exit as an error.
     try:
         install_databricks_cli()
-        code = apply_command(yes=yes)
+        code = publish_command(file_path=file_path, yes=yes)
     except RuntimeError as exc:
         print_err(str(exc))
         raise typer.Exit(1) from None
@@ -2925,11 +2934,11 @@ def apply_cmd(
 
 @app.command("export")
 def export_cmd(
-    output: Annotated[
+    file_path: Annotated[
         str | None,
         typer.Option(
-            "--output",
-            "-o",
+            "--file",
+            "-f",
             help="Write the exported config JSON to this file (atomically) instead of stdout. "
             "The parent directory must already exist.",
         ),
@@ -2940,13 +2949,13 @@ def export_cmd(
     Serializes the local managed config to the external `CodingAgentConfig` format that
     `ucode publish -f <path>` consumes, with credentials and server-owned fields (resource name,
     workspace id, timestamps, user ids) excluded. Any user can run it; it makes no network calls
-    and mutates no workspace or local state. Without --output the JSON is printed to stdout;
+    and mutates no workspace or local state. Without --file the JSON is printed to stdout;
     diagnostics and errors go to stderr.
     """
     from ucode.managed_export import export_command
 
     try:
-        export_command(output=output)
+        export_command(file_path=file_path)
     except RuntimeError as exc:
         print_err(str(exc))
         raise typer.Exit(1) from None

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -377,7 +377,7 @@ def _http_get_bytes(url: str, token: str, *, timeout: int = 10) -> tuple[bytes |
         return None, f"network error: {exc.reason}"
 
 
-# Workspace group whose members are workspace admins. `ucode setup` / `ucode apply` are restricted
+# Workspace group whose members are workspace admins. `ucode setup` / `ucode publish` are restricted
 # to this group because the coding-agent-config CRUD API enforces the same check server-side.
 WORKSPACE_ADMIN_GROUP = "admins"
 
@@ -1847,6 +1847,7 @@ def fetch_external_model_prices(workspace: str, token: str) -> tuple[list[dict],
 # currently populated, is what lets a re-run *clear* a field the admin removed: the server merges
 # per path, so an omitted path leaves the old value in place.
 MANAGED_CONFIG_UPDATE_MASK_PATHS: tuple[str, ...] = (
+    "spec_version",
     "display_name",
     "default_agent",
     "enabled_agents",

--- a/src/ucode/managed_config.py
+++ b/src/ucode/managed_config.py
@@ -13,7 +13,7 @@ local file, ``~/.ucode/managed-state.json`` (0600), that both roles share:
 
 There is deliberately one file, not a separate authored ``managed-settings.json``: the workspace is
 the source of truth, so an authored draft and the pulled copy are the same shape and coexist in
-``managed-state.json``. ``ucode setup`` authors the draft; ``ucode apply`` publishes it; a launch
+``managed-state.json``. ``ucode setup`` authors the draft; ``ucode publish`` publishes it; a launch
 then pulls the published copy back into the same file.
 
 :func:`refresh_managed_config` is the launch path's entry point. It is called before model discovery,
@@ -228,6 +228,9 @@ def normalize_managed_config(raw: dict) -> dict:
     name = _str(raw.get("name"))
     if name:
         result["name"] = name
+    display_name = _str(raw.get("display_name"))
+    if display_name:
+        result["display_name"] = display_name
     default_agent = AGENT_ENUM_TO_TOOL.get(_str(raw.get("default_agent")) or "")
     if default_agent:
         result["default_agent"] = default_agent
@@ -381,10 +384,10 @@ def load_managed_state(workspace: str | None) -> dict | None:
     Returns the normalized config dict (the ``config`` field), only when the stored file is for the
     same workspace — so a stale file from another workspace is ignored rather than misapplied.
 
-    This is the single local managed config: ``ucode setup`` authors it here, ``ucode apply``
+    This is the single local managed config: ``ucode setup`` authors it here, ``ucode publish``
     publishes it, and a launch refreshes it from the workspace. The admin-authored draft and the
     pulled copy share one file because the workspace is the source of truth — to keep a draft,
-    publish it with ``ucode apply``.
+    publish it with ``ucode publish``.
     """
     if not workspace:
         return None

--- a/src/ucode/managed_export.py
+++ b/src/ucode/managed_export.py
@@ -2,12 +2,12 @@
 
 Reads the local managed config (the one file :mod:`ucode.managed_config` owns, authored by
 ``ucode setup`` and refreshed by a launch), validates and serializes it through the same path
-``ucode apply`` uses, and writes the external proto-JSON ``CodingAgentConfig`` — prefixed with the
-source ``workspace`` and a ``spec_version`` envelope, the format a future ``ucode publish -f <path>``
-will consume — to stdout or a file.
+``ucode publish`` uses, and writes the external proto-JSON ``CodingAgentConfig`` — prefixed with the
+source ``workspace`` and a ``spec_version`` envelope, the format ``ucode publish -f <path>`` consumes
+— to stdout or a file.
 
 Deliberately read-only and offline: no auth, no admin check, no discovery, no publish, and no write
-except the explicitly requested ``--output`` file. That makes it role-agnostic (any developer can
+except the explicitly requested ``--file`` output. That makes it role-agnostic (any developer can
 run it) and keeps the machine-readable stream on stdout uncontaminated by Rich output.
 """
 
@@ -53,20 +53,20 @@ def build_export_payload() -> dict:
     return {"workspace": workspace, "spec_version": EXPORT_SPEC_VERSION, **config}
 
 
-def export_command(output: str | None = None) -> None:
-    """Serialize the managed config once and write it to ``output`` or stdout.
+def export_command(file_path: str | None = None) -> None:
+    """Serialize the managed config once and write it to ``file_path`` or stdout.
 
     The complete payload is built and serialized before the destination is touched, so a validation
-    or serialization failure never creates or truncates it. With no ``output`` the JSON goes to
-    stdout with exactly one trailing newline and nothing else; with ``output`` the identical bytes
+    or serialization failure never creates or truncates it. With no ``file_path`` the JSON goes to
+    stdout with exactly one trailing newline and nothing else; with ``file_path`` the identical bytes
     are written atomically and stdout stays empty. Raises RuntimeError on failure.
     """
     payload = build_export_payload()
     json_text = json.dumps(payload, indent=2) + "\n"
-    if output is None:
+    if file_path is None:
         sys.stdout.write(json_text)
         return
-    _write_atomic(Path(output).expanduser(), json_text)
+    _write_atomic(Path(file_path).expanduser(), json_text)
 
 
 def _write_atomic(destination: Path, json_text: str) -> None:

--- a/src/ucode/managed_publish.py
+++ b/src/ucode/managed_publish.py
@@ -1,0 +1,131 @@
+"""Input handling for ``ucode publish``: turn a config source into a publishable payload.
+
+``ucode publish`` publishes either the locally authored managed config (no ``-f``) or a config file
+produced by ``ucode export`` (``-f <path>``). Both routes converge here: a source dict is validated
+against the configured workspace and the ``spec_version`` envelope, canonicalized through the same
+normalize/serialize path the rest of ucode uses, and returned as the internal manifest (for
+validation, summaries, and diffs) plus the API payload (the canonical ``CodingAgentConfig`` with
+``spec_version`` but without ``workspace``).
+
+Pure input handling: no auth, no admin check, no network, no publish. Invalid input raises
+RuntimeError with an actionable message so ``publish`` fails before it touches the workspace.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import cast
+
+from ucode.managed_config import normalize_managed_config
+from ucode.managed_export import EXPORT_SPEC_VERSION, build_export_payload
+from ucode.managed_setup import serialize_managed_config
+from ucode.ui import normalize_workspace_url
+
+_ENVELOPE_FIELDS = ("workspace", "spec_version")
+
+
+def load_publish_payload(file_path: str | None) -> dict:
+    """Return the source config dict for ``ucode publish``.
+
+    With no ``file_path`` the locally authored config is serialized in-process via
+    :func:`ucode.managed_export.build_export_payload` (no subprocess, no captured stdout). With a
+    ``file_path`` the file is read as UTF-8 JSON; a missing file, non-UTF-8 bytes, malformed JSON, or
+    a non-object root each raise RuntimeError with an actionable message.
+    """
+    if file_path is None:
+        return build_export_payload()
+
+    path = Path(file_path).expanduser()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise RuntimeError(
+            f"No config file at {path}. Pass an existing file to `ucode publish -f`, or run "
+            "`ucode publish` with no file to publish the locally authored config."
+        ) from None
+    except UnicodeDecodeError as exc:
+        raise RuntimeError(f"{path} is not valid UTF-8 text: {exc}.") from exc
+    except OSError as exc:
+        raise RuntimeError(f"Could not read {path}: {exc}.") from exc
+
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"{path} is not valid JSON: {exc}.") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(
+            f"{path} must contain a JSON object at the top level, not a {type(payload).__name__}."
+        )
+    return payload
+
+
+def parse_publish_payload(payload: object, workspace: str) -> tuple[dict, dict]:
+    """Validate and canonicalize a source config into ``(manifest, api_payload)``.
+
+    ``manifest`` is ucode's internal normalized shape (for validation, summaries, and diffs).
+    ``api_payload`` is the canonical proto-JSON ``CodingAgentConfig`` carrying ``spec_version`` but
+    not ``workspace``, ready for the configuration API.
+
+    Enforces, before any of it reaches the workspace: an object root; a top-level ``workspace`` that
+    normalizes to the configured one (the file can never redirect publication elsewhere); a
+    ``spec_version`` that is a JSON integer (not a boolean or float) equal to the supported version;
+    no server-owned ``name``; and no unknown or lossy fields (anything normalization would silently
+    drop is rejected instead).
+    """
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"The config must be a JSON object, not a {type(payload).__name__}.")
+    payload = cast("dict[str, object]", payload)
+
+    file_workspace = payload.get("workspace")
+    if not isinstance(file_workspace, str) or not file_workspace.strip():
+        raise RuntimeError(
+            'The config is missing a top-level "workspace". Export it with `ucode export` so it '
+            "records the workspace it belongs to."
+        )
+    if normalize_workspace_url(file_workspace) != normalize_workspace_url(workspace):
+        raise RuntimeError(
+            f"The config is for {file_workspace}, but the configured workspace is {workspace}. "
+            "`ucode publish` only publishes to the configured workspace; re-run `ucode configure` "
+            "to switch workspaces."
+        )
+
+    spec_version = payload.get("spec_version")
+    if isinstance(spec_version, bool) or not isinstance(spec_version, int):
+        raise RuntimeError(
+            f'The config "spec_version" must be the integer {EXPORT_SPEC_VERSION}. Export it with '
+            "`ucode export` to get a config this ucode can publish."
+        )
+    if spec_version != EXPORT_SPEC_VERSION:
+        raise RuntimeError(
+            f"The config is spec_version {spec_version}, but this ucode publishes version "
+            f"{EXPORT_SPEC_VERSION}. Upgrade ucode, or re-export the config."
+        )
+
+    config = {key: value for key, value in payload.items() if key not in _ENVELOPE_FIELDS}
+    if "name" in config:
+        raise RuntimeError(
+            'The config includes a server-owned "name" field. Remove it — the workspace assigns the '
+            "resource name when the config is created."
+        )
+
+    manifest = normalize_managed_config(config)
+    canonical = serialize_managed_config(manifest)
+    canonical.pop("name", None)
+    if canonical != config:
+        dropped = sorted(key for key in config if key not in canonical)
+        altered = sorted(
+            key for key in config if key in canonical and config[key] != canonical[key]
+        )
+        offending = ", ".join(dropped + altered)
+        raise RuntimeError(
+            f"The config has fields ucode does not recognize or cannot publish: {offending}. "
+            "Server-owned fields (workspace ids, timestamps, user ids) and unknown fields must be "
+            "removed. Re-export a clean config with `ucode export`."
+        )
+
+    api_payload = {"spec_version": spec_version, **canonical}
+    return manifest, api_payload
+
+
+__all__ = ["load_publish_payload", "parse_publish_payload"]

--- a/src/ucode/managed_setup.py
+++ b/src/ucode/managed_setup.py
@@ -290,7 +290,7 @@ def serialize_managed_config(manifest: dict) -> dict:
     build doesn't recognize are dropped, mirroring the read side.
 
     Output-only proto fields (``workspace_id``, timestamps, user ids) are never emitted. ``name`` is
-    carried through when present so an update path can address an existing resource; ``ucode apply``
+    carried through when present so an update path can address an existing resource; ``ucode publish``
     omits it on create and lets the server assign one.
     """
     payload: dict = {}

--- a/src/ucode/managed_wizard.py
+++ b/src/ucode/managed_wizard.py
@@ -1,7 +1,7 @@
 """Interactive `ucode setup`: author the workspace's managed coding-agent config.
 
 Workspace admins run this to build the ``CodingAgentConfig`` their developers will pull, then publish
-it with ``ucode apply`` (a separate command, so the manifest can be reviewed first). The config lives
+it with ``ucode publish`` (a separate command, so the manifest can be reviewed first). The config lives
 at ``~/.ucode/managed-state.json`` (the one local managed-config file, owned by
 :mod:`ucode.managed_config`).
 
@@ -48,7 +48,6 @@ from ucode.managed_config import (
     get_managed_config,
     load_managed_state,
     managed_state_workspace,
-    normalize_managed_config,
     save_managed_state,
 )
 from ucode.managed_setup import (
@@ -1147,6 +1146,10 @@ def _config_facts(manifest: dict) -> list[tuple[str, str, str]]:
     """
     facts: list[tuple[str, str, str]] = []
 
+    display_name = manifest.get("display_name")
+    if isinstance(display_name, str) and display_name:
+        facts.append(("display_name", "Display name", display_name))
+
     default_agent = manifest.get("default_agent")
     if isinstance(default_agent, str):
         display = TOOL_SPECS.get(default_agent, {}).get("display", default_agent)
@@ -1264,7 +1267,7 @@ def _require_admin(workspace: str, token: str) -> None:
         )
     if admin is None:
         print_warning(
-            "Could not verify workspace admin permissions. Continuing — `ucode apply` will fail "
+            "Could not verify workspace admin permissions. Continuing — `ucode publish` will fail "
             "if you lack them."
         )
     else:
@@ -1456,7 +1459,7 @@ def _print_next_steps(manifest: dict) -> None:
     print_heading("Next steps")
     if config_io.is_dry_run():
         # Under --dry-run nothing was written, so the section commands (which read the saved draft)
-        # and `apply` have nothing to act on. Say so rather than send the admin to commands that
+        # and `publish` have nothing to act on. Say so rather than send the admin to commands that
         # would report "run `ucode setup` first".
         print_note("Dry run — nothing was saved. Re-run without --dry-run to author the config.")
         return
@@ -1467,28 +1470,28 @@ def _print_next_steps(manifest: dict) -> None:
         console.print(line)
     print_panel(
         "All done?",
-        ["Publish with [bold]ucode apply[/bold] so all developers use this configuration."],
+        ["Publish with [bold]ucode publish[/bold] so all developers use this configuration."],
     )
 
 
-def _offer_apply() -> None:
+def _offer_publish() -> None:
     """Offer to publish the saved draft right away, so an admin can apply changes incrementally.
 
     Each `ucode setup` command only writes a local draft. Without this an admin has to remember to run
-    `ucode apply` separately, and a `ucode setup` re-run in the meantime is easy to mistake for having
-    lost the change. Answering yes runs `apply_command`, which shows the diff against the published
-    config as it publishes; declining leaves the draft for a later `ucode apply`. Skipped under
+    `ucode publish` separately, and a `ucode setup` re-run in the meantime is easy to mistake for having
+    lost the change. Answering yes runs `publish_command`, which shows the diff against the published
+    config as it publishes; declining leaves the draft for a later `ucode publish`. Skipped under
     --dry-run, where nothing was saved to publish.
     """
     if config_io.is_dry_run():
         return
     console.print()
     if not prompt_yes_no_default(
-        "Publish these changes to the workspace now? (runs `ucode apply`)", default=False
+        "Publish these changes to the workspace now? (runs `ucode publish`)", default=False
     ):
-        print_note("Draft saved. Run `ucode apply` when you're ready to publish.")
+        print_note("Draft saved. Run `ucode publish` when you're ready to publish.")
         return
-    apply_command(yes=True)
+    publish_command(yes=True)
 
 
 # The sections `ucode setup` carries forward instead of prompting for, and how to rebuild each one.
@@ -1663,7 +1666,7 @@ def setup_command(
     errors = validate_manifest(manifest, state)
     if errors:
         # A validation failure here is a wizard bug, not admin error — the pickers only offer valid
-        # choices. Surface it plainly rather than writing a manifest that `apply` would reject.
+        # choices. Surface it plainly rather than writing a manifest that `publish` would reject.
         print_err("The generated config is not valid:")
         for error in errors:
             print_note(error)
@@ -1674,7 +1677,7 @@ def setup_command(
     console.print()
     print_success("Saved to ~/.ucode/managed-state.json")
     _print_next_steps(manifest)
-    _offer_apply()
+    _offer_publish()
     return 0
 
 
@@ -1727,7 +1730,7 @@ def _save_section_update(workspace: str, manifest: dict) -> int:
     availability. That's deliberate: a section command doesn't touch agents or models, so re-checking
     them would only reject a legitimately pinned older Claude model (`load_state` keeps just the newest
     per family) or, worse, wrongly flag a codex/gemini model whenever the re-fetched inventory happens
-    to be Claude-only. `ucode apply` runs the full model check against the live catalog before
+    to be Claude-only. `ucode publish` runs the full model check against the live catalog before
     publishing, which is where it belongs.
     """
     errors = validate_manifest(manifest, None)
@@ -1742,7 +1745,7 @@ def _save_section_update(workspace: str, manifest: dict) -> int:
     console.print()
     print_success("Saved to ~/.ucode/managed-state.json")
     _print_next_steps(manifest)
-    _offer_apply()
+    _offer_publish()
     return 0
 
 
@@ -1858,7 +1861,7 @@ def setup_help_command() -> int:
     """Walk through the whole managed-config setup, marking what this machine has authored.
 
     Hand-written rather than left to `--help`: the point is the *order* of the commands and the fact
-    that nothing reaches developers until `ucode apply`, neither of which a flag listing conveys. Reads
+    that nothing reaches developers until `ucode publish`, neither of which a flag listing conveys. Reads
     the manifest but never authenticates, so it works before `ucode configure`.
     """
     print_section("ucode setup")
@@ -1868,7 +1871,7 @@ def setup_help_command() -> int:
     )
     print_note(
         "Each command below edits your local draft; nothing reaches the workspace until "
-        "`ucode apply`."
+        "`ucode publish`."
     )
 
     workspace = load_state().get("workspace") or managed_state_workspace()
@@ -1897,9 +1900,9 @@ def setup_help_command() -> int:
 
     print_heading("3. Review and publish")
     console.print(
-        _command_line("ucode setup show", "The draft, and the payload `apply` sends", width=width)
+        _command_line("ucode setup show", "The draft, and the payload `publish` sends", width=width)
     )
-    console.print(_command_line("ucode apply", "Publish it to the workspace", width=width))
+    console.print(_command_line("ucode publish", "Publish it to the workspace", width=width))
 
     print_heading("Also")
     console.print(
@@ -1920,7 +1923,7 @@ def setup_help_command() -> int:
 
 
 def show_command() -> int:
-    """Print the authored manifest and the proto-JSON `ucode apply` would publish."""
+    """Print the authored manifest and the proto-JSON `ucode publish` would publish."""
     # Fall back to the workspace the on-disk file was authored for, so `ucode setup --show` still
     # works before `ucode configure` has put a workspace in local state.
     workspace = load_state().get("workspace") or managed_state_workspace()
@@ -1930,7 +1933,7 @@ def show_command() -> int:
         return 0
     _render_summary(workspace or "unknown", manifest)
     console.print()
-    print_heading("Payload for `ucode apply`")
+    print_heading("Payload for `ucode publish`")
     console.print(json.dumps(serialize_managed_config(manifest), indent=2))
     return 0
 
@@ -1950,7 +1953,7 @@ def _explain_publish_failure(reason: str) -> str:
     if "already_exists" in lowered:
         return (
             "This workspace already has a managed config, but ucode couldn't read it to update in "
-            "place. Run `ucode apply` again — if it keeps failing, the existing config may need to "
+            "place. Run `ucode publish` again — if it keeps failing, the existing config may need to "
             "be deleted by hand."
         )
     if "invalid_parameter_value" in lowered:
@@ -1971,7 +1974,7 @@ def _with_claude_inventory(state: dict, workspace: str, profile: str | None) -> 
         claude: model 'system.ai.claude-opus-4-8' is not available on this workspace.
 
     The wizard stashes the full listing on ``state["all_claude_models"]`` mid-run, but that is never
-    persisted — `setup` saves the manifest, not the state — so a separate `ucode apply` process
+    persisted — `setup` saves the manifest, not the state — so a separate `ucode publish` process
     starts from a fresh ``load_state()`` without it. Re-fetching here makes the check independent of
     what the wizard happened to leave behind, which also covers a hand-edited or ``--from-file``
     manifest authored on another machine.
@@ -1993,16 +1996,24 @@ def _with_claude_inventory(state: dict, workspace: str, profile: str | None) -> 
     return {**state, "all_claude_models": all_claude}
 
 
-def apply_command(*, yes: bool = False) -> int:
-    """Publish the authored manifest to the workspace.
+def publish_command(*, file_path: str | None = None, yes: bool = False) -> int:
+    """Publish a managed config to the workspace.
 
-    Updates the existing config in place when there is one, rather than deleting and recreating it:
-    a failed recreate would leave the workspace with no managed config at all, and every developer
-    would silently fall back to their own settings. Returns a process exit code.
+    With no ``file_path`` the locally authored manifest is published; with one, the config file
+    (produced by ``ucode export``) is published instead. Both routes are validated against the
+    configured workspace and canonicalized before anything is sent. Updates the existing config in
+    place when there is one, rather than deleting and recreating it: a failed recreate would leave
+    the workspace with no managed config at all, and every developer would silently fall back to
+    their own settings. Returns a process exit code.
+
+    Model-availability validation runs against the authored manifest for the no-file case, since the
+    export round-trip that builds its payload drops the internal ``model_config.custom_models``
+    exemption for hand-entered ids that discovery won't surface.
     """
     from ucode.cli import _prompt_for_configuration
+    from ucode.managed_publish import load_publish_payload, parse_publish_payload
 
-    print_section("ucode apply")
+    print_section("ucode publish")
 
     state = load_state()
     workspace = state.get("workspace")
@@ -2010,29 +2021,29 @@ def apply_command(*, yes: bool = False) -> int:
     if not workspace:
         workspace, profile = _prompt_for_configuration()
 
-    manifest = load_managed_state(workspace)
-    if manifest is None:
-        raise RuntimeError(
-            "No managed config has been authored for this workspace. Run `ucode setup` first "
-            "(or `ucode setup --from-file <json>`)."
-        )
+    manifest, api_payload = parse_publish_payload(load_publish_payload(file_path), workspace)
 
     # Auth first: validating a Claude manifest needs the workspace's full model listing, and that
     # listing needs a token. Nothing is written until well below this point.
     ensure_databricks_auth(workspace, profile)
 
-    errors = validate_manifest(manifest, _with_claude_inventory(state, workspace, profile))
+    validation_manifest = load_managed_state(workspace) if file_path is None else manifest
+    errors = validate_manifest(
+        validation_manifest or manifest, _with_claude_inventory(state, workspace, profile)
+    )
     if errors:
-        print_err("The authored config is not valid, so it was not published:")
+        print_err("The config is not valid, so it was not published:")
         for error in errors:
             print_note(error)
-        print_note("Re-run `ucode setup` to fix it, or edit ~/.ucode/managed-state.json.")
+        if file_path is None:
+            print_note("Re-run `ucode setup` to fix it, or edit ~/.ucode/managed-state.json.")
+        else:
+            print_note("Fix the config file and re-run `ucode publish -f`.")
         return 1
 
     token = get_databricks_token(workspace, profile)
     _require_admin(workspace, token)
 
-    payload = serialize_managed_config(manifest)
     _render_summary(workspace, manifest)
 
     # Read before writing: the resource name tells us whether to create or update, and shows the
@@ -2051,7 +2062,7 @@ def apply_command(*, yes: bool = False) -> int:
     if existing is not None and not isinstance(existing_name, str):
         raise RuntimeError(
             "This workspace has a managed config but the API didn't return its resource name, so "
-            "ucode can't update it in place. Delete it in the workspace and re-run `ucode apply`."
+            "ucode can't update it in place. Delete it in the workspace and re-run `ucode publish`."
         )
 
     console.print()
@@ -2062,7 +2073,7 @@ def apply_command(*, yes: bool = False) -> int:
         # rather than a bare "this replaces the current config". Comparing the round-tripped payload
         # (not the raw manifest) shows the real post-publish state — any field serialization drops
         # won't appear as a phantom change.
-        changed = _render_config_diff(existing, normalize_managed_config(payload), workspace)
+        changed = _render_config_diff(existing, manifest, workspace)
         if not changed:
             print_success(f"{workspace}'s published config already matches this one.")
             print_note("Nothing to publish.")
@@ -2075,11 +2086,11 @@ def apply_command(*, yes: bool = False) -> int:
 
     if existing is None:
         with spinner("Publishing the managed config..."):
-            published, publish_reason = create_coding_agent_config(workspace, token, payload)
+            published, publish_reason = create_coding_agent_config(workspace, token, api_payload)
     else:
         with spinner("Updating the managed config..."):
             published, publish_reason = update_coding_agent_config(
-                workspace, token, cast("str", existing_name), payload
+                workspace, token, cast("str", existing_name), api_payload
             )
     if publish_reason is not None:
         raise RuntimeError(_explain_publish_failure(publish_reason))
@@ -2091,7 +2102,7 @@ def apply_command(*, yes: bool = False) -> int:
 
 
 __all__ = [
-    "apply_command",
+    "publish_command",
     "setup_budget_policy_command",
     "setup_command",
     "setup_from_file",

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -2678,7 +2678,7 @@ class TestCodingAgentConfigCrudClients:
                 }
             )
         )
-        assert emitted == set(db_mod.MANAGED_CONFIG_UPDATE_MASK_PATHS)
+        assert set(db_mod.MANAGED_CONFIG_UPDATE_MASK_PATHS) == emitted | {"spec_version"}
 
     def test_delete_returns_only_a_reason(self, monkeypatch):
         seen = {}

--- a/tests/test_managed_config.py
+++ b/tests/test_managed_config.py
@@ -118,6 +118,15 @@ class TestNormalize:
         assert cfg["budget_policy"]["budget_id"] == "c6563b45-df9a-4b19-afb2-d42dc2b52576"
         assert cfg["budget_policy"]["tiers"][1]["default_agent"] == "opencode"
 
+    def test_reads_top_level_display_name(self):
+        cfg = normalize_managed_config({**RAW_MANIFEST, "display_name": "paved-path"})
+        assert cfg["display_name"] == "paved-path"
+
+    def test_display_name_survives_the_serialize_round_trip(self):
+        manifest = normalize_managed_config({**RAW_MANIFEST, "display_name": "paved-path"})
+        assert serialize_managed_config(manifest)["display_name"] == "paved-path"
+        assert normalize_managed_config(serialize_managed_config(manifest)) == manifest
+
     @pytest.mark.parametrize("agent_enum", ["CODING_AGENT_FUTURE", "CODING_AGENT_UNSPECIFIED"])
     def test_unrecognized_agent_enum_dropped(self, agent_enum):
         raw = {"enabled_agents": [{"agent": agent_enum, "config": {}}]}
@@ -252,7 +261,7 @@ class TestPersistence:
         assert managed_state_workspace() is None
 
     def test_loaded_config_serializes_to_a_json_encodable_payload(self, _managed_path):
-        # `ucode apply` POSTs the serialized config, so a manifest that survives a disk round-trip
+        # `ucode publish` POSTs the serialized config, so a manifest that survives a disk round-trip
         # must still serialize to something json.dumps accepts with no custom encoder.
         cfg = normalize_managed_config(RAW_MANIFEST)
         save_managed_state("https://ws.example.com", cfg)

--- a/tests/test_managed_export.py
+++ b/tests/test_managed_export.py
@@ -142,7 +142,7 @@ class TestExportCommandFile:
 
         dest = tmp_path / "config.json"
         with _with_manifest(FULL_MANIFEST):
-            export_mod.export_command(output=str(dest))
+            export_mod.export_command(file_path=str(dest))
         captured = capsys.readouterr()
         assert captured.out == ""
         assert dest.read_text(encoding="utf-8") == stdout_bytes
@@ -150,7 +150,7 @@ class TestExportCommandFile:
     def test_expands_user_home_in_output_path(self, capsys, tmp_path, monkeypatch):
         monkeypatch.setenv("HOME", str(tmp_path))
         with _with_manifest(FULL_MANIFEST):
-            export_mod.export_command(output="~/config.json")
+            export_mod.export_command(file_path="~/config.json")
         capsys.readouterr()
         assert (tmp_path / "config.json").exists()
 
@@ -158,7 +158,7 @@ class TestExportCommandFile:
         dest = tmp_path / "config.json"
         dest.write_text("stale contents", encoding="utf-8")
         with _with_manifest(FULL_MANIFEST):
-            export_mod.export_command(output=str(dest))
+            export_mod.export_command(file_path=str(dest))
         assert json.loads(dest.read_text(encoding="utf-8"))["default_agent"] == (
             "CODING_AGENT_CLAUDE_CODE"
         )
@@ -169,7 +169,7 @@ class TestExportCommandFile:
         invalid = {"enabled_agents": {"claude": {}}}
         with _with_manifest(invalid):
             with pytest.raises(RuntimeError):
-                export_mod.export_command(output=str(dest))
+                export_mod.export_command(file_path=str(dest))
         assert dest.read_text(encoding="utf-8") == "original"
 
     def test_invalid_config_does_not_create_destination(self, tmp_path):
@@ -177,7 +177,7 @@ class TestExportCommandFile:
         invalid = {"enabled_agents": {"claude": {}}}
         with _with_manifest(invalid):
             with pytest.raises(RuntimeError):
-                export_mod.export_command(output=str(dest))
+                export_mod.export_command(file_path=str(dest))
         assert not dest.exists()
 
     def test_missing_parent_directory_fails_without_creating_it(self, tmp_path):
@@ -185,7 +185,7 @@ class TestExportCommandFile:
         dest = missing_parent / "config.json"
         with _with_manifest(FULL_MANIFEST):
             with pytest.raises(RuntimeError, match="parent directory does not exist"):
-                export_mod.export_command(output=str(dest))
+                export_mod.export_command(file_path=str(dest))
         assert not missing_parent.exists()
 
     def test_write_failure_is_actionable_and_leaves_no_temp_file(self, tmp_path):
@@ -193,7 +193,7 @@ class TestExportCommandFile:
         dest.mkdir()
         with _with_manifest(FULL_MANIFEST):
             with pytest.raises(RuntimeError, match="Failed to write"):
-                export_mod.export_command(output=str(dest))
+                export_mod.export_command(file_path=str(dest))
         leftovers = [p.name for p in tmp_path.iterdir() if p.name.startswith(".ucode-export-")]
         assert leftovers == []
 
@@ -231,11 +231,11 @@ class TestExportCLI:
         result = runner.invoke(app, ["export", "--help"])
         assert result.exit_code == 0
         cleaned = _ANSI_RE.sub("", result.output)
-        assert "--output" in cleaned
-        assert "-o" in cleaned
+        assert "--file" in cleaned
+        assert "-f" in cleaned
 
-    def test_long_and_short_output_flags_both_write_the_file(self, tmp_path):
-        for flag in ("--output", "-o"):
+    def test_long_and_short_file_flags_both_write_the_file(self, tmp_path):
+        for flag in ("--file", "-f"):
             dest = tmp_path / f"cfg{flag.strip('-')}.json"
             with _with_manifest(FULL_MANIFEST):
                 result = runner.invoke(app, ["export", flag, str(dest)])

--- a/tests/test_managed_publish.py
+++ b/tests/test_managed_publish.py
@@ -1,0 +1,159 @@
+"""Tests for :mod:`ucode.managed_publish` — the input handling behind `ucode publish`.
+
+Cover the two config sources (in-process export payload and a `-f` file), the envelope checks
+(workspace match, spec_version type and value), and the canonicalization that rejects server-owned,
+unknown, and lossy fields before anything reaches the workspace.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+import ucode.managed_publish as publish_mod
+from ucode.managed_publish import load_publish_payload, parse_publish_payload
+from ucode.managed_setup import serialize_managed_config
+
+WORKSPACE = "https://ws.example.com"
+
+MANIFEST = {
+    "default_agent": "claude",
+    "enabled_agents": {
+        "claude": {"model_config": {"default_model": "system.ai.claude-opus-4-8"}},
+        "codex": {"model_config": {"default_model": "system.ai.gpt-5-6"}},
+    },
+    "mcp_servers": [{"name": "system.ai.slack", "type": "mcp-service"}],
+    "skills": {"names": ["main.default"]},
+}
+
+
+def _payload(manifest=MANIFEST, *, workspace=WORKSPACE, spec_version=1, **extra):
+    config = serialize_managed_config(manifest)
+    config.pop("name", None)
+    return {"workspace": workspace, "spec_version": spec_version, **config, **extra}
+
+
+class TestLoadPublishPayload:
+    def test_no_file_uses_build_export_payload_in_process(self):
+        sentinel = {"workspace": WORKSPACE, "spec_version": 1}
+        with patch.object(publish_mod, "build_export_payload", return_value=sentinel) as build:
+            assert load_publish_payload(None) is sentinel
+        build.assert_called_once_with()
+
+    def test_reads_json_file(self, tmp_path):
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps(_payload()), encoding="utf-8")
+        assert load_publish_payload(str(path)) == _payload()
+
+    def test_expands_user_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / "config.json").write_text(json.dumps(_payload()), encoding="utf-8")
+        assert load_publish_payload("~/config.json")["workspace"] == WORKSPACE
+
+    def test_missing_file_is_actionable(self, tmp_path):
+        with pytest.raises(RuntimeError, match="No config file"):
+            load_publish_payload(str(tmp_path / "absent.json"))
+
+    def test_malformed_json_is_actionable(self, tmp_path):
+        path = tmp_path / "config.json"
+        path.write_text("{not json", encoding="utf-8")
+        with pytest.raises(RuntimeError, match="not valid JSON"):
+            load_publish_payload(str(path))
+
+    def test_non_object_root_is_rejected(self, tmp_path):
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps([1, 2, 3]), encoding="utf-8")
+        with pytest.raises(RuntimeError, match="JSON object at the top level"):
+            load_publish_payload(str(path))
+
+    def test_non_utf8_is_actionable(self, tmp_path):
+        path = tmp_path / "config.json"
+        path.write_bytes(b"\xff\xfe not utf-8")
+        with pytest.raises(RuntimeError, match="UTF-8"):
+            load_publish_payload(str(path))
+
+
+class TestParsePublishPayload:
+    def test_returns_manifest_and_api_payload(self):
+        manifest, api_payload = parse_publish_payload(_payload(), WORKSPACE)
+        assert manifest["default_agent"] == "claude"
+        assert set(manifest["enabled_agents"]) == {"claude", "codex"}
+        assert api_payload["spec_version"] == 1
+        assert api_payload["default_agent"] == "CODING_AGENT_CLAUDE_CODE"
+        assert "workspace" not in api_payload
+        assert "name" not in api_payload
+
+    def test_api_payload_matches_serialize_of_manifest(self):
+        manifest, api_payload = parse_publish_payload(_payload(), WORKSPACE)
+        canonical = serialize_managed_config(manifest)
+        assert api_payload == {"spec_version": 1, **canonical}
+
+    def test_non_object_payload_is_rejected(self):
+        with pytest.raises(RuntimeError, match="JSON object"):
+            parse_publish_payload([1, 2], WORKSPACE)
+
+    def test_missing_workspace_is_rejected(self):
+        payload = _payload()
+        del payload["workspace"]
+        with pytest.raises(RuntimeError, match="workspace"):
+            parse_publish_payload(payload, WORKSPACE)
+
+    def test_mismatched_workspace_is_rejected(self):
+        with pytest.raises(RuntimeError, match="configured workspace"):
+            parse_publish_payload(_payload(workspace="https://other.example.com"), WORKSPACE)
+
+    def test_workspace_match_ignores_scheme_and_trailing_slash(self):
+        manifest, _ = parse_publish_payload(_payload(workspace="ws.example.com/"), WORKSPACE)
+        assert manifest["default_agent"] == "claude"
+
+    def test_missing_spec_version_is_rejected(self):
+        payload = _payload()
+        del payload["spec_version"]
+        with pytest.raises(RuntimeError, match="spec_version"):
+            parse_publish_payload(payload, WORKSPACE)
+
+    def test_boolean_spec_version_is_rejected(self):
+        with pytest.raises(RuntimeError, match="spec_version"):
+            parse_publish_payload(_payload(spec_version=True), WORKSPACE)
+
+    def test_fractional_spec_version_is_rejected(self):
+        with pytest.raises(RuntimeError, match="spec_version"):
+            parse_publish_payload(_payload(spec_version=1.0), WORKSPACE)
+
+    def test_unsupported_spec_version_is_rejected(self):
+        with pytest.raises(RuntimeError, match="spec_version 2"):
+            parse_publish_payload(_payload(spec_version=2), WORKSPACE)
+
+    def test_server_owned_name_is_rejected(self):
+        with pytest.raises(RuntimeError, match="server-owned"):
+            parse_publish_payload(_payload(name="coding-agent-configs/abc"), WORKSPACE)
+
+    def test_server_owned_workspace_id_is_rejected(self):
+        with pytest.raises(RuntimeError, match="does not recognize"):
+            parse_publish_payload(_payload(workspace_id="123456"), WORKSPACE)
+
+    def test_unknown_top_level_field_is_rejected(self):
+        with pytest.raises(RuntimeError, match="does not recognize"):
+            parse_publish_payload(_payload(bogus="value"), WORKSPACE)
+
+    def test_nested_unknown_field_is_rejected(self):
+        payload = _payload()
+        payload["enabled_agents"][0]["config"] = {"unknown_setting": True}
+        with pytest.raises(RuntimeError, match="enabled_agents"):
+            parse_publish_payload(payload, WORKSPACE)
+
+    def test_key_order_does_not_matter(self):
+        config = serialize_managed_config(MANIFEST)
+        config.pop("name", None)
+        reordered = {**config, "spec_version": 1, "workspace": WORKSPACE}
+        manifest, api_payload = parse_publish_payload(reordered, WORKSPACE)
+        assert api_payload["spec_version"] == 1
+        assert manifest["default_agent"] == "claude"
+
+    def test_display_name_round_trips(self):
+        manifest_with_name = {**MANIFEST, "display_name": "paved-path"}
+        manifest, api_payload = parse_publish_payload(_payload(manifest_with_name), WORKSPACE)
+        assert manifest["display_name"] == "paved-path"
+        assert api_payload["display_name"] == "paved-path"

--- a/tests/test_managed_wizard.py
+++ b/tests/test_managed_wizard.py
@@ -1846,7 +1846,7 @@ class TestShowCommand:
         with patch.object(wizard, "load_state", return_value={"workspace": WORKSPACE}):
             assert wizard.show_command() == 0
 
-    def test_prints_the_apply_payload(self, capsys):
+    def test_prints_the_publish_payload(self, capsys):
         manifest = {
             "default_agent": "claude",
             "enabled_agents": {
@@ -1857,7 +1857,7 @@ class TestShowCommand:
         with patch.object(wizard, "load_state", return_value={"workspace": WORKSPACE}):
             assert wizard.show_command() == 0
         out = capsys.readouterr().out
-        # The proto enum spelling is what `apply` sends, so it must appear verbatim.
+        # The proto enum spelling is what `publish` sends, so it must appear verbatim.
         assert "CODING_AGENT_CLAUDE_CODE" in out
 
 
@@ -2137,14 +2137,14 @@ class TestNextSteps:
         assert "ucode setup mcps" in out
         assert "ucode setup skills" in out
         assert "ucode setup spend-tiers" in out
-        assert "ucode apply" in out
+        assert "ucode publish" in out
 
     def test_dry_run_says_nothing_was_saved(self, capsys, monkeypatch):
         monkeypatch.setattr(config_io_mod, "_dry_run", True)
         wizard._print_next_steps(AGENTS_ONLY)
         out = capsys.readouterr().out
         assert "Dry run" in out
-        assert "ucode apply" not in out
+        assert "ucode publish" not in out
 
 
 class TestSectionCommands:
@@ -2159,7 +2159,7 @@ class TestSectionCommands:
             "get_databricks_token": lambda *a, **k: "tok",
             "is_workspace_admin": lambda *a, **k: True,
             # Decline the end-of-section "publish now?" offer so a section run saves the draft without
-            # trying to apply; the apply path is exercised in TestApplyCommand.
+            # trying to publish; the publish path is exercised in TestPublishCommand.
             "prompt_yes_no_default": lambda *a, **k: False,
         }
         defaults.update(overrides)
@@ -2313,12 +2313,12 @@ class TestSetupHelp:
             "ucode setup skills",
             "ucode setup spend-tiers",
             "ucode setup show",
-            "ucode apply",
+            "ucode publish",
         ):
             assert command in out
 
 
-class TestApplyDiff:
+class TestPublishDiff:
     def test_lists_added_removed_and_changed(self, capsys):
         existing = {
             "name": "cfg/1",
@@ -2342,8 +2342,16 @@ class TestApplyDiff:
     def test_identical_configs_report_no_change(self, capsys):
         assert wizard._render_config_diff(AGENTS_ONLY, AGENTS_ONLY, WORKSPACE) is False
 
+    def test_display_name_change_is_detected(self, capsys):
+        existing = {"display_name": "old-name", **AGENTS_ONLY}
+        incoming = {"display_name": "new-name", **AGENTS_ONLY}
+        changed = wizard._render_config_diff(existing, incoming, WORKSPACE)
+        out = capsys.readouterr().out
+        assert changed is True
+        assert "old-name" in out and "new-name" in out
 
-class TestApplyCommand:
+
+class TestPublishCommand:
     MANIFEST = {
         "default_agent": "claude",
         "enabled_agents": {
@@ -2353,7 +2361,7 @@ class TestApplyCommand:
 
     @staticmethod
     def _patches(**overrides):
-        """The network/auth boundary `apply_command` sits behind, with per-test overrides."""
+        """The network/auth boundary `publish_command` sits behind, with per-test overrides."""
         defaults = {
             "load_state": lambda: {"workspace": WORKSPACE, "profile": "p", **STATE},
             "ensure_databricks_auth": lambda *a, **k: None,
@@ -2373,18 +2381,27 @@ class TestApplyCommand:
         defaults.update(overrides)
         return [patch.object(wizard, name, value) for name, value in defaults.items()]
 
-    def _run(self, *, yes=False, **overrides):
+    def _run(self, *, yes=False, file_path=None, **overrides):
         import contextlib
 
         with contextlib.ExitStack() as stack:
             for p in self._patches(**overrides):
                 stack.enter_context(p)
-            return wizard.apply_command(yes=yes)
+            return wizard.publish_command(file_path=file_path, yes=yes)
+
+    @staticmethod
+    def _config_file(tmp_path, manifest, *, workspace=WORKSPACE, spec_version=1, **extra):
+        config = serialize_managed_config(manifest)
+        config.pop("name", None)
+        payload = {"workspace": workspace, "spec_version": spec_version, **config, **extra}
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        return str(path)
 
     def test_unauthored_config_is_an_actionable_error(self):
         with patch.object(wizard, "load_state", return_value={"workspace": WORKSPACE}):
             with pytest.raises(RuntimeError, match="ucode setup"):
-                wizard.apply_command()
+                wizard.publish_command()
 
     def test_creates_when_no_config_exists(self):
         managed_config_mod.save_managed_state(WORKSPACE, self.MANIFEST)
@@ -2430,7 +2447,7 @@ class TestApplyCommand:
         # Publishing a config identical to what's live is a no-op; say so and skip the write rather
         # than PATCH the same bytes back.
         managed_config_mod.save_managed_state(WORKSPACE, self.MANIFEST)
-        # What's live is the manifest normalized the same way `apply` will send it.
+        # What's live is the manifest normalized the same way `publish` will send it.
         existing = {
             "name": "coding-agent-configs/abc",
             **managed_config_mod.normalize_managed_config(serialize_managed_config(self.MANIFEST)),
@@ -2451,7 +2468,6 @@ class TestApplyCommand:
         assert updated["called"] is False
 
     def test_invalid_manifest_is_not_published(self):
-        # `default_agent` names an agent that isn't enabled.
         managed_config_mod.save_managed_state(
             WORKSPACE, {"default_agent": "codex", "enabled_agents": {"claude": {}}}
         )
@@ -2461,15 +2477,16 @@ class TestApplyCommand:
             created["called"] = True
             return {}, None
 
-        assert self._run(create_coding_agent_config=fake_create) == 1
+        with pytest.raises(RuntimeError, match="not valid"):
+            self._run(create_coding_agent_config=fake_create)
         assert created["called"] is False
 
     def test_an_older_family_version_the_wizard_offered_still_publishes(self):
         # `setup` offers every version of a Claude family, but `claude_models` keeps only the newest
         # per family and the wizard's `all_claude_models` stash is never persisted — so a separate
-        # `apply` process used to reject a model it had just offered:
+        # `publish` process used to reject a model it had just offered:
         #   claude: model 'system.ai.claude-opus-4-1' is not available on this workspace.
-        # `apply` re-fetches the full listing rather than trusting what `setup` left in state.
+        # `publish` re-fetches the full listing rather than trusting what `setup` left in state.
         managed_config_mod.save_managed_state(
             WORKSPACE,
             {
@@ -2599,6 +2616,100 @@ class TestApplyCommand:
         with pytest.raises(RuntimeError, match="resource name"):
             self._run(get_managed_config=lambda *a, **k: ({"enabled_agents": {}}, None))
 
+    def test_file_input_creates_and_sends_spec_version_without_workspace(self, tmp_path):
+        path = self._config_file(tmp_path, self.MANIFEST)
+        created = {}
+
+        def fake_create(workspace, token, payload):
+            created.update(workspace=workspace, payload=payload)
+            return {"name": "coding-agent-configs/new"}, None
+
+        assert self._run(file_path=path, create_coding_agent_config=fake_create) == 0
+        assert created["workspace"] == WORKSPACE
+        assert created["payload"]["spec_version"] == 1
+        assert "workspace" not in created["payload"]
+        assert "name" not in created["payload"]
+        assert created["payload"]["default_agent"] == "CODING_AGENT_CLAUDE_CODE"
+
+    def test_file_input_updates_in_place_and_sends_spec_version(self, tmp_path):
+        path = self._config_file(tmp_path, self.MANIFEST)
+        existing = {"name": "coding-agent-configs/abc", "enabled_agents": {"codex": {}}}
+        updated = {}
+
+        def fake_update(workspace, token, name, payload):
+            updated.update(name=name, payload=payload)
+            return {"name": name}, None
+
+        assert (
+            self._run(
+                file_path=path,
+                get_managed_config=lambda *a, **k: (existing, None),
+                update_coding_agent_config=fake_update,
+            )
+            == 0
+        )
+        assert updated["name"] == "coding-agent-configs/abc"
+        assert updated["payload"]["spec_version"] == 1
+        assert "workspace" not in updated["payload"]
+
+    def test_file_workspace_mismatch_aborts_before_auth_or_mutation(self, tmp_path):
+        path = self._config_file(tmp_path, self.MANIFEST, workspace="https://other.example.com")
+        called = {"auth": False, "create": False}
+
+        def fake_auth(*a, **k):
+            called["auth"] = True
+
+        def fake_create(*a, **k):
+            called["create"] = True
+            return {}, None
+
+        with pytest.raises(RuntimeError, match="configured workspace"):
+            self._run(
+                file_path=path,
+                ensure_databricks_auth=fake_auth,
+                create_coding_agent_config=fake_create,
+            )
+        assert called == {"auth": False, "create": False}
+
+    def test_file_bad_spec_version_aborts_before_auth(self, tmp_path):
+        path = self._config_file(tmp_path, self.MANIFEST, spec_version=2)
+        called = {"auth": False}
+
+        def fake_auth(*a, **k):
+            called["auth"] = True
+
+        with pytest.raises(RuntimeError, match="spec_version"):
+            self._run(file_path=path, ensure_databricks_auth=fake_auth)
+        assert called["auth"] is False
+
+    def test_missing_file_is_actionable(self, tmp_path):
+        with pytest.raises(RuntimeError, match="No config file"):
+            self._run(file_path=str(tmp_path / "absent.json"))
+
+    def test_no_file_publishes_a_hand_entered_custom_model(self):
+        managed_config_mod.save_managed_state(
+            WORKSPACE,
+            {
+                "default_agent": "codex",
+                "enabled_agents": {
+                    "codex": {
+                        "model_config": {
+                            "default_model": "main.custom.model",
+                            "custom_models": ["main.custom.model"],
+                        }
+                    }
+                },
+            },
+        )
+        created = {"called": False}
+
+        def fake_create(*a, **k):
+            created["called"] = True
+            return {"name": "coding-agent-configs/new"}, None
+
+        assert self._run(create_coding_agent_config=fake_create) == 0
+        assert created["called"] is True
+
 
 class TestPublishFailureMessages:
     """The server's error codes, turned into something an admin can act on."""
@@ -2651,30 +2762,47 @@ class TestCliWiring:
         assert result.exit_code == 0
         assert "show" in result.output
 
-    def test_apply_is_registered(self):
+    def test_publish_is_registered(self):
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0
-        assert "apply" in result.output
+        assert "publish" in result.output
 
-    def test_apply_declares_yes_and_no_dry_run(self):
-        # `--dry-run` was removed: apply always validates before publishing, so a separate
+    def test_publish_declares_yes_and_no_dry_run(self):
+        # `--dry-run` was removed: publish always validates before publishing, so a separate
         # validate-only mode is redundant. Asserted on declared options rather than rendered help,
         # which Rich ellipsizes at narrow widths (see test_setup_help_lists_from_file).
-        command = typer.main.get_command(app).commands["apply"]  # type: ignore[attr-defined]
+        command = typer.main.get_command(app).commands["publish"]  # type: ignore[attr-defined]
         declared = {opt for param in command.params for opt in param.opts}
         assert "--yes" in declared
         assert "--dry-run" not in declared
 
-    def test_apply_error_exits_nonzero_with_a_message(self):
-        with patch.object(cli_mod, "apply_command", side_effect=RuntimeError("no config authored")):
-            result = runner.invoke(app, ["apply"])
+    def test_publish_declares_file_option(self):
+        command = typer.main.get_command(app).commands["publish"]  # type: ignore[attr-defined]
+        declared = {opt for param in command.params for opt in param.opts}
+        assert "--file" in declared
+        assert "-f" in declared
+
+    def test_publish_file_flag_is_forwarded(self):
+        for flag in ("-f", "--file"):
+            with (
+                patch("ucode.cli.install_databricks_cli"),
+                patch.object(cli_mod, "publish_command", return_value=0) as publish,
+            ):
+                runner.invoke(app, ["publish", flag, "/tmp/cfg.json"])
+            assert publish.call_args.kwargs["file_path"] == "/tmp/cfg.json"
+
+    def test_publish_error_exits_nonzero_with_a_message(self):
+        with patch.object(
+            cli_mod, "publish_command", side_effect=RuntimeError("no config authored")
+        ):
+            result = runner.invoke(app, ["publish"])
         assert result.exit_code == 1
 
-    def test_successful_apply_exits_zero(self):
+    def test_successful_publish_exits_zero(self):
         # Same trap as `setup`: `typer.Exit` subclasses RuntimeError, so raising it inside the
         # command's try block would report success as "ERROR 0".
-        with patch.object(cli_mod, "apply_command", return_value=0):
-            result = runner.invoke(app, ["apply"])
+        with patch.object(cli_mod, "publish_command", return_value=0):
+            result = runner.invoke(app, ["publish"])
         assert result.exit_code == 0
         assert "ERROR" not in result.output
 


### PR DESCRIPTION
Rename the admin publish command from `ucode apply` to `ucode publish` and rename `ucode export`'s output flag from --output/-o to --file/-f, so the export-write and publish-read flags match.

`ucode publish` now takes an optional config file:
- with no file, it publishes the locally authored config (built in-process);
- with -f/--file, it publishes a config file produced by `ucode export`.

Both modes feed the same parser and enter the same validation and publication path. A file input must carry a top-level workspace that matches the configured one (stripped before the API request) and a spec_version that is the integer 1; server-owned and unknown or lossy fields are rejected. spec_version is kept in create and update requests and added to the update mask. The existing diff, no-op, confirmation, and update-in-place behavior is unchanged.