### PR TITLE
[speed up ucode] Skip preflight for configured agent launches

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -1784,7 +1784,7 @@ def _launch_tool(
             profile=state.get("profile"),
             tools=[tool],
             skip_model_discovery=bool(provider) or managed_models_known,
-            skip_preflight=skip_preflight,
+            skip_preflight=skip_preflight or not needs_auto_configure,
         )
         # An admin-published managed config wins over the developer's own settings. Layered on after
         # `configure_shared_state`, whose returned state it overrides, and before the provider and

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2539,13 +2539,29 @@ class TestSkipPreflightFlag:
         assert result.exit_code == 0, result.output
         assert cfg.call_args.kwargs["skip_preflight"] is True
 
-    @pytest.mark.parametrize("tool", ["codex", "gemini"])
-    def test_absent_flag_defaults_false(self, tool):
+    @pytest.mark.parametrize("tool", LAUNCH_TOOLS)
+    def test_established_launch_skips_preflight_by_default(self, tool):
         cfg = MagicMock(return_value=MINIMAL_STATE)
         with contextlib.ExitStack() as stack:
             for p in self._patches(cfg):
                 stack.enter_context(p)
+            stack.enter_context(
+                patch(
+                    "ucode.cli.load_state",
+                    return_value={**MINIMAL_STATE, "available_tools": self.LAUNCH_TOOLS},
+                )
+            )
             result = runner.invoke(app, [tool])
+        assert result.exit_code == 0, result.output
+        assert cfg.call_args.kwargs["skip_preflight"] is True
+
+    def test_auto_configure_keeps_preflight(self):
+        cfg = MagicMock(return_value=MINIMAL_STATE)
+        with contextlib.ExitStack() as stack:
+            for p in self._patches(cfg):
+                stack.enter_context(p)
+            stack.enter_context(patch("ucode.cli.load_state", return_value={}))
+            result = runner.invoke(app, ["claude"])
         assert result.exit_code == 0, result.output
         assert cfg.call_args.kwargs["skip_preflight"] is False
 


### PR DESCRIPTION
Configured agent launches now trust their persisted preflight state instead of repeating Databricks auth, AI Gateway validation, and model discovery. First-run and auto-configured launches continue to run the full preflight.\n\nTests: PYTHONPATH=src pytest -q tests/test_cli.py; ruff check .; ruff format --check src tests

wall clock time with this change is 2s faster than without (4.4 vs 6.3) 

```
$ time ucode claude        
✔ Databricks auth already available for https://dbc-a5d4177a-49dc.cloud.databricks.com
✔ Unity AI Gateway detected

╭────────────────────────╮
│ ucode with Claude Code │
╰────────────────────────╯
  Model: system.ai.claude-opus-4-8
  Smart routing: enabled
✔ Starting Claude Code
ucode claude  4.15s user 1.23s system 85% cpu 6.327 total
# lilly.luo at ip-10-93-38-229 in ~/worktrees/ucode-demo (git:lilly/improve-launch-time) [0:01:21]
$ time uv run ucode claude

╭────────────────────────╮
│ ucode with Claude Code │
╰────────────────────────╯
  Model: system.ai.claude-opus-4-8
  Smart routing: enabled
✔ Starting Claude Code
uv run ucode claude  4.10s user 1.15s system 119% cpu 4.407 total
``` 

test 
- [x] ucode claude 
- [x] ucode codex (it's 2s faster)
- [x] `ucode claude --workspace xxxx` 
- [x] delete all my ~/.ucode stuff and `ucode claude` -should be slower to configure but work 