### PR TITLE
Pin Copilot CLI in e2e CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,13 +48,14 @@ jobs:
       # The agent launch tests `_require_binary("codex")` etc. and skip when
       # the CLI isn't on PATH. Install all six so each TestXxxLaunch test
       # actually runs instead of skipping.
+      # Pin Copilot because 1.0.81-6 sends unsupported parameters through BYOK providers.
       - name: Install agent CLIs
         run: npm install -g
           @anthropic-ai/claude-code
           @openai/codex
           @google/gemini-cli
           opencode-ai
-          @github/copilot
+          @github/copilot@1.0.80
           @earendil-works/pi-coding-agent
       - run: uv lock
       - run: uv tool install .


### PR DESCRIPTION
Pin the GitHub Copilot CLI used by e2e CI to 1.0.80. npm moved the latest tag to 1.0.81-6, which sends unsupported request parameters through BYOK providers and broke the Copilot model matrix on main. Verified the pinned package resolves as GitHub Copilot CLI 1.0.80.