### PR TITLE
Preserve agent names in launch banners

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -1613,7 +1613,7 @@ def _fetch_budget_recommendation(state: dict, managed: dict | None) -> dict | No
 
 
 def _launch_title(tool: str) -> str:
-    return f"Launching {TOOL_SPECS[tool]['display'].title()} with Unity Gateway"
+    return f"Launching {TOOL_SPECS[tool]['display']} with Unity Gateway"
 
 
 def _print_budget_panel(recommendation: dict, tool: str, managed: dict | None = None) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1131,6 +1131,10 @@ class TestAutoConfigureOnFirstRun:
     [
         ("claude", "Launching Claude Code with Unity Gateway"),
         ("codex", "Launching Codex with Unity Gateway"),
+        ("gemini", "Launching Gemini CLI with Unity Gateway"),
+        ("opencode", "Launching OpenCode with Unity Gateway"),
+        ("copilot", "Launching GitHub Copilot CLI with Unity Gateway"),
+        ("pi", "Launching Pi with Unity Gateway"),
     ],
 )
 def test_launch_title(tool, expected):


### PR DESCRIPTION
## Summary
- preserve canonical agent capitalization in Unity Gateway launch banners
- cover Codex, Claude Code, Gemini CLI, OpenCode, GitHub Copilot CLI, and Pi
- keep Cursor's separate banner unchanged because it uses Cursor's own account

## Testing
- Ruff check passed
- Python syntax compilation passed
- git diff --check passed
- focused pytest blocked by missing `websockets` dependency in the environment