### PR TITLE
Claude route selector api

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -2729,6 +2729,33 @@ def list_all_mcp_services(
     return sorted(names), None
 
 
+def list_anthropic_models(workspace: str, token: str) -> tuple[list[str], str | None]:
+    """List every model id advertised by AI Gateway's Anthropic endpoint.
+
+    Claude Code's native gateway discovery consumes this same catalog, so callers
+    using that mode must not apply ucode's legacy ``databricks-claude-*`` family
+    validation.
+    """
+    hostname = workspace_hostname(workspace)
+    payload, reason = _http_get_json(f"https://{hostname}/ai-gateway/anthropic/v1/models", token)
+    if payload is None:
+        return [], reason
+
+    data = cast(dict, payload) if isinstance(payload, dict) else {}
+    model_ids: list[str] = []
+    seen: set[str] = set()
+    for model in data.get("data", []):
+        if not isinstance(model, dict):
+            continue
+        model_id = model.get("id")
+        if isinstance(model_id, str) and model_id and model_id not in seen:
+            seen.add(model_id)
+            model_ids.append(model_id)
+    if model_ids:
+        return model_ids, None
+    return [], "AI Gateway returned no Anthropic model ids"
+
+
 def discover_claude_models(workspace: str, token: str) -> tuple[dict[str, str], str | None]:
     """Discover Claude families on this workspace's AI Gateway.
 

--- a/src/ucode/smart_routing/claude_pty.py
+++ b/src/ucode/smart_routing/claude_pty.py
@@ -276,7 +276,7 @@ def run_claude_pty(
     *,
     route_prompt: Callable[[str], str],
     socket_path: Path,
-    prepare_model_switch: Callable[[], None] = lambda: None,
+    prepare_model_switch: Callable[[str], None] = lambda _model: None,
     model_switch_persisted: Callable[[], bool] = lambda: True,
     restore_model_setting: Callable[[], None] = lambda: None,
     log_path: Path | None = None,
@@ -383,7 +383,7 @@ def run_claude_pty(
                 now = time.monotonic()
                 idle = last_output > 0.0 and now - last_output >= READY_QUIET_S
                 if phase == "waiting_to_switch" and idle:
-                    prepare_model_switch()
+                    prepare_model_switch(routed_model)
                     inject_model_switch(master_fd, routed_model)
                     confirm.arm(now + CONFIRM_TIMEOUT_S)
                     switch_complete = OutputMarkerDetector(("Set model to", "Model set to"))

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -126,18 +126,21 @@ class _ClaudeModelSettingGuard:
     def __init__(self, settings_path: Path) -> None:
         self.settings_path = settings_path
         self._before: dict | None = None
+        self._routed_model: str | None = None
         self._lock: TextIO | None = None
 
-    def begin(self) -> None:
+    def begin(self, routed_model: str) -> None:
         import fcntl
 
         APP_DIR.mkdir(parents=True, exist_ok=True)
         self._lock = open(APP_DIR / "claude-v2-model.lock", "a+", encoding="utf-8")
         fcntl.flock(self._lock, fcntl.LOCK_EX)
         self._before = read_json_safe(self.settings_path)
+        self._routed_model = routed_model
 
     def is_routed(self) -> bool:
-        return _is_claude_target_model(read_json_safe(self.settings_path).get("model"))
+        value = read_json_safe(self.settings_path).get("model")
+        return isinstance(value, str) and value == self._routed_model
 
     def restore(self) -> None:
         import fcntl
@@ -152,6 +155,7 @@ class _ClaudeModelSettingGuard:
                 current.pop("model", None)
             write_json_file(self.settings_path, current)
             self._before = None
+            self._routed_model = None
         finally:
             if self._lock is not None:
                 fcntl.flock(self._lock, fcntl.LOCK_UN)
@@ -204,12 +208,12 @@ def launch_claude(
 
     print_note(
         "Smart routing v2: the first submitted prompt will select Claude Code's "
-        f"model ({CLAUDE_TARGET_MODEL}); log: {CLAUDE_PTY_LOG}."
+        f"model; log: {CLAUDE_PTY_LOG}."
     )
     try:
         returncode = claude_pty.run_claude_pty(
             argv,
-            route_prompt=lambda prompt: _route_claude_prompt(state, token, prompt),
+            route_prompt=lambda prompt: _route_claude_prompt(state, token, prompt).model,
             socket_path=socket_path,
             prepare_model_switch=model_setting.begin,
             model_switch_persisted=model_setting.is_routed,

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -16,8 +16,12 @@ import tomlkit
 
 from ucode.config_io import APP_DIR, read_json_safe, write_json_file
 from ucode.constants import LOOPBACK_HOST
-from ucode.databricks import build_auth_token_argv, get_databricks_token
-from ucode.smart_routing import codex_interposer
+from ucode.databricks import (
+    build_auth_token_argv,
+    get_databricks_token,
+    list_anthropic_models,
+)
+from ucode.smart_routing import codex_interposer, routing
 from ucode.smart_routing.claude_hooks import FIRST_PROMPT_SOCKET_ENV, sync_first_prompt_hook
 from ucode.ui import print_note
 
@@ -34,6 +38,7 @@ PROCESS_SHUTDOWN_TIMEOUT_SECONDS = 5
 OAUTH_TOKEN_ENV_VAR = "OAUTH_TOKEN"
 HEALTH_REQUEST_TIMEOUT_SECONDS = 1
 HEALTH_POLL_INTERVAL_SECONDS = 0.25
+CLAUDE_ROUTE_SELECTION_TIMEOUT_S = 20.0
 
 
 def enabled() -> bool:
@@ -76,8 +81,39 @@ def _switch_message(model: str, reason: str) -> str:
     return "\n".join([f"┌{border}┐", *(f"│ {line:<{width}} │" for line in lines), f"└{border}┘"])
 
 
-def _route_claude_prompt(_prompt: str) -> str:
-    return CLAUDE_TARGET_MODEL
+def _canonical_claude_model_id(model: str) -> str:
+    """Use the system.ai id when Anthropic discovery returns a legacy alias."""
+    prefix = "databricks-claude-"
+    if model.startswith(prefix):
+        return f"system.ai.claude-{model[len(prefix) :]}"
+    return model
+
+
+def _route_claude_prompt(state: dict, token: str, prompt: str) -> routing.RoutingDecision:
+    workspace = state.get("workspace")
+    if not isinstance(workspace, str):
+        raise RuntimeError("workspace metadata is unavailable")
+
+    model_ids, discovery_error = list_anthropic_models(workspace, token)
+    if not model_ids:
+        raise RuntimeError(discovery_error or "Anthropic models endpoint returned no Claude models")
+
+    available: dict[str, str] = {}
+    for model in model_ids:
+        if isinstance(model, str) and model:
+            canonical = _canonical_claude_model_id(model)
+            available.setdefault(routing.normalize_model(canonical), canonical)
+    decision, error = routing.select_route(
+        workspace,
+        token,
+        prompt,
+        [(model, "claude") for model in available],
+        lambda selected: available.get(routing.normalize_model(selected)),
+        timeout=CLAUDE_ROUTE_SELECTION_TIMEOUT_S,
+    )
+    if decision is None:
+        raise RuntimeError(error or "router returned no Claude model selection")
+    return decision
 
 
 def _is_claude_target_model(value: object) -> bool:
@@ -142,7 +178,8 @@ def launch_claude(
         raise RuntimeError(
             "Smart routing v2 needs a configured workspace; run `ucode configure claude` first."
         )
-    os.environ[OAUTH_TOKEN_ENV_VAR] = get_databricks_token(workspace, state.get("profile"))
+    token = get_databricks_token(workspace, state.get("profile"))
+    os.environ[OAUTH_TOKEN_ENV_VAR] = token
     os.environ[GATEWAY_MODEL_DISCOVERY_ENV_VAR] = "1"
 
     run_id = f"{os.getpid()}-{uuid.uuid4().hex[:8]}"
@@ -172,7 +209,7 @@ def launch_claude(
     try:
         returncode = claude_pty.run_claude_pty(
             argv,
-            route_prompt=_route_claude_prompt,
+            route_prompt=lambda prompt: _route_claude_prompt(state, token, prompt),
             socket_path=socket_path,
             prepare_model_switch=model_setting.begin,
             model_switch_persisted=model_setting.is_routed,

--- a/tests/test_claude_smart_routing_v2.py
+++ b/tests/test_claude_smart_routing_v2.py
@@ -85,15 +85,24 @@ class TestV2Launch:
         monkeypatch.setattr(v2, "CLAUDE_PTY_LOG", tmp_path / "v2.log")
         monkeypatch.setattr(v2, "get_databricks_token", lambda *_args, **_kwargs: "token")
         monkeypatch.setattr(v2, "build_auth_token_argv", lambda *_args, **_kwargs: ["ucode"])
+        monkeypatch.setattr(
+            v2,
+            "_route_claude_prompt",
+            lambda *_args: v2.routing.RoutingDecision(
+                model="system.ai.claude-sonnet-5",
+                raw_model="claude-sonnet-5",
+            ),
+        )
         captured: dict = {}
 
         def fake_run(argv, **kwargs):
             captured["argv"] = argv
+            captured["routed_model"] = kwargs["route_prompt"]("fix the parser")
             generated = Path(argv[argv.index("--settings") + 1])
             captured["settings"] = json.loads(generated.read_text())
             # A user-selected model before the first prompt becomes the value to restore.
             user_settings.write_text(json.dumps({"model": "haiku", "theme": "dark"}))
-            kwargs["prepare_model_switch"]()
+            kwargs["prepare_model_switch"]("system.ai.claude-sonnet-5")
             # Simulate `/model` changing the user file, plus an unrelated concurrent edit.
             user_settings.write_text(json.dumps({"model": "routed", "theme": "light", "new": True}))
             kwargs["restore_model_setting"]()
@@ -118,6 +127,7 @@ class TestV2Launch:
 
         assert exc.value.code == 0
         assert captured["argv"][-3:] == ["--model", "opus", "--debug"]
+        assert captured["routed_model"] == "system.ai.claude-sonnet-5"
         assert claude_hooks.FIRST_PROMPT_SOCKET_ENV in captured["settings"]["env"]
         assert "modelPicker" not in captured["settings"]
         assert captured["restored_during_run"] == {
@@ -166,8 +176,9 @@ class TestV2Launch:
         monkeypatch.setattr(v2, "build_auth_token_argv", lambda *_args, **_kwargs: ["ucode"])
 
         def fake_run(_argv, **kwargs):
-            kwargs["prepare_model_switch"]()
-            user_settings.write_text(json.dumps({"model": v2.CLAUDE_TARGET_MODEL, "theme": "dark"}))
+            routed_model = "system.ai.claude-opus-4-8"
+            kwargs["prepare_model_switch"](routed_model)
+            user_settings.write_text(json.dumps({"model": routed_model, "theme": "dark"}))
             assert kwargs["model_switch_persisted"]() is True
             kwargs["restore_model_setting"]()
             assert json.loads(user_settings.read_text()) == {"model": "haiku", "theme": "dark"}
@@ -200,11 +211,11 @@ class TestV2Launch:
         second = v2._ClaudeModelSettingGuard(user_settings)
         captured: list[str] = []
 
-        first.begin()
-        user_settings.write_text(json.dumps({"model": v2.CLAUDE_TARGET_MODEL}))
+        first.begin("system.ai.claude-opus-4-8")
+        user_settings.write_text(json.dumps({"model": "system.ai.claude-opus-4-8"}))
 
         def run_second() -> None:
-            second.begin()
+            second.begin("system.ai.claude-sonnet-5")
             captured.append(json.loads(user_settings.read_text())["model"])
             second.restore()
 

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -161,6 +161,37 @@ class TestBuildSkillsMcpUrl:
 
 
 class TestDiscoverClaudeModels:
+    def test_lists_all_anthropic_model_ids_without_legacy_validation(self, monkeypatch):
+        captured = {}
+        payload = {
+            "data": [
+                {"id": "system.ai.claude-opus-5"},
+                {"id": "databricks-claude-sonnet-5"},
+                {"id": "opaque-model-id"},
+                {"id": "opaque-model-id"},
+                {"id": ""},
+            ]
+        }
+
+        def fake_get(url, token):
+            captured["request"] = (url, token)
+            return payload, None
+
+        monkeypatch.setattr(db_mod, "_http_get_json", fake_get)
+
+        models, reason = db_mod.list_anthropic_models(WS, "token")
+
+        assert reason is None
+        assert models == [
+            "system.ai.claude-opus-5",
+            "databricks-claude-sonnet-5",
+            "opaque-model-id",
+        ]
+        assert captured["request"] == (
+            f"{WS}/ai-gateway/anthropic/v1/models",
+            "token",
+        )
+
     def test_selects_opus_4_8_when_advertised(self, monkeypatch):
         payload = {
             "data": [


### PR DESCRIPTION
<img width="1088" height="671" alt="Screenshot 2026-08-27 at 8 41 10 PM" src="https://github.com/user-attachments/assets/a91d3020-b209-47f2-bbf2-912abbc0310b" />

## Testing
- [x] my first prompt routes to the smart routed model 
- [x] without smart routing, my prompt goes to my default value (not the model from the previous smart router session)
- [x] i can change the model via /model. 
- [x] i can change the model via /model and it stick for the next session 
- [x] normal ucode claude works. /model changes my default model there. 
- [x] model discovery works 
- [x] running /model before the first prompt
- [x] starting out w/ sonnet and routing to sonnet
- [x] --model works 