### PR TITLE
smart routing: route Claude subagents 

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -118,7 +118,7 @@ WEB_SEARCH_MCP_NAME = "web_search"
 # Matches both the AI Gateway form (`databricks-claude-opus-4-8`) and the UC
 # model-services form (`system.ai.claude-opus-4-8`).
 _CLAUDE_MODEL_RE = re.compile(
-    r"^(?:system\.ai\.)?(?:databricks-)?claude-(opus|sonnet)-(\d+)-(\d+)(.*)$"
+    r"^(?:system\.ai\.)?(?:databricks-)?claude-(opus|sonnet)-(\d+)(?:-(\d+))?(.*)$"
 )
 
 # Env keys the MLflow Stop hook reads to route traces. Written into the
@@ -438,7 +438,7 @@ def _maybe_add_1m_suffix(model: str) -> str:
 
     family, major_raw, minor_raw, _ = match.groups()
     major = int(major_raw)
-    minor = int(minor_raw)
+    minor = int(minor_raw or 0)
     should_suffix = (family == "opus" and (major, minor) >= (4, 6)) or (
         family == "sonnet" and (major, minor) >= (4, 6)
     )
@@ -1188,6 +1188,7 @@ def _launch_claude_with_gateway_proxy(
                 launch_model=_original_launch_model(state),
                 compose_settings=compose_gateway_settings,
                 launch_model_args=_launch_model_args,
+                model_name=_maybe_add_1m_suffix,
             )
             return
 

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -1480,13 +1480,22 @@ def claude_router_hook_cmd(
             token = get_databricks_token(host, profile)
         except RuntimeError:
             return
-    output = route_pre_tool_use(
-        payload,
-        workspace=host,
-        token=token,
-        available_models=model or [],
-        audit_decision=True,
-    )
+    if smart_routing_v2.enabled():
+        output = smart_routing_v2.route_claude_pre_tool_use(
+            payload,
+            workspace=host,
+            token=token,
+            available_models=model or [],
+            audit_decision=True,
+        )
+    else:
+        output = route_pre_tool_use(
+            payload,
+            workspace=host,
+            token=token,
+            available_models=model or [],
+            audit_decision=True,
+        )
     if output is not None:
         sys.stdout.write(json.dumps(output))
 

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -52,6 +52,7 @@ WINDOWS_DATABRICKS_INSTALL_URL = (
     "https://raw.githubusercontent.com/databricks/setup-cli/main/install.ps1"
 )
 AI_GATEWAY_V2_DOCS_URL = "https://docs.databricks.com/aws/en/ai-gateway/overview-beta"
+ANTHROPIC_MODELS_PATH = "/ai-gateway/anthropic/v1/models"
 # v1.0.0 is the release that ships `databricks aitools`.
 MIN_DATABRICKS_CLI_VERSION = (1, 0, 0)
 TOKEN_REFRESH_INTERVAL_SECONDS = 1800
@@ -2737,7 +2738,7 @@ def list_anthropic_models(workspace: str, token: str) -> tuple[list[str], str | 
     validation.
     """
     hostname = workspace_hostname(workspace)
-    payload, reason = _http_get_json(f"https://{hostname}/ai-gateway/anthropic/v1/models", token)
+    payload, reason = _http_get_json(f"https://{hostname}{ANTHROPIC_MODELS_PATH}", token)
     if payload is None:
         return [], reason
 
@@ -2764,7 +2765,7 @@ def discover_claude_models(workspace: str, token: str) -> tuple[dict[str, str], 
     matching the expected naming convention).
     """
     hostname = workspace_hostname(workspace)
-    payload, reason = _http_get_json(f"https://{hostname}/ai-gateway/anthropic/v1/models", token)
+    payload, reason = _http_get_json(f"https://{hostname}{ANTHROPIC_MODELS_PATH}", token)
     if payload is None:
         return {}, reason
 

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -2729,6 +2729,33 @@ def list_all_mcp_services(
     return sorted(names), None
 
 
+def list_anthropic_models(workspace: str, token: str) -> tuple[list[str], str | None]:
+    """List every model id advertised by AI Gateway's Anthropic endpoint.
+
+    Claude Code's native gateway discovery consumes this same catalog, so callers
+    using that mode must not apply ucode's legacy ``databricks-claude-*`` family
+    validation.
+    """
+    hostname = workspace_hostname(workspace)
+    payload, reason = _http_get_json(f"https://{hostname}/ai-gateway/anthropic/v1/models", token)
+    if payload is None:
+        return [], reason
+
+    data = cast(dict, payload) if isinstance(payload, dict) else {}
+    model_ids: list[str] = []
+    seen: set[str] = set()
+    for model in data.get("data", []):
+        if not isinstance(model, dict):
+            continue
+        model_id = model.get("id")
+        if isinstance(model_id, str) and model_id and model_id not in seen:
+            seen.add(model_id)
+            model_ids.append(model_id)
+    if model_ids:
+        return model_ids, None
+    return [], "AI Gateway returned no Anthropic model ids"
+
+
 def discover_claude_models(workspace: str, token: str) -> tuple[dict[str, str], str | None]:
     """Discover Claude families on this workspace's AI Gateway.
 

--- a/src/ucode/smart_routing/claude_pty.py
+++ b/src/ucode/smart_routing/claude_pty.py
@@ -161,9 +161,7 @@ def first_prompt_hook_output(response: dict | None) -> dict | None:
     rationale = response.get("rationale")
     return {
         "decision": "block",
-        "reason": format_routing_notice(
-            model, rationale if isinstance(rationale, str) else None
-        ),
+        "reason": format_routing_notice(model, rationale if isinstance(rationale, str) else None),
     }
 
 

--- a/src/ucode/smart_routing/claude_pty.py
+++ b/src/ucode/smart_routing/claude_pty.py
@@ -56,13 +56,14 @@ def valid_model_name(name: object) -> bool:
     )
 
 
-def switch_message(model: str, reason: str) -> str:
+def switch_message(model: str, rationale: str | None) -> str:
     """Format the routed-model notice shown in Claude Code."""
     lines = [
         "Using Unity Gateway Smart Router.",
         f"Selected Model : {model}",
-        f"Reason : {reason}",
     ]
+    if rationale:
+        lines.append(f"Reason : {rationale}")
     width = max(len(line) for line in lines)
     border = "─" * (width + 2)
     return "\n".join([f"┌{border}┐", *(f"│ {line:<{width}} │" for line in lines), f"└{border}┘"])
@@ -168,15 +169,16 @@ def first_prompt_hook_output(response: dict | None) -> dict | None:
     if not valid_model_name(model):
         return None
     assert isinstance(model, str)
+    rationale = response.get("rationale")
     return {
         "decision": "block",
-        "reason": switch_message(model, "Low complexity, unclear intent, and no code reference."),
+        "reason": switch_message(model, rationale if isinstance(rationale, str) else None),
     }
 
 
 def serve_first_prompt_socket(
     path: Path,
-    route_prompt: Callable[[str], str],
+    route_prompt: Callable[[str], tuple[str, str]],
     on_blocked_prompt: Callable[[str, str], None],
     stop: threading.Event,
     *,
@@ -223,10 +225,14 @@ def serve_first_prompt_socket(
                             and prompt.strip()
                             and not is_command
                         ):
-                            model = route_prompt(prompt)
+                            model, rationale = route_prompt(prompt)
                             if valid_model_name(model):
                                 claimed = True
-                                response = {"action": "block", "model": model}
+                                response = {
+                                    "action": "block",
+                                    "model": model,
+                                    "rationale": rationale,
+                                }
                                 blocked = (prompt, model)
                     except Exception as exc:  # noqa: BLE001 - hooks must fail open
                         log(f"[ERR] first-prompt request: {exc!r}")
@@ -274,7 +280,7 @@ def sync_winsize(master_fd: int, stdin_fd: int = 0) -> None:
 def run_claude_pty(
     argv: list[str],
     *,
-    route_prompt: Callable[[str], str],
+    route_prompt: Callable[[str], tuple[str, str]],
     socket_path: Path,
     prepare_model_switch: Callable[[str], None] = lambda _model: None,
     model_switch_persisted: Callable[[], bool] = lambda: True,

--- a/src/ucode/smart_routing/claude_pty.py
+++ b/src/ucode/smart_routing/claude_pty.py
@@ -276,7 +276,7 @@ def run_claude_pty(
     *,
     route_prompt: Callable[[str], str],
     socket_path: Path,
-    prepare_model_switch: Callable[[], None] = lambda: None,
+    prepare_model_switch: Callable[[str], None] = lambda _model: None,
     model_switch_persisted: Callable[[], bool] = lambda: True,
     restore_model_setting: Callable[[], None] = lambda: None,
     log_path: Path | None = None,
@@ -383,7 +383,7 @@ def run_claude_pty(
                 now = time.monotonic()
                 idle = last_output > 0.0 and now - last_output >= READY_QUIET_S
                 if phase == "waiting_to_switch" and idle:
-                    prepare_model_switch()
+                    prepare_model_switch(routed_model)
                     inject_model_switch(master_fd, routed_model)
                     confirm.arm(now + CONFIRM_TIMEOUT_S)
                     switch_complete = OutputMarkerDetector(("Set model to", "Model set to"))

--- a/src/ucode/smart_routing/claude_pty.py
+++ b/src/ucode/smart_routing/claude_pty.py
@@ -150,7 +150,7 @@ def request_first_prompt_route(path: Path, payload: dict, *, timeout: float = 5.
 
 def first_prompt_hook_output(response: dict | None) -> dict | None:
     """Translate the wrapper response into Claude hook output."""
-    from ucode.smart_routing.v2 import _switch_message
+    from ucode.smart_routing.v2 import format_routing_notice
 
     if not isinstance(response, dict) or response.get("action") != "block":
         return None
@@ -161,7 +161,9 @@ def first_prompt_hook_output(response: dict | None) -> dict | None:
     rationale = response.get("rationale")
     return {
         "decision": "block",
-        "reason": _switch_message(model, rationale if isinstance(rationale, str) else None),
+        "reason": format_routing_notice(
+            model, rationale if isinstance(rationale, str) else None
+        ),
     }
 
 

--- a/src/ucode/smart_routing/claude_pty.py
+++ b/src/ucode/smart_routing/claude_pty.py
@@ -56,19 +56,6 @@ def valid_model_name(name: object) -> bool:
     )
 
 
-def switch_message(model: str, rationale: str | None) -> str:
-    """Format the routed-model notice shown in Claude Code."""
-    lines = [
-        "Using Unity Gateway Smart Router.",
-        f"Selected Model : {model}",
-    ]
-    if rationale:
-        lines.append(f"Reason : {rationale}")
-    width = max(len(line) for line in lines)
-    border = "─" * (width + 2)
-    return "\n".join([f"┌{border}┐", *(f"│ {line:<{width}} │" for line in lines), f"└{border}┘"])
-
-
 class ConfirmationState:
     """Detect and accept Claude's optional cache-cost confirmation dialog."""
 
@@ -163,6 +150,8 @@ def request_first_prompt_route(path: Path, payload: dict, *, timeout: float = 5.
 
 def first_prompt_hook_output(response: dict | None) -> dict | None:
     """Translate the wrapper response into Claude hook output."""
+    from ucode.smart_routing.v2 import _switch_message
+
     if not isinstance(response, dict) or response.get("action") != "block":
         return None
     model = response.get("model")
@@ -172,7 +161,7 @@ def first_prompt_hook_output(response: dict | None) -> dict | None:
     rationale = response.get("rationale")
     return {
         "decision": "block",
-        "reason": switch_message(model, rationale if isinstance(rationale, str) else None),
+        "reason": _switch_message(model, rationale if isinstance(rationale, str) else None),
     }
 
 

--- a/src/ucode/smart_routing/routing.py
+++ b/src/ucode/smart_routing/routing.py
@@ -47,6 +47,14 @@ class RoutingDecision:
         return message
 
 
+@dataclass(frozen=True)
+class SpawnRoute:
+    tool_input: dict[str, Any]
+    task: str
+    decision: RoutingDecision
+    routed_model: str
+
+
 def normalize_model(model: str) -> str:
     """Strip provider prefixes so router arms and workspace ids compare equal.
 
@@ -180,23 +188,15 @@ def select_route(
     )
 
 
-def route_spawn_tool(
+def resolve_spawn_route(
     payload: dict[str, Any],
     *,
     is_spawn_agent: Callable[[Any], bool],
     decision_fn: Callable[[str], tuple[RoutingDecision | None, str | None]],
     default_task_label: str,
     model_id_mapper: Callable[[str], str],
-    skip_arms: dict[str, str] | None = None,
-    record_decision: Callable[[dict[str, Any], str, RoutingDecision, str], None] | None = None,
-) -> dict[str, Any] | None:
-    """Route one subagent-spawn tool call, rewriting its ``model`` input.
-
-    Returns a PreToolUse hook output that allows the call with the routed model
-    injected; a bare ``systemMessage`` when the pick is an arm the harness can't
-    use for subagents (``skip_arms``); or None when the tool is not a spawn or
-    routing was unavailable — fail open, leaving the original model in place.
-    """
+) -> SpawnRoute | None:
+    """Resolve one subagent-spawn payload to a routed model."""
     if not is_spawn_agent(payload.get("tool_name")):
         return None
     tool_input = payload.get("tool_input")
@@ -219,19 +219,42 @@ def route_spawn_tool(
     decision, _ = decision_fn(task)
     if decision is None:
         return None
-    if skip_arms and decision.raw_model in skip_arms:
-        return {"systemMessage": skip_arms[decision.raw_model]}
     routed_model = model_id_mapper(decision.model)
+    return SpawnRoute(tool_input, task, decision, routed_model)
+
+
+def route_spawn_tool(
+    payload: dict[str, Any],
+    *,
+    is_spawn_agent: Callable[[Any], bool],
+    decision_fn: Callable[[str], tuple[RoutingDecision | None, str | None]],
+    default_task_label: str,
+    model_id_mapper: Callable[[str], str],
+    skip_arms: dict[str, str] | None = None,
+    record_decision: Callable[[dict[str, Any], str, RoutingDecision, str], None] | None = None,
+) -> dict[str, Any] | None:
+    """Route one subagent-spawn tool call, rewriting its ``model`` input."""
+    route = resolve_spawn_route(
+        payload,
+        is_spawn_agent=is_spawn_agent,
+        decision_fn=decision_fn,
+        default_task_label=default_task_label,
+        model_id_mapper=model_id_mapper,
+    )
+    if route is None:
+        return None
+    if skip_arms and route.decision.raw_model in skip_arms:
+        return {"systemMessage": skip_arms[route.decision.raw_model]}
     if record_decision is not None:
-        record_decision(payload, task, decision, routed_model)
+        record_decision(payload, route.task, route.decision, route.routed_model)
     # Surface the router's rationale in BOTH the systemMessage (the line the
     # harness shows the user) and permissionDecisionReason — the "why", not just
     # the "what". The shown model is the harness-translated id (routed_model).
-    routing_message = decision.display_message(model_label=routed_model)
+    routing_message = route.decision.display_message(model_label=route.routed_model)
     output: dict[str, Any] = {
         "hookEventName": "PreToolUse",
         "permissionDecision": "allow",
-        "updatedInput": {**tool_input, "model": routed_model},
+        "updatedInput": {**route.tool_input, "model": route.routed_model},
         "permissionDecisionReason": routing_message,
     }
     return {"systemMessage": routing_message, "hookSpecificOutput": output}

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -21,8 +21,12 @@ from ucode.databricks import (
     get_databricks_token,
     list_anthropic_models,
 )
-from ucode.smart_routing import codex_interposer, routing
-from ucode.smart_routing.claude_hooks import FIRST_PROMPT_SOCKET_ENV, sync_first_prompt_hook
+from ucode.smart_routing import claude_routing, codex_interposer, routing
+from ucode.smart_routing.claude_hooks import (
+    FIRST_PROMPT_SOCKET_ENV,
+    sync_first_prompt_hook,
+    sync_smart_routing_hooks,
+)
 from ucode.ui import print_note
 
 ENV_VAR = "ENABLE_SMART_ROUTING_V2"
@@ -89,21 +93,20 @@ def _canonical_claude_model_id(model: str) -> str:
     return model
 
 
-def _route_claude_prompt(state: dict, token: str, prompt: str) -> routing.RoutingDecision:
-    workspace = state.get("workspace")
-    if not isinstance(workspace, str):
-        raise RuntimeError("workspace metadata is unavailable")
-
-    model_ids, discovery_error = list_anthropic_models(workspace, token)
-    if not model_ids:
-        raise RuntimeError(discovery_error or "Anthropic models endpoint returned no Claude models")
-
+def _request_claude_routing_decision(
+    workspace: str,
+    token: str,
+    prompt: str,
+    model_ids: list[str],
+) -> tuple[routing.RoutingDecision | None, str | None]:
     available: dict[str, str] = {}
     for model in model_ids:
         if isinstance(model, str) and model:
             canonical = _canonical_claude_model_id(model)
             available.setdefault(routing.normalize_model(canonical), canonical)
-    decision, error = routing.select_route(
+    if not available:
+        return None, "Anthropic models endpoint returned no Claude models"
+    return routing.select_route(
         workspace,
         token,
         prompt,
@@ -111,9 +114,57 @@ def _route_claude_prompt(state: dict, token: str, prompt: str) -> routing.Routin
         lambda selected: available.get(routing.normalize_model(selected)),
         timeout=CLAUDE_ROUTE_SELECTION_TIMEOUT_S,
     )
+
+
+def _route_claude_prompt(
+    state: dict,
+    token: str,
+    prompt: str,
+    model_ids: list[str] | None = None,
+) -> routing.RoutingDecision:
+    workspace = state.get("workspace")
+    if not isinstance(workspace, str):
+        raise RuntimeError("workspace metadata is unavailable")
+
+    if model_ids is None:
+        model_ids, discovery_error = list_anthropic_models(workspace, token)
+        if not model_ids:
+            raise RuntimeError(
+                discovery_error or "Anthropic models endpoint returned no Claude models"
+            )
+    decision, error = _request_claude_routing_decision(workspace, token, prompt, model_ids)
     if decision is None:
         raise RuntimeError(error or "router returned no Claude model selection")
     return decision
+
+
+def route_claude_pre_tool_use(
+    payload: dict,
+    *,
+    workspace: str,
+    token: str,
+    available_models: list[str],
+    audit_decision: bool = False,
+) -> dict | None:
+    """Route a Claude Code Agent call using the V2 Anthropic model menu."""
+    record = None
+    if audit_decision:
+
+        def record(payload, task, decision, requested):
+            routing.write_decision_record(
+                claude_routing.DECISIONS_PATH, payload, task, decision, requested
+            )
+
+    return routing.route_spawn_tool(
+        payload,
+        is_spawn_agent=claude_routing.is_spawn_agent_tool,
+        decision_fn=lambda task: _request_claude_routing_decision(
+            workspace, token, task, available_models
+        ),
+        default_task_label="Claude Code subagent task",
+        model_id_mapper=claude_routing._claude_model_id,
+        record_decision=record,
+    )
 
 
 def _is_claude_target_model(value: object) -> bool:
@@ -185,6 +236,9 @@ def launch_claude(
     token = get_databricks_token(workspace, state.get("profile"))
     os.environ[OAUTH_TOKEN_ENV_VAR] = token
     os.environ[GATEWAY_MODEL_DISCOVERY_ENV_VAR] = "1"
+    model_ids, discovery_error = list_anthropic_models(workspace, token)
+    if not model_ids:
+        raise RuntimeError(discovery_error or "Anthropic models endpoint returned no Claude models")
 
     run_id = f"{os.getpid()}-{uuid.uuid4().hex[:8]}"
     socket_path = APP_DIR / f"claude-v2-{run_id}.sock"
@@ -199,6 +253,11 @@ def launch_claude(
         raise RuntimeError("Claude settings 'env' must be an object for smart routing.")
     env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
     env[FIRST_PROMPT_SOCKET_ENV] = str(socket_path)
+    routing_state = {
+        **state,
+        "claude_models": {str(index): model for index, model in enumerate(model_ids)},
+    }
+    sync_smart_routing_hooks(settings, routing_state, enabled=True)
     sync_first_prompt_hook(settings, hook_executable)
     write_json_file(settings_path, settings)
     model_args = launch_model_args(remaining, launch_model)
@@ -213,7 +272,7 @@ def launch_claude(
     try:
         returncode = claude_pty.run_claude_pty(
             argv,
-            route_prompt=lambda prompt: _route_claude_prompt(state, token, prompt).model,
+            route_prompt=lambda prompt: _route_claude_prompt(state, token, prompt, model_ids).model,
             socket_path=socket_path,
             prepare_model_switch=model_setting.begin,
             model_switch_persisted=model_setting.is_routed,

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import signal
 import socket
@@ -32,7 +34,6 @@ from ucode.ui import print_note
 ENV_VAR = "ENABLE_SMART_ROUTING_V2"
 
 CODEX_INTERPOSER_LOG = APP_DIR / "codex-v2-interposer.log"
-STUBBED_SWITCH_REASON = "Low complexity, unclear intent, and no code reference."  # TODO(lilly): replace with smart router rationale.
 
 CLAUDE_TARGET_MODEL = "system.ai.claude-sonnet-4-6[1m]"  # TODO(lilly): replace with smart router.
 CLAUDE_PTY_LOG = APP_DIR / "claude-v2-pty.log"
@@ -43,6 +44,11 @@ OAUTH_TOKEN_ENV_VAR = "OAUTH_TOKEN"
 HEALTH_REQUEST_TIMEOUT_SECONDS = 1
 HEALTH_POLL_INTERVAL_SECONDS = 0.25
 CLAUDE_ROUTE_SELECTION_TIMEOUT_S = 20.0
+CLAUDE_ROUTED_AGENT_PREFIX = "ucode-route-"
+CLAUDE_ROUTED_AGENT_PROMPT = (
+    "Complete the delegated task exactly as requested. Follow the parent agent's instructions and "
+    "return a concise report of your findings or changes."
+)
 
 
 def enabled() -> bool:
@@ -74,8 +80,9 @@ def _wait_for_app_server(port: int, timeout: float) -> bool:
     return False
 
 
-def _switch_message(model: str, reason: str) -> str:
+def _switch_message(model: str, reason: str, *, title: str | None = None) -> str:
     lines = [
+        *([title] if title else []),
         "Using Unity Gateway Smart Router.",
         f"Selected Model : {model}",
         f"Reason : {reason}",
@@ -91,6 +98,67 @@ def _canonical_claude_model_id(model: str) -> str:
     if model.startswith(prefix):
         return f"system.ai.claude-{model[len(prefix) :]}"
     return model
+
+
+def _routed_claude_agent_name(model: str) -> str:
+    canonical = _canonical_claude_model_id(model)
+    normalized = routing.normalize_model(canonical)
+    safe = "".join(character if character.isalnum() else "-" for character in normalized)
+    slug = "-".join(part for part in safe.split("-") if part)
+    digest = hashlib.sha256(canonical.encode()).hexdigest()[:8]
+    return f"{CLAUDE_ROUTED_AGENT_PREFIX}{slug[:36]}-{digest}"
+
+
+def _routed_claude_agent_definitions(model_ids: list[str]) -> dict[str, dict[str, str]]:
+    definitions: dict[str, dict[str, str]] = {}
+    for model in model_ids:
+        if not isinstance(model, str) or not model:
+            continue
+        canonical = _canonical_claude_model_id(model)
+        definitions[_routed_claude_agent_name(canonical)] = {
+            "description": f"Smart-routed coding agent using {canonical}",
+            "prompt": CLAUDE_ROUTED_AGENT_PROMPT,
+            "model": canonical,
+        }
+    return definitions
+
+
+def _with_routed_claude_agents(tool_args: list[str], model_ids: list[str]) -> list[str]:
+    definitions = _routed_claude_agent_definitions(model_ids)
+    caller_definitions: dict = {}
+    remaining: list[str] = []
+    index = 0
+    while index < len(tool_args):
+        arg = tool_args[index]
+        if arg == "--":
+            remaining.extend(tool_args[index:])
+            break
+        if arg == "--agents":
+            if index + 1 >= len(tool_args):
+                raise RuntimeError("Claude's --agents option requires a JSON object.")
+            raw = tool_args[index + 1]
+            index += 2
+        elif arg.startswith("--agents="):
+            raw = arg.partition("=")[2]
+            index += 1
+        else:
+            remaining.append(arg)
+            index += 1
+            continue
+        try:
+            parsed = json.loads(raw)
+        except ValueError as exc:
+            raise RuntimeError("Claude's --agents option must contain valid JSON.") from exc
+        if not isinstance(parsed, dict):
+            raise RuntimeError("Claude's --agents option must contain a JSON object.")
+        caller_definitions.update(parsed)
+
+    collisions = definitions.keys() & caller_definitions.keys()
+    if collisions:
+        names = ", ".join(sorted(collisions))
+        raise RuntimeError(f"Claude --agents names conflict with smart routing: {names}.")
+    combined = {**caller_definitions, **definitions}
+    return ["--agents", json.dumps(combined, separators=(",", ":")), *remaining]
 
 
 def _request_claude_routing_decision(
@@ -146,25 +214,43 @@ def route_claude_pre_tool_use(
     available_models: list[str],
     audit_decision: bool = False,
 ) -> dict | None:
-    """Route a Claude Code Agent call using the V2 Anthropic model menu."""
-    record = None
-    if audit_decision:
-
-        def record(payload, task, decision, requested):
-            routing.write_decision_record(
-                claude_routing.DECISIONS_PATH, payload, task, decision, requested
-            )
-
-    return routing.route_spawn_tool(
-        payload,
-        is_spawn_agent=claude_routing.is_spawn_agent_tool,
-        decision_fn=lambda task: _request_claude_routing_decision(
-            workspace, token, task, available_models
+    """Route a Claude Agent call through a transient exact-model agent definition."""
+    if not claude_routing.is_spawn_agent_tool(payload.get("tool_name")):
+        return None
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return None
+    task = next(
+        (
+            value
+            for field in ("prompt", "description", "message", "task_name", "agent_name")
+            if isinstance(value := tool_input.get(field), str) and value
         ),
-        default_task_label="Claude Code subagent task",
-        model_id_mapper=claude_routing._claude_model_id,
-        record_decision=record,
+        "Claude Code subagent task",
     )
+    decision, _ = _request_claude_routing_decision(workspace, token, task, available_models)
+    if decision is None:
+        return None
+
+    exact_model = decision.model
+    if audit_decision:
+        routing.write_decision_record(
+            claude_routing.DECISIONS_PATH, payload, task, decision, exact_model
+        )
+    routing_message = _switch_message(
+        exact_model,
+        decision.rationale,
+        title="Subagent Smart Routing",
+    )
+    updated_input = {key: value for key, value in tool_input.items() if key != "model"}
+    updated_input["subagent_type"] = _routed_claude_agent_name(exact_model)
+    hook_output = {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "allow",
+        "updatedInput": updated_input,
+        "permissionDecisionReason": routing_message,
+    }
+    return {"systemMessage": routing_message, "hookSpecificOutput": hook_output}
 
 
 def _is_claude_target_model(value: object) -> bool:
@@ -261,9 +347,14 @@ def launch_claude(
     sync_first_prompt_hook(settings, hook_executable)
     write_json_file(settings_path, settings)
     model_args = launch_model_args(remaining, launch_model)
-    argv = [binary, "--settings", str(settings_path), *model_args, *remaining]
+    routed_agent_args = _with_routed_claude_agents(remaining, model_ids)
+    argv = [binary, "--settings", str(settings_path), *model_args, *routed_agent_args]
 
     model_setting = _ClaudeModelSettingGuard(user_settings_path)
+
+    def route_prompt(prompt: str) -> tuple[str, str]:
+        decision = _route_claude_prompt(state, token, prompt, model_ids)
+        return decision.model, decision.rationale
 
     print_note(
         "Smart routing v2: the first submitted prompt will select Claude Code's "
@@ -272,7 +363,7 @@ def launch_claude(
     try:
         returncode = claude_pty.run_claude_pty(
             argv,
-            route_prompt=lambda prompt: _route_claude_prompt(state, token, prompt, model_ids).model,
+            route_prompt=route_prompt,
             socket_path=socket_path,
             prepare_model_switch=model_setting.begin,
             model_switch_persisted=model_setting.is_routed,

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -80,14 +80,15 @@ def _wait_for_app_server(port: int, timeout: float) -> bool:
     return False
 
 
-def _switch_message(model: str, reason: str, *, title: str | None = None) -> str:
+def _switch_message(model: str, reason: str | None, *, title: str | None = None) -> str:
     lines = [
         *([title] if title else []),
         "Using Unity Gateway Smart Router.",
         f"Selected Model : {model}",
-        f"Reason : {reason}",
     ]
-    width = max(len(line) for line in lines)
+    if reason:
+        lines.append(f"Reason : {reason}")
+    width = max(map(len, lines))
     border = "─" * (width + 2)
     return "\n".join([f"┌{border}┐", *(f"│ {line:<{width}} │" for line in lines), f"└{border}┘"])
 
@@ -100,6 +101,16 @@ def _canonical_claude_model_id(model: str) -> str:
     return model
 
 
+def _canonical_claude_models(model_ids: list[str]) -> list[str]:
+    return list(
+        dict.fromkeys(
+            _canonical_claude_model_id(model)
+            for model in model_ids
+            if isinstance(model, str) and model
+        )
+    )
+
+
 def _routed_claude_agent_name(model: str) -> str:
     canonical = _canonical_claude_model_id(model)
     normalized = routing.normalize_model(canonical)
@@ -110,17 +121,14 @@ def _routed_claude_agent_name(model: str) -> str:
 
 
 def _routed_claude_agent_definitions(model_ids: list[str]) -> dict[str, dict[str, str]]:
-    definitions: dict[str, dict[str, str]] = {}
-    for model in model_ids:
-        if not isinstance(model, str) or not model:
-            continue
-        canonical = _canonical_claude_model_id(model)
-        definitions[_routed_claude_agent_name(canonical)] = {
-            "description": f"Smart-routed coding agent using {canonical}",
+    return {
+        _routed_claude_agent_name(model): {
+            "description": f"Smart-routed coding agent using {model}",
             "prompt": CLAUDE_ROUTED_AGENT_PROMPT,
-            "model": canonical,
+            "model": model,
         }
-    return definitions
+        for model in _canonical_claude_models(model_ids)
+    }
 
 
 def _with_routed_claude_agents(tool_args: list[str], model_ids: list[str]) -> list[str]:
@@ -168,10 +176,8 @@ def _request_claude_routing_decision(
     model_ids: list[str],
 ) -> tuple[routing.RoutingDecision | None, str | None]:
     available: dict[str, str] = {}
-    for model in model_ids:
-        if isinstance(model, str) and model:
-            canonical = _canonical_claude_model_id(model)
-            available.setdefault(routing.normalize_model(canonical), canonical)
+    for model in _canonical_claude_models(model_ids):
+        available.setdefault(routing.normalize_model(model), model)
     if not available:
         return None, "Anthropic models endpoint returned no Claude models"
     return routing.select_route(
@@ -215,35 +221,34 @@ def route_claude_pre_tool_use(
     audit_decision: bool = False,
 ) -> dict | None:
     """Route a Claude Agent call through a transient exact-model agent definition."""
-    if not claude_routing.is_spawn_agent_tool(payload.get("tool_name")):
-        return None
-    tool_input = payload.get("tool_input")
-    if not isinstance(tool_input, dict):
-        return None
-    task = next(
-        (
-            value
-            for field in ("prompt", "description", "message", "task_name", "agent_name")
-            if isinstance(value := tool_input.get(field), str) and value
+    route = routing.resolve_spawn_route(
+        payload,
+        is_spawn_agent=claude_routing.is_spawn_agent_tool,
+        decision_fn=lambda task: _request_claude_routing_decision(
+            workspace, token, task, available_models
         ),
-        "Claude Code subagent task",
+        default_task_label="Claude Code subagent task",
+        model_id_mapper=lambda model: model,
     )
-    decision, _ = _request_claude_routing_decision(workspace, token, task, available_models)
-    if decision is None:
+    if route is None:
         return None
-
-    exact_model = decision.model
     if audit_decision:
         routing.write_decision_record(
-            claude_routing.DECISIONS_PATH, payload, task, decision, exact_model
+            claude_routing.DECISIONS_PATH,
+            payload,
+            route.task,
+            route.decision,
+            route.routed_model,
         )
     routing_message = _switch_message(
-        exact_model,
-        decision.rationale,
+        route.routed_model,
+        route.decision.rationale,
         title="Subagent Smart Routing",
     )
-    updated_input = {key: value for key, value in tool_input.items() if key != "model"}
-    updated_input["subagent_type"] = _routed_claude_agent_name(exact_model)
+    updated_input = {
+        **{key: value for key, value in route.tool_input.items() if key != "model"},
+        "subagent_type": _routed_claude_agent_name(route.routed_model),
+    }
     hook_output = {
         "hookEventName": "PreToolUse",
         "permissionDecision": "allow",

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -126,18 +126,21 @@ class _ClaudeModelSettingGuard:
     def __init__(self, settings_path: Path) -> None:
         self.settings_path = settings_path
         self._before: dict | None = None
+        self._routed_model: str | None = None
         self._lock: TextIO | None = None
 
-    def begin(self) -> None:
+    def begin(self, routed_model: str) -> None:
         import fcntl
 
         APP_DIR.mkdir(parents=True, exist_ok=True)
         self._lock = open(APP_DIR / "claude-v2-model.lock", "a+", encoding="utf-8")
         fcntl.flock(self._lock, fcntl.LOCK_EX)
         self._before = read_json_safe(self.settings_path)
+        self._routed_model = routed_model
 
     def is_routed(self) -> bool:
-        return _is_claude_target_model(read_json_safe(self.settings_path).get("model"))
+        value = read_json_safe(self.settings_path).get("model")
+        return isinstance(value, str) and value == self._routed_model
 
     def restore(self) -> None:
         import fcntl
@@ -152,6 +155,7 @@ class _ClaudeModelSettingGuard:
                 current.pop("model", None)
             write_json_file(self.settings_path, current)
             self._before = None
+            self._routed_model = None
         finally:
             if self._lock is not None:
                 fcntl.flock(self._lock, fcntl.LOCK_UN)
@@ -204,12 +208,12 @@ def launch_claude(
 
     print_note(
         "Smart routing v2: the first submitted prompt will select Claude Code's "
-        f"model ({CLAUDE_TARGET_MODEL}); log: {CLAUDE_PTY_LOG}."
+        f"model; log: {CLAUDE_PTY_LOG}."
     )
     try:
         returncode = claude_pty.run_claude_pty(
             argv,
-            route_prompt=lambda prompt: _route_claude_prompt(state, token, prompt),
+            route_prompt=lambda prompt: _route_claude_prompt(state, token, prompt).model,
             socket_path=socket_path,
             prepare_model_switch=model_setting.begin,
             model_switch_persisted=model_setting.is_routed,

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -120,19 +120,23 @@ def _routed_claude_agent_name(model: str) -> str:
     return f"{CLAUDE_ROUTED_AGENT_PREFIX}{slug[:36]}-{digest}"
 
 
-def _routed_claude_agent_definitions(model_ids: list[str]) -> dict[str, dict[str, str]]:
+def _routed_claude_agent_definitions(
+    model_ids: list[str], model_name: Callable[[str], str]
+) -> dict[str, dict[str, str]]:
     return {
         _routed_claude_agent_name(model): {
             "description": f"Smart-routed coding agent using {model}",
             "prompt": CLAUDE_ROUTED_AGENT_PROMPT,
-            "model": model,
+            "model": model_name(model),
         }
         for model in _canonical_claude_models(model_ids)
     }
 
 
-def _with_routed_claude_agents(tool_args: list[str], model_ids: list[str]) -> list[str]:
-    definitions = _routed_claude_agent_definitions(model_ids)
+def _with_routed_claude_agents(
+    tool_args: list[str], model_ids: list[str], model_name: Callable[[str], str]
+) -> list[str]:
+    definitions = _routed_claude_agent_definitions(model_ids, model_name)
     caller_definitions: dict = {}
     remaining: list[str] = []
     index = 0
@@ -314,6 +318,7 @@ def launch_claude(
     launch_model: str | None,
     compose_settings: Callable[[list[str]], tuple[dict, list[str]]],
     launch_model_args: Callable[[list[str], str | None], list[str]],
+    model_name: Callable[[str], str],
 ) -> NoReturn:
     """Launch Claude in the first-prompt routing PTY wrapper."""
     from ucode.agents.claude import GATEWAY_MODEL_DISCOVERY_ENV_VAR
@@ -352,14 +357,14 @@ def launch_claude(
     sync_first_prompt_hook(settings, hook_executable)
     write_json_file(settings_path, settings)
     model_args = launch_model_args(remaining, launch_model)
-    routed_agent_args = _with_routed_claude_agents(remaining, model_ids)
+    routed_agent_args = _with_routed_claude_agents(remaining, model_ids, model_name)
     argv = [binary, "--settings", str(settings_path), *model_args, *routed_agent_args]
 
     model_setting = _ClaudeModelSettingGuard(user_settings_path)
 
     def route_prompt(prompt: str) -> tuple[str, str]:
         decision = _route_claude_prompt(state, token, prompt, model_ids)
-        return decision.model, decision.rationale
+        return model_name(decision.model), decision.rationale
 
     print_note(
         "Smart routing v2: the first submitted prompt will select Claude Code's "

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -111,6 +111,15 @@ def _canonical_claude_models(model_ids: list[str]) -> list[str]:
     )
 
 
+def _claude_model_overrides(model_ids: list[str]) -> dict[str, str]:
+    overrides: dict[str, str] = {}
+    prefix = "system.ai."
+    for model in _canonical_claude_models(model_ids):
+        if model.startswith(f"{prefix}claude-"):
+            overrides[model[len(prefix) :]] = model
+    return overrides
+
+
 def _routed_claude_agent_name(model: str) -> str:
     canonical = _canonical_claude_model_id(model)
     normalized = routing.normalize_model(canonical)
@@ -345,6 +354,10 @@ def launch_claude(
         raise RuntimeError("Claude settings 'env' must be an object for smart routing.")
     env["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
     env[FIRST_PROMPT_SOCKET_ENV] = str(socket_path)
+    model_overrides = settings.setdefault("modelOverrides", {})
+    if not isinstance(model_overrides, dict):
+        raise RuntimeError("Claude settings 'modelOverrides' must be an object for smart routing.")
+    model_overrides.update(_claude_model_overrides(model_ids))
     routing_state = {
         **state,
         "claude_models": {str(index): model for index, model in enumerate(model_ids)},

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -80,7 +80,7 @@ def _wait_for_app_server(port: int, timeout: float) -> bool:
     return False
 
 
-def _switch_message(model: str, reason: str | None, *, title: str | None = None) -> str:
+def format_routing_notice(model: str, reason: str | None, *, title: str | None = None) -> str:
     lines = [
         *([title] if title else []),
         "Using Unity Gateway Smart Router.",
@@ -240,7 +240,7 @@ def route_claude_pre_tool_use(
             route.decision,
             route.routed_model,
         )
-    routing_message = _switch_message(
+    routing_message = format_routing_notice(
         route.routed_model,
         route.decision.rationale,
         title="Subagent Smart Routing",
@@ -476,7 +476,7 @@ def launch_codex(
             available_models=available_models,
             workspace=workspace,
             token_provider=lambda: get_databricks_token(workspace, profile),
-            switch_message_fn=_switch_message,
+            switch_message_fn=format_routing_notice,
             log_path=CODEX_INTERPOSER_LOG,
         )
         tui_url = _loopback_websocket_url(tui_port)

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -16,8 +16,12 @@ import tomlkit
 
 from ucode.config_io import APP_DIR, read_json_safe, write_json_file
 from ucode.constants import LOOPBACK_HOST
-from ucode.databricks import build_auth_token_argv, get_databricks_token
-from ucode.smart_routing import codex_interposer
+from ucode.databricks import (
+    build_auth_token_argv,
+    get_databricks_token,
+    list_anthropic_models,
+)
+from ucode.smart_routing import codex_interposer, routing
 from ucode.smart_routing.claude_hooks import FIRST_PROMPT_SOCKET_ENV, sync_first_prompt_hook
 from ucode.ui import print_note
 
@@ -34,6 +38,7 @@ PROCESS_SHUTDOWN_TIMEOUT_SECONDS = 5
 OAUTH_TOKEN_ENV_VAR = "OAUTH_TOKEN"
 HEALTH_REQUEST_TIMEOUT_SECONDS = 1
 HEALTH_POLL_INTERVAL_SECONDS = 0.25
+CLAUDE_ROUTE_SELECTION_TIMEOUT_S = 20.0
 
 
 def enabled() -> bool:
@@ -76,8 +81,39 @@ def _switch_message(model: str, reason: str) -> str:
     return "\n".join([f"┌{border}┐", *(f"│ {line:<{width}} │" for line in lines), f"└{border}┘"])
 
 
-def _route_claude_prompt(_prompt: str) -> str:
-    return CLAUDE_TARGET_MODEL
+def _canonical_claude_model_id(model: str) -> str:
+    """Use the system.ai id when Anthropic discovery returns a legacy alias."""
+    prefix = "databricks-claude-"
+    if model.startswith(prefix):
+        return f"system.ai.claude-{model[len(prefix) :]}"
+    return model
+
+
+def _route_claude_prompt(state: dict, token: str, prompt: str) -> routing.RoutingDecision:
+    workspace = state.get("workspace")
+    if not isinstance(workspace, str):
+        raise RuntimeError("workspace metadata is unavailable")
+
+    model_ids, discovery_error = list_anthropic_models(workspace, token)
+    if not model_ids:
+        raise RuntimeError(discovery_error or "Anthropic models endpoint returned no Claude models")
+
+    available: dict[str, str] = {}
+    for model in model_ids:
+        if isinstance(model, str) and model:
+            canonical = _canonical_claude_model_id(model)
+            available.setdefault(routing.normalize_model(canonical), canonical)
+    decision, error = routing.select_route(
+        workspace,
+        token,
+        prompt,
+        [(model, "claude") for model in available],
+        lambda selected: available.get(routing.normalize_model(selected)),
+        timeout=CLAUDE_ROUTE_SELECTION_TIMEOUT_S,
+    )
+    if decision is None:
+        raise RuntimeError(error or "router returned no Claude model selection")
+    return decision
 
 
 def _is_claude_target_model(value: object) -> bool:
@@ -142,7 +178,8 @@ def launch_claude(
         raise RuntimeError(
             "Smart routing v2 needs a configured workspace; run `ucode configure claude` first."
         )
-    os.environ[OAUTH_TOKEN_ENV_VAR] = get_databricks_token(workspace, state.get("profile"))
+    token = get_databricks_token(workspace, state.get("profile"))
+    os.environ[OAUTH_TOKEN_ENV_VAR] = token
     os.environ[GATEWAY_MODEL_DISCOVERY_ENV_VAR] = "1"
 
     run_id = f"{os.getpid()}-{uuid.uuid4().hex[:8]}"
@@ -172,7 +209,7 @@ def launch_claude(
     try:
         returncode = claude_pty.run_claude_pty(
             argv,
-            route_prompt=_route_claude_prompt,
+            route_prompt=lambda prompt: _route_claude_prompt(state, token, prompt),
             socket_path=socket_path,
             prepare_model_switch=model_setting.begin,
             model_switch_persisted=model_setting.is_routed,

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -120,23 +120,19 @@ def _routed_claude_agent_name(model: str) -> str:
     return f"{CLAUDE_ROUTED_AGENT_PREFIX}{slug[:36]}-{digest}"
 
 
-def _routed_claude_agent_definitions(
-    model_ids: list[str], model_name: Callable[[str], str]
-) -> dict[str, dict[str, str]]:
+def _routed_claude_agent_definitions(model_ids: list[str]) -> dict[str, dict[str, str]]:
     return {
         _routed_claude_agent_name(model): {
             "description": f"Smart-routed coding agent using {model}",
             "prompt": CLAUDE_ROUTED_AGENT_PROMPT,
-            "model": model_name(model),
+            "model": model,
         }
         for model in _canonical_claude_models(model_ids)
     }
 
 
-def _with_routed_claude_agents(
-    tool_args: list[str], model_ids: list[str], model_name: Callable[[str], str]
-) -> list[str]:
-    definitions = _routed_claude_agent_definitions(model_ids, model_name)
+def _with_routed_claude_agents(tool_args: list[str], model_ids: list[str]) -> list[str]:
+    definitions = _routed_claude_agent_definitions(model_ids)
     caller_definitions: dict = {}
     remaining: list[str] = []
     index = 0
@@ -357,7 +353,7 @@ def launch_claude(
     sync_first_prompt_hook(settings, hook_executable)
     write_json_file(settings_path, settings)
     model_args = launch_model_args(remaining, launch_model)
-    routed_agent_args = _with_routed_claude_agents(remaining, model_ids, model_name)
+    routed_agent_args = _with_routed_claude_agents(remaining, model_ids)
     argv = [binary, "--settings", str(settings_path), *model_args, *routed_agent_args]
 
     model_setting = _ClaudeModelSettingGuard(user_settings_path)

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -27,6 +27,11 @@ class TestClaudeSpec:
 
 
 class TestRenderOverlay:
+    def test_long_context_suffix_supports_major_only_claude_versions(self):
+        assert claude._maybe_add_1m_suffix("system.ai.claude-sonnet-5") == (
+            "system.ai.claude-sonnet-5[1m]"
+        )
+
     def test_does_not_set_anthropic_model_env(self):
         # We deliberately don't pin ANTHROPIC_MODEL: when set, Claude Code's
         # /model picker surfaces a duplicate catalog row on top of the family

--- a/tests/test_claude_smart_routing_v2.py
+++ b/tests/test_claude_smart_routing_v2.py
@@ -149,18 +149,19 @@ class TestV2Launch:
                 launch_model="opus",
                 compose_settings=claude._compose_v2_settings,
                 launch_model_args=claude._launch_model_args,
+                model_name=claude._maybe_add_1m_suffix,
             )
 
         assert exc.value.code == 0
         assert captured["argv"][3:5] == ["--model", "opus"]
         assert captured["argv"][-1] == "--debug"
         assert captured["routed_model"] == (
-            "system.ai.claude-sonnet-5",
+            "system.ai.claude-sonnet-5[1m]",
             "Selected for the parser task.",
         )
         assert {definition["model"] for definition in captured["agents"].values()} == {
-            "system.ai.claude-opus-4-8",
-            "system.ai.claude-sonnet-5",
+            "system.ai.claude-opus-4-8[1m]",
+            "system.ai.claude-sonnet-5[1m]",
         }
         assert claude_hooks.FIRST_PROMPT_SOCKET_ENV in captured["settings"]["env"]
         first_prompt_command = captured["settings"]["hooks"]["UserPromptSubmit"][0]["hooks"][0][
@@ -210,6 +211,7 @@ class TestV2Launch:
                 launch_model="opus",
                 compose_settings=lambda _args: ({}, []),
                 launch_model_args=claude._launch_model_args,
+                model_name=claude._maybe_add_1m_suffix,
             )
 
         assert json.loads(user_settings.read_text()) == {"model": "user-selected"}
@@ -245,6 +247,7 @@ class TestV2Launch:
                 launch_model=None,
                 compose_settings=lambda _args: ({}, []),
                 launch_model_args=claude._launch_model_args,
+                model_name=claude._maybe_add_1m_suffix,
             )
 
         assert json.loads(user_settings.read_text()) == {
@@ -328,14 +331,22 @@ class TestSubagentRouting:
                 "--debug",
             ],
             ["databricks-claude-opus-4-8"],
+            claude._maybe_add_1m_suffix,
         )
 
         assert args[0] == "--agents"
         definitions = json.loads(args[1])
         assert definitions["reviewer"]["prompt"] == "Review the requested code."
         routed = definitions[v2._routed_claude_agent_name("system.ai.claude-opus-4-8")]
-        assert routed["model"] == "system.ai.claude-opus-4-8"
+        assert routed["model"] == "system.ai.claude-opus-4-8[1m]"
         assert args[2:] == ["--debug"]
+
+    def test_leaves_non_claude_custom_agent_model_unchanged(self):
+        definitions = v2._routed_claude_agent_definitions(
+            ["catalog.schema.gpt-5"], claude._maybe_add_1m_suffix
+        )
+
+        assert next(iter(definitions.values()))["model"] == "catalog.schema.gpt-5"
 
     def test_model_switch_lock_serializes_routed_sessions(self, tmp_path, monkeypatch):
         user_settings = tmp_path / "settings.json"

--- a/tests/test_claude_smart_routing_v2.py
+++ b/tests/test_claude_smart_routing_v2.py
@@ -85,15 +85,24 @@ class TestV2Launch:
         monkeypatch.setattr(v2, "CLAUDE_PTY_LOG", tmp_path / "v2.log")
         monkeypatch.setattr(v2, "get_databricks_token", lambda *_args, **_kwargs: "token")
         monkeypatch.setattr(v2, "build_auth_token_argv", lambda *_args, **_kwargs: ["ucode"])
+        monkeypatch.setattr(
+            v2,
+            "_route_claude_prompt",
+            lambda *_args: v2.routing.RoutingDecision(
+                model="system.ai.claude-sonnet-5",
+                raw_model="claude-sonnet-5",
+            ),
+        )
         captured: dict = {}
 
         def fake_run(argv, **kwargs):
             captured["argv"] = argv
+            captured["routed_model"] = kwargs["route_prompt"]("fix the parser")
             generated = Path(argv[argv.index("--settings") + 1])
             captured["settings"] = json.loads(generated.read_text())
             # A user-selected model before the first prompt becomes the value to restore.
             user_settings.write_text(json.dumps({"model": "haiku", "theme": "dark"}))
-            kwargs["prepare_model_switch"]()
+            kwargs["prepare_model_switch"]("system.ai.claude-sonnet-5")
             # Simulate `/model` changing the user file, plus an unrelated concurrent edit.
             user_settings.write_text(json.dumps({"model": "routed", "theme": "light", "new": True}))
             kwargs["restore_model_setting"]()
@@ -118,6 +127,7 @@ class TestV2Launch:
 
         assert exc.value.code == 0
         assert captured["argv"][-3:] == ["--model", "opus", "--debug"]
+        assert captured["routed_model"] == "system.ai.claude-sonnet-5"
         assert claude_hooks.FIRST_PROMPT_SOCKET_ENV in captured["settings"]["env"]
         assert "modelPicker" not in captured["settings"]
         assert captured["restored_during_run"] == {
@@ -166,8 +176,9 @@ class TestV2Launch:
         monkeypatch.setattr(v2, "build_auth_token_argv", lambda *_args, **_kwargs: ["ucode"])
 
         def fake_run(_argv, **kwargs):
-            kwargs["prepare_model_switch"]()
-            user_settings.write_text(json.dumps({"model": v2.CLAUDE_TARGET_MODEL, "theme": "dark"}))
+            routed_model = "system.ai.claude-opus-4-8"
+            kwargs["prepare_model_switch"](routed_model)
+            user_settings.write_text(json.dumps({"model": routed_model, "theme": "dark"}))
             assert kwargs["model_switch_persisted"]() is True
             kwargs["restore_model_setting"]()
             assert json.loads(user_settings.read_text()) == {"model": "haiku", "theme": "dark"}
@@ -200,11 +211,11 @@ class TestV2Launch:
         second = v2._ClaudeModelSettingGuard(user_settings)
         captured: list[str] = []
 
-        first.begin()
-        user_settings.write_text(json.dumps({"model": v2.CLAUDE_TARGET_MODEL}))
+        first.begin("system.ai.claude-opus-4-8")
+        user_settings.write_text(json.dumps({"model": "system.ai.claude-opus-4-8"}))
 
         def run_second() -> None:
-            second.begin()
+            second.begin("system.ai.claude-sonnet-5")
             captured.append(json.loads(user_settings.read_text())["model"])
             second.restore()
 

--- a/tests/test_claude_smart_routing_v2.py
+++ b/tests/test_claude_smart_routing_v2.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import pytest
 
 from ucode.agents import claude
-from ucode.smart_routing import claude_hooks, claude_pty, v2
+from ucode.smart_routing import claude_hooks, claude_pty, routing, v2
 
 
 class TestDirectModelCommand:
@@ -87,6 +87,14 @@ class TestV2Launch:
         monkeypatch.setattr(v2, "build_auth_token_argv", lambda *_args, **_kwargs: ["ucode"])
         monkeypatch.setattr(
             v2,
+            "list_anthropic_models",
+            lambda *_args: (
+                ["system.ai.claude-opus-4-8", "system.ai.claude-sonnet-5"],
+                None,
+            ),
+        )
+        monkeypatch.setattr(
+            v2,
             "_route_claude_prompt",
             lambda *_args: v2.routing.RoutingDecision(
                 model="system.ai.claude-sonnet-5",
@@ -129,6 +137,15 @@ class TestV2Launch:
         assert captured["argv"][-3:] == ["--model", "opus", "--debug"]
         assert captured["routed_model"] == "system.ai.claude-sonnet-5"
         assert claude_hooks.FIRST_PROMPT_SOCKET_ENV in captured["settings"]["env"]
+        route_commands = [
+            hook["command"]
+            for group in captured["settings"]["hooks"]["PreToolUse"]
+            for hook in group["hooks"]
+            if "route-subagent" in hook["command"]
+        ]
+        assert len(route_commands) == 1
+        assert "--model system.ai.claude-opus-4-8" in route_commands[0]
+        assert "--model system.ai.claude-sonnet-5" in route_commands[0]
         assert "modelPicker" not in captured["settings"]
         assert captured["restored_during_run"] == {
             "model": "haiku",
@@ -147,6 +164,7 @@ class TestV2Launch:
         monkeypatch.setattr(v2, "APP_DIR", tmp_path)
         monkeypatch.setattr(v2, "get_databricks_token", lambda *_args, **_kwargs: "token")
         monkeypatch.setattr(v2, "build_auth_token_argv", lambda *_args, **_kwargs: ["ucode"])
+        monkeypatch.setattr(v2, "list_anthropic_models", lambda *_args: (["opus"], None))
 
         def fake_run(_argv, **_kwargs):
             user_settings.write_text(json.dumps({"model": "user-selected"}))
@@ -174,6 +192,7 @@ class TestV2Launch:
         monkeypatch.setattr(v2, "APP_DIR", tmp_path)
         monkeypatch.setattr(v2, "get_databricks_token", lambda *_args, **_kwargs: "token")
         monkeypatch.setattr(v2, "build_auth_token_argv", lambda *_args, **_kwargs: ["ucode"])
+        monkeypatch.setattr(v2, "list_anthropic_models", lambda *_args: (["opus"], None))
 
         def fake_run(_argv, **kwargs):
             routed_model = "system.ai.claude-opus-4-8"
@@ -202,6 +221,51 @@ class TestV2Launch:
             "model": v2.CLAUDE_TARGET_MODEL,
             "theme": "dark",
         }
+
+
+class TestSubagentRouting:
+    def test_routes_agent_prompt_with_initialized_model_menu(self, monkeypatch):
+        captured = {}
+
+        def fake_select(workspace, token, task, route_options, resolve, **kwargs):
+            captured.update(
+                workspace=workspace,
+                token=token,
+                task=task,
+                route_options=list(route_options),
+            )
+            return (
+                routing.RoutingDecision(
+                    model=resolve("claude-opus-4-8"),
+                    raw_model="claude-opus-4-8",
+                ),
+                None,
+            )
+
+        monkeypatch.setattr(routing, "select_route", fake_select)
+        output = v2.route_claude_pre_tool_use(
+            {
+                "tool_name": "Agent",
+                "tool_input": {"prompt": "inspect the parser", "model": "sonnet"},
+            },
+            workspace="https://example.com",
+            token="token",
+            available_models=[
+                "system.ai.claude-opus-4-8",
+                "databricks-claude-sonnet-5",
+            ],
+        )
+
+        assert captured == {
+            "workspace": "https://example.com",
+            "token": "token",
+            "task": "inspect the parser",
+            "route_options": [
+                ("claude-opus-4-8", "claude"),
+                ("claude-sonnet-5", "claude"),
+            ],
+        }
+        assert output["hookSpecificOutput"]["updatedInput"]["model"] == "opus"
 
     def test_model_switch_lock_serializes_routed_sessions(self, tmp_path, monkeypatch):
         user_settings = tmp_path / "settings.json"

--- a/tests/test_claude_smart_routing_v2.py
+++ b/tests/test_claude_smart_routing_v2.py
@@ -36,7 +36,6 @@ class TestFirstPromptHook:
         )
 
         assert result == {"decision": "block", "reason": v2._switch_message(model, reason)}
-        assert claude_pty.switch_message(model, reason) == v2._switch_message(model, reason)
 
     def test_omits_reason_when_router_returns_none(self):
         result = claude_pty.first_prompt_hook_output(

--- a/tests/test_claude_smart_routing_v2.py
+++ b/tests/test_claude_smart_routing_v2.py
@@ -30,11 +30,20 @@ class TestDirectModelCommand:
 class TestFirstPromptHook:
     def test_renders_boxed_router_notice(self):
         model = "system.ai.claude-sonnet-4-6[1m]"
-        reason = "Low complexity, unclear intent, and no code reference."
-        result = claude_pty.first_prompt_hook_output({"action": "block", "model": model})
+        reason = "Routed to Sonnet because the task is narrowly scoped."
+        result = claude_pty.first_prompt_hook_output(
+            {"action": "block", "model": model, "rationale": reason}
+        )
 
         assert result == {"decision": "block", "reason": v2._switch_message(model, reason)}
         assert claude_pty.switch_message(model, reason) == v2._switch_message(model, reason)
+
+    def test_omits_reason_when_router_returns_none(self):
+        result = claude_pty.first_prompt_hook_output(
+            {"action": "block", "model": "system.ai.claude-sonnet-5"}
+        )
+
+        assert "Reason" not in result["reason"]
 
     def test_blocks_once_then_allows_replay(self, tmp_path):
         socket_path = tmp_path / "first.sock"
@@ -42,7 +51,7 @@ class TestFirstPromptHook:
         stop = threading.Event()
         claude_pty.serve_first_prompt_socket(
             socket_path,
-            lambda _prompt: "sonnet",
+            lambda _prompt: ("sonnet", "Selected for a narrow task."),
             lambda prompt, model: blocked.append((prompt, model)),
             stop,
         )
@@ -56,7 +65,11 @@ class TestFirstPromptHook:
             replay = claude_pty.request_first_prompt_route(
                 socket_path, {"session_id": "s1", "prompt": "fix the parser"}
             )
-            assert first == {"action": "block", "model": "sonnet"}
+            assert first == {
+                "action": "block",
+                "model": "sonnet",
+                "rationale": "Selected for a narrow task.",
+            }
             assert replay == {"action": "allow"}
             assert blocked == [("fix the parser", "sonnet")]
         finally:
@@ -99,12 +112,15 @@ class TestV2Launch:
             lambda *_args: v2.routing.RoutingDecision(
                 model="system.ai.claude-sonnet-5",
                 raw_model="claude-sonnet-5",
+                rationale="Selected for the parser task.",
             ),
         )
         captured: dict = {}
 
         def fake_run(argv, **kwargs):
             captured["argv"] = argv
+            agents_index = argv.index("--agents")
+            captured["agents"] = json.loads(argv[agents_index + 1])
             captured["routed_model"] = kwargs["route_prompt"]("fix the parser")
             generated = Path(argv[argv.index("--settings") + 1])
             captured["settings"] = json.loads(generated.read_text())
@@ -134,8 +150,16 @@ class TestV2Launch:
             )
 
         assert exc.value.code == 0
-        assert captured["argv"][-3:] == ["--model", "opus", "--debug"]
-        assert captured["routed_model"] == "system.ai.claude-sonnet-5"
+        assert captured["argv"][3:5] == ["--model", "opus"]
+        assert captured["argv"][-1] == "--debug"
+        assert captured["routed_model"] == (
+            "system.ai.claude-sonnet-5",
+            "Selected for the parser task.",
+        )
+        assert {definition["model"] for definition in captured["agents"].values()} == {
+            "system.ai.claude-opus-4-8",
+            "system.ai.claude-sonnet-5",
+        }
         assert claude_hooks.FIRST_PROMPT_SOCKET_ENV in captured["settings"]["env"]
         first_prompt_command = captured["settings"]["hooks"]["UserPromptSubmit"][0]["hooks"][0][
             "command"
@@ -228,8 +252,10 @@ class TestV2Launch:
 
 
 class TestSubagentRouting:
-    def test_routes_agent_prompt_with_initialized_model_menu(self, monkeypatch):
+    def test_routes_agent_prompt_with_initialized_model_menu(self, tmp_path, monkeypatch):
         captured = {}
+        decisions_path = tmp_path / "decisions.jsonl"
+        monkeypatch.setattr(v2.claude_routing, "DECISIONS_PATH", decisions_path)
 
         def fake_select(workspace, token, task, route_options, resolve, **kwargs):
             captured.update(
@@ -258,6 +284,7 @@ class TestSubagentRouting:
                 "system.ai.claude-opus-4-8",
                 "databricks-claude-sonnet-5",
             ],
+            audit_decision=True,
         )
 
         assert captured == {
@@ -269,7 +296,44 @@ class TestSubagentRouting:
                 ("claude-sonnet-5", "claude"),
             ],
         }
-        assert output["hookSpecificOutput"]["updatedInput"]["model"] == "opus"
+        updated_input = output["hookSpecificOutput"]["updatedInput"]
+        assert "model" not in updated_input
+        assert updated_input["subagent_type"] == v2._routed_claude_agent_name(
+            "system.ai.claude-opus-4-8"
+        )
+        expected_message = v2._switch_message(
+            "system.ai.claude-opus-4-8",
+            "",
+            title="Subagent Smart Routing",
+        )
+        assert output["systemMessage"] == expected_message
+        assert output["hookSpecificOutput"]["permissionDecisionReason"] == expected_message
+        decision_record = json.loads(decisions_path.read_text())
+        assert decision_record["requested_model"] == "system.ai.claude-opus-4-8"
+
+    def test_merges_caller_agents_with_transient_routed_agents(self):
+        args = v2._with_routed_claude_agents(
+            [
+                "--agents",
+                json.dumps(
+                    {
+                        "reviewer": {
+                            "description": "Reviews code",
+                            "prompt": "Review the requested code.",
+                        }
+                    }
+                ),
+                "--debug",
+            ],
+            ["databricks-claude-opus-4-8"],
+        )
+
+        assert args[0] == "--agents"
+        definitions = json.loads(args[1])
+        assert definitions["reviewer"]["prompt"] == "Review the requested code."
+        routed = definitions[v2._routed_claude_agent_name("system.ai.claude-opus-4-8")]
+        assert routed["model"] == "system.ai.claude-opus-4-8"
+        assert args[2:] == ["--debug"]
 
     def test_model_switch_lock_serializes_routed_sessions(self, tmp_path, monkeypatch):
         user_settings = tmp_path / "settings.json"
@@ -318,7 +382,7 @@ class TestPtyFlow:
         with pytest.raises(RuntimeError, match="Claude was not launched"):
             claude_pty.run_claude_pty(
                 ["claude"],
-                route_prompt=lambda _prompt: "sonnet",
+                route_prompt=lambda _prompt: ("sonnet", ""),
                 socket_path=tmp_path / "missing.sock",
             )
 
@@ -376,7 +440,7 @@ capture_path.write_text(json.dumps({
                 str(capture),
                 str(restored),
             ],
-            route_prompt=lambda _prompt: "system.ai.claude-sonnet-5",
+            route_prompt=lambda _prompt: ("system.ai.claude-sonnet-5", ""),
             socket_path=socket_path,
             restore_model_setting=lambda: restored.write_text("restored"),
         )

--- a/tests/test_claude_smart_routing_v2.py
+++ b/tests/test_claude_smart_routing_v2.py
@@ -160,8 +160,8 @@ class TestV2Launch:
             "Selected for the parser task.",
         )
         assert {definition["model"] for definition in captured["agents"].values()} == {
-            "system.ai.claude-opus-4-8[1m]",
-            "system.ai.claude-sonnet-5[1m]",
+            "system.ai.claude-opus-4-8",
+            "system.ai.claude-sonnet-5",
         }
         assert claude_hooks.FIRST_PROMPT_SOCKET_ENV in captured["settings"]["env"]
         first_prompt_command = captured["settings"]["hooks"]["UserPromptSubmit"][0]["hooks"][0][
@@ -331,20 +331,17 @@ class TestSubagentRouting:
                 "--debug",
             ],
             ["databricks-claude-opus-4-8"],
-            claude._maybe_add_1m_suffix,
         )
 
         assert args[0] == "--agents"
         definitions = json.loads(args[1])
         assert definitions["reviewer"]["prompt"] == "Review the requested code."
         routed = definitions[v2._routed_claude_agent_name("system.ai.claude-opus-4-8")]
-        assert routed["model"] == "system.ai.claude-opus-4-8[1m]"
+        assert routed["model"] == "system.ai.claude-opus-4-8"
         assert args[2:] == ["--debug"]
 
     def test_leaves_non_claude_custom_agent_model_unchanged(self):
-        definitions = v2._routed_claude_agent_definitions(
-            ["catalog.schema.gpt-5"], claude._maybe_add_1m_suffix
-        )
+        definitions = v2._routed_claude_agent_definitions(["catalog.schema.gpt-5"])
 
         assert next(iter(definitions.values()))["model"] == "catalog.schema.gpt-5"
 

--- a/tests/test_claude_smart_routing_v2.py
+++ b/tests/test_claude_smart_routing_v2.py
@@ -163,6 +163,10 @@ class TestV2Launch:
             "system.ai.claude-opus-4-8",
             "system.ai.claude-sonnet-5",
         }
+        assert captured["settings"]["modelOverrides"] == {
+            "claude-opus-4-8": "system.ai.claude-opus-4-8",
+            "claude-sonnet-5": "system.ai.claude-sonnet-5",
+        }
         assert claude_hooks.FIRST_PROMPT_SOCKET_ENV in captured["settings"]["env"]
         first_prompt_command = captured["settings"]["hooks"]["UserPromptSubmit"][0]["hooks"][0][
             "command"
@@ -344,6 +348,18 @@ class TestSubagentRouting:
         definitions = v2._routed_claude_agent_definitions(["catalog.schema.gpt-5"])
 
         assert next(iter(definitions.values()))["model"] == "catalog.schema.gpt-5"
+
+    def test_maps_gateway_claude_ids_to_known_model_metadata(self):
+        assert v2._claude_model_overrides(
+            [
+                "system.ai.claude-opus-4-8",
+                "databricks-claude-sonnet-5",
+                "catalog.schema.gpt-5",
+            ]
+        ) == {
+            "claude-opus-4-8": "system.ai.claude-opus-4-8",
+            "claude-sonnet-5": "system.ai.claude-sonnet-5",
+        }
 
     def test_model_switch_lock_serializes_routed_sessions(self, tmp_path, monkeypatch):
         user_settings = tmp_path / "settings.json"

--- a/tests/test_claude_smart_routing_v2.py
+++ b/tests/test_claude_smart_routing_v2.py
@@ -137,6 +137,10 @@ class TestV2Launch:
         assert captured["argv"][-3:] == ["--model", "opus", "--debug"]
         assert captured["routed_model"] == "system.ai.claude-sonnet-5"
         assert claude_hooks.FIRST_PROMPT_SOCKET_ENV in captured["settings"]["env"]
+        first_prompt_command = captured["settings"]["hooks"]["UserPromptSubmit"][0]["hooks"][0][
+            "command"
+        ]
+        assert first_prompt_command == "ucode claude-router-hook route-first-prompt"
         route_commands = [
             hook["command"]
             for group in captured["settings"]["hooks"]["PreToolUse"]

--- a/tests/test_claude_smart_routing_v2.py
+++ b/tests/test_claude_smart_routing_v2.py
@@ -35,7 +35,10 @@ class TestFirstPromptHook:
             {"action": "block", "model": model, "rationale": reason}
         )
 
-        assert result == {"decision": "block", "reason": v2._switch_message(model, reason)}
+        assert result == {
+            "decision": "block",
+            "reason": v2.format_routing_notice(model, reason),
+        }
 
     def test_omits_reason_when_router_returns_none(self):
         result = claude_pty.first_prompt_hook_output(
@@ -300,7 +303,7 @@ class TestSubagentRouting:
         assert updated_input["subagent_type"] == v2._routed_claude_agent_name(
             "system.ai.claude-opus-4-8"
         )
-        expected_message = v2._switch_message(
+        expected_message = v2.format_routing_notice(
             "system.ai.claude-opus-4-8",
             "",
             title="Subagent Smart Routing",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import os
 import re
 from unittest.mock import MagicMock, patch
@@ -334,6 +335,41 @@ class TestSubcommandRouting:
         assert result.exit_code == 0, result.output
         assert result.output == ""
         mock_request.assert_not_called()
+
+    def test_claude_v2_subagent_hook_uses_v2_router(self, monkeypatch):
+        monkeypatch.setenv("ENABLE_SMART_ROUTING_V2", "1")
+        routed = {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "allow",
+                "updatedInput": {"prompt": "fix it", "model": "opus"},
+            }
+        }
+        with (
+            patch(
+                "ucode.cli.smart_routing_v2.route_claude_pre_tool_use",
+                return_value=routed,
+            ) as mock_v2_route,
+            patch("ucode.cli.claude_routing.route_pre_tool_use") as mock_legacy_route,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "claude-router-hook",
+                    "route-subagent",
+                    "--host",
+                    "https://example.com",
+                    "--model",
+                    "system.ai.claude-opus-4-8",
+                ],
+                input='{"tool_name":"Agent","tool_input":{"prompt":"fix it"}}',
+                env={"OAUTH_TOKEN": "token"},
+            )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output) == routed
+        mock_v2_route.assert_called_once()
+        mock_legacy_route.assert_not_called()
 
 
 class TestClaudeModelFlag:

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -36,7 +36,7 @@ class TestCodexConfigArgs:
 
 
 def test_smart_routing_switch_message_is_boxed():
-    message = v2._switch_message("model-x", "Because X.")
+    message = v2.format_routing_notice("model-x", "Because X.")
 
     assert message == (
         "┌───────────────────────────────────┐\n"
@@ -169,7 +169,7 @@ class TestLaunchCodex:
         assert token_calls == [(WS, "myprof")]
         assert interposer_args["kwargs"]["token_provider"]() == "token-2"
         assert token_calls == [(WS, "myprof"), (WS, "myprof")]
-        assert interposer_args["kwargs"]["switch_message_fn"] is v2._switch_message
+        assert interposer_args["kwargs"]["switch_message_fn"] is v2.format_routing_notice
         assert stopped == [True]
         assert processes[0].terminated is True
 
@@ -299,7 +299,7 @@ class TestInterposerSession:
             log=lambda _m: None,
             available_models=["claude-opus-4-8", "gpt-5.5"],
             route_decision=select,
-            switch_message_fn=v2._switch_message,
+            switch_message_fn=v2.format_routing_notice,
         )
 
         output = sess.on_tui_frame(self._turn_start("gpt-5.5", prompt="Fix issue #42"))

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -161,6 +161,37 @@ class TestBuildSkillsMcpUrl:
 
 
 class TestDiscoverClaudeModels:
+    def test_lists_all_anthropic_model_ids_without_legacy_validation(self, monkeypatch):
+        captured = {}
+        payload = {
+            "data": [
+                {"id": "system.ai.claude-opus-5"},
+                {"id": "databricks-claude-sonnet-5"},
+                {"id": "opaque-model-id"},
+                {"id": "opaque-model-id"},
+                {"id": ""},
+            ]
+        }
+
+        def fake_get(url, token):
+            captured["request"] = (url, token)
+            return payload, None
+
+        monkeypatch.setattr(db_mod, "_http_get_json", fake_get)
+
+        models, reason = db_mod.list_anthropic_models(WS, "token")
+
+        assert reason is None
+        assert models == [
+            "system.ai.claude-opus-5",
+            "databricks-claude-sonnet-5",
+            "opaque-model-id",
+        ]
+        assert captured["request"] == (
+            f"{WS}/ai-gateway/anthropic/v1/models",
+            "token",
+        )
+
     def test_selects_opus_4_8_when_advertised(self, monkeypatch):
         payload = {
             "data": [


### PR DESCRIPTION
## Summary

- initialize a Claude Code `PreToolUse` hook for `Agent` calls when `ENABLE_SMART_ROUTING_V2=1`
- pass the discovered compatible Anthropic model menu and subagent prompt to Unity Gateway smart routing
- override the subagent tool input with the selected Claude model
- preserve the existing legacy Claude routing path when V2 is disabled

https://docs.google.com/document/d/1lO1l3sOH0V9_YIx2SQQIvDOBlBJfIwpITLFl1rYTZ7s/edit?tab=t.whcgscnu6a6r

## Testing

- `uv run pytest tests/test_claude_smart_routing_v2.py tests/test_claude_routing.py tests/test_cli.py -q`
- `uv run ruff check .`
- `uv run ruff format --check src/ tests/`

<img width="1291" height="968" alt="Screenshot 2026-08-28 at 3 53 54 PM" src="https://github.com/user-attachments/assets/4b8ca046-df3d-4b71-8cb8-4330f0ddbc94" />

logs:
```
{"decision_id": "63fe7743a93e444d867f43e4669e9b88", "session_id": "592c41aa-8cf8-4e1d-966a-92fc10d64598", "task_name": "There is a config loader in this repository (working directory /home/lilly.luo/ucode, but search the whole repo \u2014 it may be elsewhere) that parses config files of the form `key = value`. The bug: when it parses a line, it strips trailing whitespace from the value before storing it, so a setting like `token = abc123 ` (with a trailing space) gets stored as `abc123`, which no longer matches the literal value the user typed, breaking downstream equality checks.\n\nYour task:\n1. Locate the config loader / config-file parsing code. Search for where lines are split on a delimiter (`=` or similar) and where `.strip()` / `.rstrip()` / trimming is applied to the value.\n2. Fix the trimming logic so the value preserves the EXACT characters between the delimiter and the end of the line, including any trailing spaces. \n   - IMPORTANT: Preserve existing behavior for LEADING whitespace (i.e. if leading whitespace after the delimiter is currently stripped, keep stripping it; the fix is only about trailing whitespace).\n   - Do NOT change behavior for keys or any other fields \u2014 only the value's trailing-whitespace handling.\n3. Add a focused regression test that covers a value with trailing spaces (assert the stored value still contains the trailing spaces exactly). Follow the existing test conventions in the repo (this repo uses pytest; run with `uv run pytest`).\n4. Run the relevant tests to confirm the fix works and nothing else broke (`uv run pytest tests/<the_file>.py`, and consider running the loader-related tests).\n\nReport back: the exact file(s) and line(s) you changed, a diff of the change, the test you added, and the test run output. If you cannot find a config loader that does trailing-whitespace trimming, report what you found instead of guessing \u2014 do not invent a loader.", "router_model": "claude-sonnet-5", "requested_model": "system.ai.claude-sonnet-5", "rationale": "Routed to claude-sonnet-5 because [not_crosscutting AND not_mixed_change AND low_ambiguity] not all hold -> default claude-sonnet-5.", "at": 1787946656.952682}
``` 

audit log: 
```
{"agent_id": "a4bb6a9724d8df438", "agent_type": "ucode-route-claude-sonnet-5-413de6c6", "model": null, "session_id": "592c41aa-8cf8-4e1d-966a-92fc10d64598", "at": 1787946657.2221286, "decision_id": "63fe7743a93e444d867f43e4669e9b88", "router_model": "claude-sonnet-5", "requested_model": "system.ai.claude-sonnet-5", "matches_router_decision": null}
``` 

