### PR TITLE
if smart routing v2 + codex, refresh model list if oss_models not present 

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -1829,6 +1829,10 @@ def _can_launch_from_cached_config(
     if refresh or model or explicit_provider is not None:
         return False
 
+    if tool == "codex" and smart_routing_v2.enabled():
+        if not state.get("codex_models") or not state.get("oss_models"):
+            return False
+
     smart_routing_enabled = _ROUTING_AGENTS[tool].smart_routing_enabled(state)
     legacy_smart_routing_enabled = enable_smart_routing_flag or smart_routing_enabled
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1352,6 +1352,48 @@ class TestCachedConfigPredicate:
                 is True
             )
 
+    def test_accepts_codex_v2_launch_with_complete_model_cache(self, monkeypatch):
+        import ucode.cli as cli_mod
+
+        monkeypatch.setenv("ENABLE_SMART_ROUTING_V2", "1")
+        state = {
+            **MINIMAL_STATE,
+            "codex_models": ["system.ai.gpt-5-6-sol"],
+            "oss_models": ["system.ai.glm-5-2"],
+        }
+        with (
+            patch("ucode.cli.managed_agent_config_enabled", return_value=False),
+            patch("ucode.cli.codex_agent.has_ucode_config", return_value=True),
+        ):
+            assert cli_mod._can_launch_from_cached_config("codex", state, **self._kwargs()) is True
+
+    @pytest.mark.parametrize(
+        ("incomplete_key", "value"),
+        [
+            ("codex_models", None),
+            ("codex_models", []),
+            ("oss_models", None),
+            ("oss_models", []),
+        ],
+    )
+    def test_rejects_codex_v2_launch_with_incomplete_model_cache(
+        self, monkeypatch, incomplete_key, value
+    ):
+        import ucode.cli as cli_mod
+
+        monkeypatch.setenv("ENABLE_SMART_ROUTING_V2", "1")
+        state = {
+            **MINIMAL_STATE,
+            "codex_models": ["system.ai.gpt-5-6-sol"],
+            "oss_models": ["system.ai.glm-5-2"],
+        }
+        if value is None:
+            state.pop(incomplete_key)
+        else:
+            state[incomplete_key] = value
+        with patch("ucode.cli.managed_agent_config_enabled", return_value=False):
+            assert cli_mod._can_launch_from_cached_config("codex", state, **self._kwargs()) is False
+
     @pytest.mark.parametrize(
         "override",
         [


### PR DESCRIPTION
## Summary
- bypass the cached Codex launch path when smart-routing v2 is missing either model bucket
- refresh both Codex and OSS model caches so GLM/Kimi/DeepSeek remain router options
- cover missing, empty, and complete cache states

If users run `ENABLE_SMART_ROUTING_V2 ucode codex`, the behavior in main is to only pull codex_models. however, we need to also refresh oss_models because oss_models oss models should also be included in smart router. 

this PR updates such that if ENABLE_SMART_ROUTING_V2=1, codex, and oss_models not present in state, then do not do fast startup so that we can pull oss_models. future starts will do fast startup 

## Testing
- `.venv/bin/pytest tests/test_cli.py::TestCachedConfigPredicate -q`
- `.venv/bin/ruff check src/ucode/cli.py tests/test_cli.py`