### PR TITLE
test: isolate OS managed config writes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,16 +21,26 @@ def _isolate_ucode_state(tmp_path, monkeypatch):
     """Redirect ucode's state file and APP_DIR to a per-test tmp dir.
 
     Defense in depth: even if an individual test forgets to patch save_state,
-    it can never touch the developer's real ~/.ucode/state.json.
+    it can never touch the developer's real ~/.ucode/state.json or invoke the
+    privileged writer for an OS-managed agent config.
     """
     import ucode.config_io as config_io_mod
     import ucode.databricks as databricks_mod
+    import ucode.managed_files as managed_files_mod
     import ucode.state as state_mod
 
     state_dir = tmp_path / ".ucode"
     state_dir.mkdir()
     monkeypatch.setattr(state_mod, "STATE_PATH", state_dir / "state.json")
     monkeypatch.setattr(config_io_mod, "APP_DIR", state_dir)
+
+    def reject_privileged_write(path, _desired_text):
+        pytest.fail(
+            f"test attempted a privileged managed-config write to {path}; "
+            "mock the agent's managed path and writer"
+        )
+
+    monkeypatch.setattr(managed_files_mod, "_sudo_replace", reject_privileged_write)
     # Isolate the managed-config opt-in from the developer's own shell: leaving it set changes what
     # `ucode`/`ucode configure` do mid-test. Tests that exercise the managed path set it explicitly.
     monkeypatch.delenv("ENABLE_MANAGED_AGENT_CONFIG", raising=False)

--- a/tests/test_managed_resolve.py
+++ b/tests/test_managed_resolve.py
@@ -230,11 +230,19 @@ class TestStateFileIsNotRewritten:
 
     @pytest.fixture
     def real_state_file(self, tmp_path, monkeypatch):
-        """Redirect state.json and the claude settings file into tmp_path, unstubbed."""
+        """Redirect state.json and both Claude settings files into tmp_path, unstubbed."""
         monkeypatch.setattr(config_io, "APP_DIR", tmp_path)
         monkeypatch.setattr(state_mod, "STATE_PATH", tmp_path / "state.json")
         monkeypatch.setattr(claude, "CLAUDE_SETTINGS_PATH", tmp_path / "ucode-settings.json")
         monkeypatch.setattr(claude, "CLAUDE_BACKUP_PATH", tmp_path / "backup.json")
+        managed_settings_path = tmp_path / "managed-settings.json"
+        monkeypatch.setattr(claude, "_managed_settings_path", lambda: managed_settings_path)
+
+        def write_managed_file(path, desired_text, *, display):
+            path.write_text(desired_text, encoding="utf-8")
+            return "written"
+
+        monkeypatch.setattr(claude, "write_managed_file", write_managed_file)
         # Seed a developer whose own opus choice differs from the manifest's.
         state_mod.save_state(
             {
@@ -268,6 +276,8 @@ class TestStateFileIsNotRewritten:
 
         env = json.loads((real_state_file / "ucode-settings.json").read_text())["env"]
         assert env["ANTHROPIC_DEFAULT_OPUS_MODEL"].startswith("system.ai.claude-opus-5")
+        managed_env = json.loads((real_state_file / "managed-settings.json").read_text())["env"]
+        assert managed_env["ANTHROPIC_DEFAULT_OPUS_MODEL"].startswith("system.ai.claude-opus-5")
 
     def test_overlay_bookkeeping_never_lands_on_disk(self, real_state_file):
         resolved_state = resolve_state(MANAGED, state_mod.load_state(), "claude")


### PR DESCRIPTION
## Summary
- make the pytest suite fail closed before any unmocked OS-managed config write can reach the sudo-backed writer
- redirect the managed-resolution persistence tests to a temporary `managed-settings.json`
- retain coverage that both user-level and machine-wide Claude settings receive the managed model

## Root cause
`TestStateFileIsNotRewritten` uses a fake workspace together with a managed manifest that enables `use_as_global_settings`. Its fixture redirected `state.json` and the user-level Claude settings file, but not Claude Code's OS-managed settings path or privileged writer.

Calling `claude.write_tool_config` therefore reached the real `/etc/claude-code/managed-settings.json`. On a developer machine where sudo was available, running the test suite could merge the fake workspace routing and auth configuration into the real machine-wide file.

## Fix
- patch `managed_files._sudo_replace` in the suite-wide isolation fixture to fail any test that reaches an unmocked privileged write
- give the affected persistence fixture a temporary managed-settings path and a local writer
- assert the temporary managed file still receives the expected model, so the production behavior remains covered

Production behavior is unchanged: ucode can still write the actual OS-managed config when an administrator explicitly enables global settings.

## Validation
- `uv run pytest tests/test_managed_resolve.py tests/test_managed_files.py tests/test_agent_claude.py::TestWriteToolConfigManagedSettings tests/test_agent_codex.py::TestCodexManagedConfig` — 86 passed
- `uv run ruff check tests/conftest.py tests/test_managed_resolve.py`
- `git diff --check`
- verified the real `/etc/claude-code/managed-settings.json` checksum and mtime remain unchanged during the focused suite

### Full-suite verification
- `uv run pytest` — 1988 passed, 39 skipped, 1 environment-specific failure
- the remaining failure is `TestCliWiring.test_successful_apply_exits_zero`, where the bootstrap installer refuses to overwrite this host's existing `/usr/local/bin/databricks`; it does not exercise managed config writes
- `/etc/claude-code/managed-settings.json` remained byte-for-byte identical before and after the suite (`sha256: 7544dc52fb73317e3699b30724e81b46f82de8bac4a360e88cfcbda0b79d253a`), with unchanged mtime, ownership, mode, size, and file attributes
