### PR TITLE
[AIGTWY-4565] Scope Claude model discovery to MPS

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -1150,11 +1150,11 @@ def _original_launch_model(state: dict) -> str | None:
     return default_model(state)
 
 
-def _has_provider_launch(state: dict) -> bool:
+def _launch_provider(state: dict) -> str | None:
     transient = state.get("_claude_launch_provider")
-    return (isinstance(transient, str) and bool(transient.strip())) or bool(
-        get_provider_service(state, "claude")
-    )
+    if isinstance(transient, str) and transient.strip():
+        return transient.strip()
+    return get_provider_service(state, "claude")
 
 
 def _launch_model_args(tool_args: list[str], launch_model: str | None) -> list[str]:
@@ -1260,7 +1260,9 @@ def _rewrite_relayed_port(state: dict, port: int) -> None:
         write_json_file(CLAUDE_SETTINGS_PATH, settings)
 
 
-def _launch_relayed(state: dict, binary: str, tool_args: list[str]) -> None:
+def _launch_relayed(
+    state: dict, binary: str, tool_args: list[str], *, provider: str | None = None
+) -> None:
     """Relayed launch: sign into the Claude subscription, start the loopback
     refresh proxy, then run Claude Code alongside it (the proxy must outlive the
     exec, so we spawn-and-wait rather than replacing the process)."""
@@ -1276,6 +1278,7 @@ def _launch_relayed(state: dict, binary: str, tool_args: list[str]) -> None:
         port,
         token_header=gateway_proxy.AI_GATEWAY_TOKEN_HEADER,
         force_refresh_near_expiry=False,
+        model_provider_service=provider,
     )
     # start_proxy falls back to an OS-assigned port when the cached one is taken
     # (stale proxy from a killed session). Reconcile settings + state to whatever
@@ -1300,6 +1303,41 @@ def _launch_relayed(state: dict, binary: str, tool_args: list[str]) -> None:
     raise SystemExit(returncode)
 
 
+def _launch_with_discovery_proxy(
+    state: dict, binary: str, tool_args: list[str], *, provider: str
+) -> None:
+    workspace = state["workspace"]
+    server, cache, client = gateway_proxy.start_proxy(
+        workspace,
+        state.get("profile"),
+        0,
+        token_header=gateway_proxy.AUTHORIZATION_HEADER,
+        force_refresh_near_expiry=True,
+        model_provider_service=provider,
+    )
+    token = cache.token
+    os.environ["OAUTH_TOKEN"] = token
+    os.environ["ANTHROPIC_AUTH_TOKEN"] = token
+    os.environ["ANTHROPIC_BASE_URL"] = f"http://{LOOPBACK_HOST}:{server.server_address[1]}"
+    os.environ["CLAUDE_CODE_USE_GATEWAY"] = "1"
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    settings = {"env": {"ANTHROPIC_BASE_URL": os.environ["ANTHROPIC_BASE_URL"]}}
+    try:
+        proc = subprocess.Popen(_build_claude_argv(binary, tool_args, settings_override=settings))
+        try:
+            returncode = proc.wait()
+        except KeyboardInterrupt:
+            proc.send_signal(signal.SIGINT)
+            returncode = proc.wait()
+    finally:
+        cache.stop()
+        server.shutdown()
+        client.close()
+    raise SystemExit(returncode)
+
+
 def launch(
     state: dict,
     tool_args: list[str],
@@ -1308,8 +1346,9 @@ def launch(
 ) -> None:
     binary = SPEC["binary"]
     workspace = state.get("workspace")
+    provider = _launch_provider(state)
     if state.get("claude_relayed"):
-        _launch_relayed(state, binary, tool_args)
+        _launch_relayed(state, binary, tool_args, provider=provider)
         return
     # Smart routing v2 needs Unix PTY support, which Windows does not provide.
     if options.launch_smart_routing and os.name == "nt":
@@ -1329,14 +1368,13 @@ def launch(
             model_name=_maybe_add_1m_suffix,
         )
         return
-    if (
-        workspace
-        and os.environ.get(GATEWAY_MODEL_DISCOVERY_ENV_VAR) == "1"
-        and not _has_provider_launch(state)
-    ):
+    if workspace and os.environ.get(GATEWAY_MODEL_DISCOVERY_ENV_VAR) == "1":
         # Discovery is launch-scoped. Pass it in the process environment rather
         # than persisting it in Claude's private or OS-managed settings.
         os.environ["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
+        if provider:
+            _launch_with_discovery_proxy(state, binary, tool_args, provider=provider)
+            return
     if workspace:
         os.environ["OAUTH_TOKEN"] = get_databricks_token(workspace, state.get("profile"))
     if options.claude_launch_model:

--- a/src/ucode/gateway_proxy.py
+++ b/src/ucode/gateway_proxy.py
@@ -34,6 +34,7 @@ from ucode.databricks import get_databricks_token
 # client-supplied value is replaced, so a stale settings.json value can't leak.
 AI_GATEWAY_TOKEN_HEADER = "X-Databricks-AI-Gateway-Token"
 AUTHORIZATION_HEADER = "Authorization"
+MODEL_PROVIDER_SERVICE_HEADER = "Databricks-Model-Provider-Service"
 # Hop-by-hop headers must not be forwarded across a proxy.
 HOP_BY_HOP_HEADERS = frozenset(
     h.lower()
@@ -200,6 +201,7 @@ class _ProxyHandler(BaseHTTPRequestHandler):
     cache: TokenCache
     client: httpx.Client
     token_header = AI_GATEWAY_TOKEN_HEADER
+    model_provider_service: str | None = None
 
     def log_message(self, format: str, *args: object) -> None:
         return
@@ -211,6 +213,16 @@ class _ProxyHandler(BaseHTTPRequestHandler):
             self.send_error(code, message)
         except OSError:
             pass
+
+    def _forwarded_request_headers(self) -> dict[str, str]:
+        headers = forwarded_request_headers(self, self.cache.token, self.token_header)
+        if (
+            self.command == "GET"
+            and self.path.partition("?")[0] == "/v1/models"
+            and self.model_provider_service
+        ):
+            headers[MODEL_PROVIDER_SERVICE_HEADER] = self.model_provider_service
+        return headers
 
     def _handle(self) -> None:
         diagnostic_id = uuid.uuid4().hex[:12]
@@ -226,7 +238,7 @@ class _ProxyHandler(BaseHTTPRequestHandler):
         )
         try:
             # First attempt with the current token.
-            headers = forwarded_request_headers(self, self.cache.token, self.token_header)
+            headers = self._forwarded_request_headers()
             with self.client.stream(self.command, url, headers=headers, content=body) as resp:
                 log_proxy_diagnostic(
                     "upstream_headers",
@@ -256,7 +268,7 @@ class _ProxyHandler(BaseHTTPRequestHandler):
                 # which otherwise reads as an Anthropic `/login` prompt and sends the
                 # user to the wrong re-auth. Still retry + relay with the existing token.
                 log_token_refresh_failure(exc)
-            headers = forwarded_request_headers(self, self.cache.token, self.token_header)
+            headers = self._forwarded_request_headers()
             with self.client.stream(self.command, url, headers=headers, content=body) as resp:
                 log_proxy_diagnostic(
                     "upstream_headers",
@@ -374,6 +386,7 @@ def start_proxy(
     port: int,
     token_header: str,
     force_refresh_near_expiry: bool,
+    model_provider_service: str | None = None,
 ) -> tuple[ThreadingHTTPServer, TokenCache, httpx.Client]:
     """Start the loopback refresh proxy + its background token refresher.
 
@@ -399,7 +412,12 @@ def start_proxy(
     handler = type(
         "BoundProxyHandler",
         (_ProxyHandler,),
-        {"cache": cache, "client": client, "token_header": token_header},
+        {
+            "cache": cache,
+            "client": client,
+            "token_header": token_header,
+            "model_provider_service": model_provider_service,
+        },
     )
     try:
         server = ThreadingHTTPServer(("127.0.0.1", port), handler)

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -205,10 +205,7 @@ class TestRenderOverlay:
         overlay, _ = claude.render_overlay(WS, "s4")
         assert "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY" not in overlay["env"]
 
-    def test_gateway_model_discovery_skipped_under_provider(self, monkeypatch):
-        # A Model Provider Service routes every request to the external provider,
-        # so a discovered gateway endpoint id would reach a provider that can't
-        # resolve it — discovery must be off in that mode.
+    def test_gateway_model_discovery_not_persisted_under_provider(self, monkeypatch):
         monkeypatch.setenv("ENABLE_CLAUDE_CODE_GATEWAY_MODEL_DISCOVERY", "1")
         overlay, _ = claude.render_overlay(WS, "s4", provider="main.x.claude-svc")
         assert "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY" not in overlay["env"]
@@ -1094,7 +1091,14 @@ class TestClaudeLaunch:
             def wait(self):
                 return 0
 
-        def start_proxy(workspace, profile, port, token_header, force_refresh_near_expiry):
+        def start_proxy(
+            workspace,
+            profile,
+            port,
+            token_header,
+            force_refresh_near_expiry,
+            model_provider_service=None,
+        ):
             calls.append(
                 (
                     "proxy",
@@ -1103,6 +1107,7 @@ class TestClaudeLaunch:
                     port,
                     token_header,
                     force_refresh_near_expiry,
+                    model_provider_service,
                 )
             )
             return Server(), Cache(), Client()
@@ -1119,6 +1124,7 @@ class TestClaudeLaunch:
                     "profile": "test",
                     "claude_relayed": True,
                     "relayed_proxy_port": 12345,
+                    "_claude_launch_provider": "main.default.anthropic",
                 },
                 ["--debug"],
                 options=LaunchOptions(),
@@ -1132,6 +1138,7 @@ class TestClaudeLaunch:
             12345,
             claude.gateway_proxy.AI_GATEWAY_TOKEN_HEADER,
             False,
+            "main.default.anthropic",
         )
         assert calls[-3:] == [("stop",), ("shutdown",), ("close",)]
 
@@ -1233,6 +1240,63 @@ class TestClaudeLaunch:
         assert os.environ["OAUTH_TOKEN"] == "token"
         assert os.environ["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] == "1"
         assert calls == [["claude", "--settings", str(claude.CLAUDE_SETTINGS_PATH), "--debug"]]
+
+    def test_gateway_discovery_injects_launch_provider(self, monkeypatch):
+        calls: list[tuple] = []
+
+        class Server:
+            server_address = ("127.0.0.1", 12345)
+
+            def serve_forever(self):
+                calls.append(("serve",))
+
+            def shutdown(self):
+                calls.append(("shutdown",))
+
+        class Cache:
+            token = "fresh-token"
+
+            def stop(self):
+                calls.append(("stop",))
+
+        class Client:
+            def close(self):
+                calls.append(("close",))
+
+        class Process:
+            def __init__(self, argv):
+                calls.append(("popen", argv))
+
+            def wait(self):
+                return 0
+
+        def start_proxy(*args, **kwargs):
+            calls.append(("proxy", args, kwargs))
+            return Server(), Cache(), Client()
+
+        monkeypatch.delenv(v2.ENV_VAR, raising=False)
+        monkeypatch.setenv(claude.GATEWAY_MODEL_DISCOVERY_ENV_VAR, "1")
+        monkeypatch.setattr(claude.gateway_proxy, "start_proxy", start_proxy)
+        monkeypatch.setattr(claude.subprocess, "Popen", Process)
+
+        with pytest.raises(SystemExit) as exc:
+            claude.launch(
+                {"workspace": WS, "_claude_launch_provider": "main.default.anthropic"},
+                ["--debug"],
+                options=LaunchOptions(),
+            )
+
+        assert exc.value.code == 0
+        assert calls[0] == (
+            "proxy",
+            (WS, None, 0),
+            {
+                "token_header": claude.gateway_proxy.AUTHORIZATION_HEADER,
+                "force_refresh_near_expiry": True,
+                "model_provider_service": "main.default.anthropic",
+            },
+        )
+        assert calls[-3:] == [("stop",), ("shutdown",), ("close",)]
 
 
 class TestWriteToolConfigPrunesStaleModelEnv:

--- a/tests/test_gateway_proxy.py
+++ b/tests/test_gateway_proxy.py
@@ -328,9 +328,11 @@ class _FakeClient:
     def __init__(self, responses):
         self._responses = list(responses)
         self.sent_tokens: list[str | None] = []
+        self.sent_headers: list[dict[str, str]] = []
 
     def stream(self, _method, _url, headers, content):
         self.sent_tokens.append(headers.get(gateway_proxy.AI_GATEWAY_TOKEN_HEADER))
+        self.sent_headers.append(headers)
         return self._responses.pop(0)
 
 
@@ -392,6 +394,28 @@ class _Collect(io.RawIOBase):
 
 
 class TestRetryOn401:
+    def test_injects_provider_header_into_model_discovery(self):
+        client = _FakeClient([_FakeResp(200, b'{"data":[]}')])
+        handler = _handle_handler(client, _FakeCache(), _Collect())
+        handler.command = "GET"
+        handler.path = "/v1/models?limit=20"
+        handler.model_provider_service = "main.default.anthropic"
+
+        handler._handle()
+
+        assert client.sent_headers[0][gateway_proxy.MODEL_PROVIDER_SERVICE_HEADER] == (
+            "main.default.anthropic"
+        )
+
+    def test_does_not_inject_provider_header_into_inference(self):
+        client = _FakeClient([_FakeResp(200, b"ok")])
+        handler = _handle_handler(client, _FakeCache(), _Collect())
+        handler.model_provider_service = "main.default.anthropic"
+
+        handler._handle()
+
+        assert gateway_proxy.MODEL_PROVIDER_SERVICE_HEADER not in client.sent_headers[0]
+
     def test_401_forces_refresh_and_retries(self):
         # A stale swap token yields 401; the proxy force-refreshes and retries,
         # this time succeeding, so Claude Code never sees the 401.
@@ -463,11 +487,13 @@ class TestStartProxyPortFallback:
                 busy_port,
                 token_header=gateway_proxy.AI_GATEWAY_TOKEN_HEADER,
                 force_refresh_near_expiry=False,
+                model_provider_service="main.default.anthropic",
             )
             try:
                 bound = server.server_address[1]
                 assert bound != busy_port  # fell back to a different, free port
                 assert bound != 0
+                assert server.RequestHandlerClass.model_provider_service == "main.default.anthropic"
             finally:
                 server.server_close()
                 client.close()


### PR DESCRIPTION
## Summary

When Claude is launched with `--provider` and model discovery enabled, proxy `GET /v1/models` and inject `Databricks-Model-Provider-Service`. Other requests keep their existing headers.

Server counterpart: https://github.com/databricks-eng/universe/pull/2523045

## Testing

- `uv run pytest tests/test_agent_claude.py tests/test_gateway_proxy.py -q` (161 passed)
- `uv run ruff check` on changed files
- `uv run ruff format --check` on changed files