### PR TITLE
Add first-prompt routing to Codex interposer

### DIFF
--- a/src/ucode/smart_routing/codex_interposer.py
+++ b/src/ucode/smart_routing/codex_interposer.py
@@ -22,6 +22,7 @@ TURN_STARTED = "turn/started"
 
 RouteDecisionFn = Callable[[str], tuple[routing.RoutingDecision | None, str | None]]
 SwitchMessageFn = Callable[[str, str], str]
+TokenProvider = Callable[[], str]
 
 
 def _prompt_from_turn(params: dict) -> str | None:
@@ -211,16 +212,20 @@ async def _handle_tui(
     switch_message: str | None = None,
     available_models: list[str] | None = None,
     workspace: str | None = None,
-    token: str | None = None,
+    token_provider: TokenProvider | None = None,
     switch_message_fn: SwitchMessageFn | None = None,
 ) -> None:
     path = getattr(getattr(tui, "request", None), "path", "/") or "/"
     uri = upstream_uri.rstrip("/") + path
     log(f"[CONN] TUI connected (path={path}); dialing app-server {uri}")
     route_decision: RouteDecisionFn | None = None
-    if workspace is not None and token is not None:
+    if workspace is not None and token_provider is not None:
 
         def route_decision(prompt: str):
+            try:
+                token = token_provider()
+            except RuntimeError as exc:
+                return None, f"could not refresh workspace auth: {exc}"
             return _request_routing_decision(
                 workspace,
                 token,
@@ -275,7 +280,7 @@ async def _serve(
     switch_message: str | None = None,
     available_models: list[str] | None = None,
     workspace: str | None = None,
-    token: str | None = None,
+    token_provider: TokenProvider | None = None,
     switch_message_fn: SwitchMessageFn | None = None,
 ):
     async def handler(tui):
@@ -288,7 +293,7 @@ async def _serve(
                 switch_message,
                 available_models,
                 workspace,
-                token,
+                token_provider,
                 switch_message_fn,
             )
         except Exception as exc:  # noqa: BLE001
@@ -307,7 +312,7 @@ def start_interposer_thread(
     *,
     available_models: list[str] | None = None,
     workspace: str | None = None,
-    token: str | None = None,
+    token_provider: TokenProvider | None = None,
     switch_message_fn: SwitchMessageFn | None = None,
     switch_message: str | None = None,
     log_path: Path | None = None,
@@ -340,7 +345,7 @@ def start_interposer_thread(
                     switch_message,
                     available_models,
                     workspace,
-                    token,
+                    token_provider,
                     switch_message_fn,
                 )
             )

--- a/src/ucode/smart_routing/codex_interposer.py
+++ b/src/ucode/smart_routing/codex_interposer.py
@@ -12,23 +12,82 @@ from pathlib import Path
 from websockets.asyncio.client import connect
 from websockets.asyncio.server import serve
 
+from ucode.smart_routing import routing
+
 SETTINGS_UPDATED = "thread/settings/updated"
 ITEM_STARTED = "item/started"
 ITEM_COMPLETED = "item/completed"
 TURN_START = "turn/start"
 TURN_STARTED = "turn/started"
 
+RouteDecisionFn = Callable[[str], tuple[routing.RoutingDecision | None, str | None]]
+SwitchMessageFn = Callable[[str, str], str]
+
+
+def _prompt_from_turn(params: dict) -> str | None:
+    """Extract the plaintext portions of a Codex ``turn/start`` input."""
+    raw_input = params.get("input")
+    if isinstance(raw_input, str):
+        return raw_input if raw_input.strip() else None
+    if not isinstance(raw_input, list):
+        return None
+
+    parts: list[str] = []
+    for item in raw_input:
+        if isinstance(item, str):
+            parts.append(item)
+        elif isinstance(item, dict) and isinstance(item.get("text"), str):
+            parts.append(item["text"])
+    prompt = "\n".join(part for part in parts if part.strip())
+    return prompt or None
+
+
+def _request_routing_decision(
+    workspace: str,
+    token: str,
+    prompt: str,
+    available_models: list[str],
+    log: Callable[[str], None] | None = None,
+) -> tuple[routing.RoutingDecision | None, str | None]:
+    available = {routing.normalize_model(model): model for model in available_models}
+    route_options = [(model, "codex") for model in available]
+    if not route_options:
+        return None, "no cached model services are available"
+    if log is not None:
+        payload = {
+            "route_options": [
+                {"model": model, "harness": harness} for model, harness in route_options
+            ],
+            "task": {"prompt": prompt},
+            "route_selector": {"router_name": routing.ROUTER_NAME},
+        }
+        url = workspace.rstrip("/") + routing.ROUTING_PATH
+        log(f"[ROUTE] request POST {url}: {json.dumps(payload, separators=(',', ':'))}")
+    return routing.select_route(
+        workspace,
+        token,
+        prompt,
+        route_options,
+        lambda selected: available.get(routing.normalize_model(selected)),
+    )
+
 
 class _Session:
     def __init__(
         self,
-        target_model: str,
+        target_model: str | None,
         log: Callable[[str], None],
         switch_message: str | None = None,
+        available_models: list[str] | None = None,
+        route_decision: RouteDecisionFn | None = None,
+        switch_message_fn: SwitchMessageFn | None = None,
     ) -> None:
         self.target = target_model
+        self.available_models = list(available_models or [])
         self.log = log
         self.switch_message = switch_message
+        self.route_decision = route_decision
+        self.switch_message_fn = switch_message_fn
         self.thread_id: str | None = None
         self.settings: dict | None = None
         self.first_turn_seen = False
@@ -50,8 +109,21 @@ class _Session:
             if self.first_turn_seen:
                 return raw
             self.first_turn_seen = True
+            if self.route_decision is not None:
+                prompt = _prompt_from_turn(params)
+                if prompt is None:
+                    self.log("[ROUTE] first turn had no plaintext prompt; keeping current model")
+                    return raw
+                decision, reason = self.route_decision(prompt)
+                if decision is None:
+                    self.log(f"[ROUTE] selection failed; keeping current model: {reason}")
+                    return raw
+                self.target = decision.model
+                if self.switch_message_fn is not None:
+                    self.switch_message = self.switch_message_fn(decision.model, decision.rationale)
+                self.log(f"[ROUTE] selected {decision.model!r}; rationale={decision.rationale!r}")
             old = params.get("model")
-            if old != self.target:
+            if self.target is not None and old != self.target:
                 params["model"] = self.target
                 self.switch_pending = True
                 self.log(f"[REWRITE] model {old!r} -> {self.target!r}")
@@ -132,18 +204,48 @@ class _Session:
 
 
 async def _handle_tui(
-    tui, upstream_uri: str, target_model: str, log, switch_message: str | None = None
+    tui,
+    upstream_uri: str,
+    target_model: str | None,
+    log,
+    switch_message: str | None = None,
+    available_models: list[str] | None = None,
+    workspace: str | None = None,
+    token: str | None = None,
+    switch_message_fn: SwitchMessageFn | None = None,
 ) -> None:
     path = getattr(getattr(tui, "request", None), "path", "/") or "/"
     uri = upstream_uri.rstrip("/") + path
     log(f"[CONN] TUI connected (path={path}); dialing app-server {uri}")
-    sess = _Session(target_model, log, switch_message)
+    route_decision: RouteDecisionFn | None = None
+    if workspace is not None and token is not None:
+
+        def route_decision(prompt: str):
+            return _request_routing_decision(
+                workspace,
+                token,
+                prompt,
+                list(available_models or []),
+                log,
+            )
+
+    sess = _Session(
+        target_model,
+        log,
+        switch_message,
+        available_models,
+        route_decision,
+        switch_message_fn,
+    )
     async with connect(uri, max_size=None) as upstream:
 
         async def tui_to_app():
             async for frame in tui:
                 if isinstance(frame, str):
-                    frame = sess.on_tui_frame(frame)
+                    # Route selection is a blocking HTTP call. Keep it off the
+                    # WebSocket event loop while holding this first frame until
+                    # its selected model has been written into ``turn/start``.
+                    frame = await asyncio.to_thread(sess.on_tui_frame, frame)
                 await upstream.send(frame)
 
         async def app_to_tui():
@@ -168,13 +270,27 @@ async def _serve(
     host: str,
     port: int,
     upstream_uri: str,
-    model: str,
+    model: str | None,
     log,
     switch_message: str | None = None,
+    available_models: list[str] | None = None,
+    workspace: str | None = None,
+    token: str | None = None,
+    switch_message_fn: SwitchMessageFn | None = None,
 ):
     async def handler(tui):
         try:
-            await _handle_tui(tui, upstream_uri, model, log, switch_message)
+            await _handle_tui(
+                tui,
+                upstream_uri,
+                model,
+                log,
+                switch_message,
+                available_models,
+                workspace,
+                token,
+                switch_message_fn,
+            )
         except Exception as exc:  # noqa: BLE001
             log(f"[ERR] session: {exc!r}")
 
@@ -187,8 +303,12 @@ async def _serve(
 def start_interposer_thread(
     host: str,
     upstream_uri: str,
-    model: str,
+    model: str | None = None,
     *,
+    available_models: list[str] | None = None,
+    workspace: str | None = None,
+    token: str | None = None,
+    switch_message_fn: SwitchMessageFn | None = None,
     switch_message: str | None = None,
     log_path: Path | None = None,
     ready_timeout: float = 10.0,
@@ -211,7 +331,18 @@ def start_interposer_thread(
         asyncio.set_event_loop(loop)
         try:
             holder["server"] = loop.run_until_complete(
-                _serve(host, 0, upstream_uri, model, log, switch_message)
+                _serve(
+                    host,
+                    0,
+                    upstream_uri,
+                    model,
+                    log,
+                    switch_message,
+                    available_models,
+                    workspace,
+                    token,
+                    switch_message_fn,
+                )
             )
             holder["port"] = holder["server"].sockets[0].getsockname()[1]
         except Exception as exc:  # noqa: BLE001

--- a/src/ucode/smart_routing/routing.py
+++ b/src/ucode/smart_routing/routing.py
@@ -119,7 +119,7 @@ def select_route(
     workspace: str,
     token: str,
     task: str,
-    route_options: Iterable[tuple[str, str]],
+    route_options: Iterable[tuple[str, str | None]],
     resolve: Callable[[str], str | None],
     *,
     router_name: str = ROUTER_NAME,
@@ -135,7 +135,7 @@ def select_route(
     """
     body = {
         "route_options": [{"model": model, "harness": harness} for model, harness in route_options],
-        "task": {"prompt": task[:4000]},
+        "task": {"prompt": task},
         "route_selector": {"router_name": router_name},
     }
     request = urllib.request.Request(

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -123,8 +123,8 @@ def launch_codex(
             "Smart routing v2 could not determine a starting Codex model for this workspace."
         )
 
-    token = get_databricks_token(workspace, state.get("profile"))
-    os.environ[OAUTH_TOKEN_ENV_VAR] = token
+    profile = state.get("profile")
+    os.environ[OAUTH_TOKEN_ENV_VAR] = get_databricks_token(workspace, profile)
     available_models = _cached_routing_models(state)
     if not available_models:
         raise RuntimeError(
@@ -161,7 +161,7 @@ def launch_codex(
             app_server_url,
             available_models=available_models,
             workspace=workspace,
-            token=token,
+            token_provider=lambda: get_databricks_token(workspace, profile),
             switch_message_fn=_switch_message,
             log_path=CODEX_INTERPOSER_LOG,
         )

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -18,9 +18,7 @@ from ucode.smart_routing import codex_interposer
 
 ENV_VAR = "ENABLE_SMART_ROUTING_V2"
 
-CODEX_TARGET_MODEL = "system.ai.glm-5-2"  # TODO(lilly): replace with smart router.
 CODEX_INTERPOSER_LOG = APP_DIR / "codex-v2-interposer.log"
-CODEX_SWITCH_REASON = "Low complexity, unclear intent, and no code reference."  # TODO(lilly): replace with smart router rationale.
 
 APP_SERVER_READY_TIMEOUT_SECONDS = 30
 PROCESS_SHUTDOWN_TIMEOUT_SECONDS = 5
@@ -96,6 +94,17 @@ def _codex_config_args(overlay: dict) -> list[str]:
     return args
 
 
+# TODO: Replace with /codex/v1/models once /codex/v1/models can send GPT models as well.
+def _cached_routing_models(state: dict) -> list[str]:
+    """Return the persisted UC model-service ids usable by Codex routing."""
+    models: list[str] = []
+    for key in ("codex_models", "oss_models"):
+        values = state.get(key)
+        if isinstance(values, list):
+            models.extend(value for value in values if isinstance(value, str) and value)
+    return list(dict.fromkeys(models))
+
+
 def launch_codex(
     state: dict,
     tool_args: list[str],
@@ -114,7 +123,14 @@ def launch_codex(
             "Smart routing v2 could not determine a starting Codex model for this workspace."
         )
 
-    os.environ[OAUTH_TOKEN_ENV_VAR] = get_databricks_token(workspace, state.get("profile"))
+    token = get_databricks_token(workspace, state.get("profile"))
+    os.environ[OAUTH_TOKEN_ENV_VAR] = token
+    available_models = _cached_routing_models(state)
+    if not available_models:
+        raise RuntimeError(
+            "Smart routing v2 has no cached Unity Catalog model services; "
+            "run `ucode configure codex` to refresh them."
+        )
     overlay = render_overlay(
         workspace,
         start_model,
@@ -143,8 +159,10 @@ def launch_codex(
         tui_port, stop_interposer = codex_interposer.start_interposer_thread(
             LOOPBACK_HOST,
             app_server_url,
-            CODEX_TARGET_MODEL,
-            switch_message=_switch_message(CODEX_TARGET_MODEL, CODEX_SWITCH_REASON),
+            available_models=available_models,
+            workspace=workspace,
+            token=token,
+            switch_message_fn=_switch_message,
             log_path=CODEX_INTERPOSER_LOG,
         )
         tui_url = _loopback_websocket_url(tui_port)

--- a/tests/test_codex_routing.py
+++ b/tests/test_codex_routing.py
@@ -26,6 +26,7 @@ class _Response:
 
 def test_routes_with_task_v1_codex_menu(monkeypatch):
     captured = {}
+    task = "Refactor the parser" + "x" * 5000
 
     def fake_urlopen(request, timeout):
         captured["url"] = request.full_url
@@ -44,7 +45,7 @@ def test_routes_with_task_v1_codex_menu(monkeypatch):
     decision, error = codex_routing.request_routing_decision(
         WS,
         "token",
-        "Refactor the parser",
+        task,
         ["system.ai.gpt-5-6-luna", "system.ai.gpt-5-6-sol"],
     )
 
@@ -62,7 +63,7 @@ def test_routes_with_task_v1_codex_menu(monkeypatch):
             {"model": "gpt-5-6-sol", "harness": "codex"},
             {"model": "gpt-5-6-luna", "harness": "codex"},
         ],
-        "task": {"prompt": "Refactor the parser"},
+        "task": {"prompt": task},
         "route_selector": {"router_name": "task_v1"},
     }
 

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -80,6 +80,7 @@ class TestLaunchCodex:
         processes = []
         interposer_args = {}
         stopped = []
+        token_calls = []
         monkeypatch.setenv("CODEX_HOME", "/user/codex-home")
         monkeypatch.setattr(codex, "ucode_version", lambda: "0.1.0")
         monkeypatch.setattr(codex, "agent_version", lambda binary: "0.148.0")
@@ -104,7 +105,11 @@ class TestLaunchCodex:
                 raise AssertionError("test does not interrupt the TUI")
 
         monkeypatch.setattr(v2.subprocess, "Popen", FakeProcess)
-        monkeypatch.setattr(v2, "get_databricks_token", lambda workspace, profile: "token")
+        def get_token(workspace, profile):
+            token_calls.append((workspace, profile))
+            return f"token-{len(token_calls)}"
+
+        monkeypatch.setattr(v2, "get_databricks_token", get_token)
         monkeypatch.setattr(v2, "_free_port", lambda: 41001)
         monkeypatch.setattr(v2, "_wait_for_app_server", lambda port, timeout: True)
 
@@ -144,7 +149,7 @@ class TestLaunchCodex:
             "ws://127.0.0.1:41001",
         ]
         assert processes[0].argv[7].startswith("model_providers.ucode-databricks={")
-        assert processes[0].kwargs["env"][v2.OAUTH_TOKEN_ENV_VAR] == "token"
+        assert processes[0].kwargs["env"][v2.OAUTH_TOKEN_ENV_VAR] == "token-1"
         assert processes[0].kwargs["env"]["CODEX_HOME"] == "/user/codex-home"
         assert processes[1].argv == [
             "codex",
@@ -160,7 +165,9 @@ class TestLaunchCodex:
             "system.ai.glm-5-2",
         ]
         assert interposer_args["kwargs"]["workspace"] == WS
-        assert interposer_args["kwargs"]["token"] == "token"
+        assert token_calls == [(WS, "myprof")]
+        assert interposer_args["kwargs"]["token_provider"]() == "token-2"
+        assert token_calls == [(WS, "myprof"), (WS, "myprof")]
         assert interposer_args["kwargs"]["switch_message_fn"] is v2._switch_message
         assert stopped == [True]
         assert processes[0].terminated is True

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -117,7 +117,12 @@ class TestLaunchCodex:
 
         with pytest.raises(SystemExit) as exc:
             v2.launch_codex(
-                {"workspace": WS, "profile": "myprof"},
+                {
+                    "workspace": WS,
+                    "profile": "myprof",
+                    "codex_models": ["system.ai.gpt-5-6-sol"],
+                    "oss_models": ["system.ai.glm-5-2"],
+                },
                 ["--search"],
                 binary="codex",
                 start_model="gpt-start",
@@ -149,14 +154,28 @@ class TestLaunchCodex:
             "gpt-start",
             "--search",
         ]
-        assert interposer_args["args"] == (
-            v2.LOOPBACK_HOST,
-            "ws://127.0.0.1:41001",
-            v2.CODEX_TARGET_MODEL,
-        )
-        assert "Using Unity Gateway Smart Router." in interposer_args["kwargs"]["switch_message"]
+        assert interposer_args["args"] == (v2.LOOPBACK_HOST, "ws://127.0.0.1:41001")
+        assert interposer_args["kwargs"]["available_models"] == [
+            "system.ai.gpt-5-6-sol",
+            "system.ai.glm-5-2",
+        ]
+        assert interposer_args["kwargs"]["workspace"] == WS
+        assert interposer_args["kwargs"]["token"] == "token"
+        assert interposer_args["kwargs"]["switch_message_fn"] is v2._switch_message
         assert stopped == [True]
         assert processes[0].terminated is True
+
+    def test_missing_cached_models_blocks_launch(self, monkeypatch):
+        monkeypatch.setattr(v2, "get_databricks_token", lambda workspace, profile: "token")
+
+        with pytest.raises(RuntimeError, match="ucode configure codex"):
+            v2.launch_codex(
+                {"workspace": WS},
+                [],
+                binary="codex",
+                start_model="gpt-start",
+                render_overlay=codex.render_overlay,
+            )
 
 
 def test_interposer_startup_failure_is_propagated(monkeypatch):
@@ -176,12 +195,16 @@ def test_interposer_startup_failure_is_propagated(monkeypatch):
 
 
 class TestInterposerSession:
-    def _turn_start(self, model: str, thread_id: str = "t1") -> str:
+    def _turn_start(self, model: str, thread_id: str = "t1", prompt: str = "Fix the parser") -> str:
         return json.dumps(
             {
                 "method": codex_interposer.TURN_START,
                 "id": 1,
-                "params": {"threadId": thread_id, "input": [], "model": model},
+                "params": {
+                    "threadId": thread_id,
+                    "input": [{"type": "text", "text": prompt}],
+                    "model": model,
+                },
             }
         )
 
@@ -248,3 +271,105 @@ class TestInterposerSession:
         second_turn = self._turn_start("luna")
         assert sess.on_tui_frame(second_turn) == second_turn
         assert sess.on_engine_frame(self._turn_started("turn-2")) == []
+
+    def test_routes_first_prompt_and_uses_returned_model_and_rationale(self):
+        calls = []
+
+        def select(prompt):
+            calls.append(prompt)
+            return (
+                codex_interposer.routing.RoutingDecision(
+                    model="claude-opus-4-8",
+                    raw_model="claude-opus-4-8",
+                    rationale="Task classified as bugfix.",
+                ),
+                None,
+            )
+
+        sess = codex_interposer._Session(
+            None,
+            log=lambda _m: None,
+            available_models=["claude-opus-4-8", "gpt-5.5"],
+            route_decision=select,
+            switch_message_fn=v2._switch_message,
+        )
+
+        output = sess.on_tui_frame(self._turn_start("gpt-5.5", prompt="Fix issue #42"))
+
+        assert calls == ["Fix issue #42"]
+        assert json.loads(output)["params"]["model"] == "claude-opus-4-8"
+        assert "Task classified as bugfix." in sess.switch_message
+
+    def test_router_failure_keeps_original_model(self):
+        sess = codex_interposer._Session(
+            None,
+            log=lambda _m: None,
+            route_decision=lambda prompt: (None, "router unavailable"),
+        )
+        frame = self._turn_start("gpt-start")
+
+        assert sess.on_tui_frame(frame) == frame
+
+
+def test_routing_request_uses_models_prompt_and_same_token(monkeypatch):
+    captured = {}
+    logged = []
+
+    def select_route(workspace, token, task, route_options, resolve):
+        captured.update(
+            workspace=workspace,
+            token=token,
+            task=task,
+            route_options=list(route_options),
+        )
+        return (
+            codex_interposer.routing.RoutingDecision(
+                model=resolve("gpt-5-6-sol"),
+                raw_model="gpt-5-6-sol",
+                rationale="Bugfix needs deeper reasoning.",
+            ),
+            None,
+        )
+
+    monkeypatch.setattr(codex_interposer.routing, "select_route", select_route)
+
+    decision, reason = codex_interposer._request_routing_decision(
+        WS,
+        "same-oauth-token",
+        "Fix the parser",
+        [
+            "system.ai.kimi-k3-neo",
+            "system.ai.gpt-5-6-sol",
+            "system.ai.gpt-5-6-luna",
+            "system.ai.glm-5-2",
+        ],
+        logged.append,
+    )
+
+    assert reason is None
+    assert decision.model == "system.ai.gpt-5-6-sol"
+    assert captured == {
+        "workspace": WS,
+        "token": "same-oauth-token",
+        "task": "Fix the parser",
+        "route_options": [
+            ("kimi-k3-neo", "codex"),
+            ("gpt-5-6-sol", "codex"),
+            ("gpt-5-6-luna", "codex"),
+            ("glm-5-2", "codex"),
+        ],
+    }
+    assert len(logged) == 1
+    assert logged[0].startswith(f"[ROUTE] request POST {WS}/ai-gateway/routing/v1/routes:select: ")
+    request_payload = json.loads(logged[0].split(": ", 1)[1])
+    assert request_payload == {
+        "route_options": [
+            {"model": "kimi-k3-neo", "harness": "codex"},
+            {"model": "gpt-5-6-sol", "harness": "codex"},
+            {"model": "gpt-5-6-luna", "harness": "codex"},
+            {"model": "glm-5-2", "harness": "codex"},
+        ],
+        "task": {"prompt": "Fix the parser"},
+        "route_selector": {"router_name": "task_v1"},
+    }
+    assert "same-oauth-token" not in logged[0]

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -105,6 +105,7 @@ class TestLaunchCodex:
                 raise AssertionError("test does not interrupt the TUI")
 
         monkeypatch.setattr(v2.subprocess, "Popen", FakeProcess)
+
         def get_token(workspace, profile):
             token_calls.append((workspace, profile))
             return f"token-{len(token_calls)}"


### PR DESCRIPTION
## Summary
- route the first Codex prompt through task_v1 using the existing workspace token
- source all route options from cached Unity Catalog model services and mark them with the codex harness
- rewrite the app-server turn to the selected full system.ai model and log routing requests without credentials

## Testing
- 569 focused tests passed
- ruff checks passed
- full suite: 1,988 passed and 37 skipped; remaining failures require loopback sockets unavailable in the sandbox