### PR TITLE
MPS: resolve relayed --model against a curated target allowlist

### DIFF
--- a/src/ucode/agents/__init__.py
+++ b/src/ucode/agents/__init__.py
@@ -335,10 +335,10 @@ def resolve_provider_models(
     """Validate ``provider`` for ``tool`` and return the model ids to pin.
 
     Returns ``(provider_models, error, relayed)``. ``provider_models`` is a ``{family: model_id}``
-    dict re-derived from the service's live targets for a non-relayed claude service — both Bedrock
-    (provider-side slugs) and API-key Anthropic (canonical ids) — so the client sends exactly the ids
-    the MPS allows rather than Claude Code's defaults, which may not match the declared targets. It is
-    None when ``provider`` is None, for a relayed subscription (see below), or for a non-Claude (e.g.
+    dict re-derived from the service's declared targets — Bedrock (provider-side slugs), API-key
+    Anthropic, and relayed Anthropic that declares a curated allowlist alike — so the client uses the
+    ids the MPS allows rather than Claude Code's defaults. It is None when ``provider`` is None, when
+    the service declares no Claude targets (e.g. an ``allow_all`` relay), or for a non-Claude (e.g.
     codex) service. ``relayed`` is True for a credential-less Anthropic subscription relay, which the
     launch path wires with the relayed overlay + refresh proxy. A non-None ``error`` means the
     provider is invalid for the tool and the caller should not launch.
@@ -355,10 +355,8 @@ def resolve_provider_models(
     if error or service is None:
         return None, error, False
     relayed = bool(service.get("relayed"))
-    # Relayed (Claude Max/Enterprise subscription) is exempt: the gateway disables
-    # model selection server-side for that tier, so there's nothing to reconcile.
-    if relayed:
-        return None, None, relayed
+    # Relayed services enforce their declared targets too, so map them like any Anthropic service
+    # (allow_all declares none). relayed gates auth, not model reconciliation.
     # Only Claude pins per-family model ids. Codex ignores this map, and gemini resolves
     # its target through resolve_gemini_provider_model instead — so mapping their targets
     # through Claude-family logic would be meaningless (see docstring).

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -2109,15 +2109,24 @@ def _launch_tool(
         # The router's per-launch pick for the root session. Codex pins it as the
         # resolved model; claude pins it via ANTHROPIC_MODEL (route_root_model).
         route_root_model = None
+        relayed_forward_model = None  # forwarded to Claude Code's --model for a relayed provider
         if provider:
             # Routing through a Model Provider Service pins no Databricks model;
             # the agent uses its own canonical model names (header selects the
             # provider). Skip model resolution, which would otherwise fail when
             # the workspace has no matching Databricks models.
             resolved_model = None
-            # Relayed services forward --model to Claude Code's own flag at launch (below), not env.
-            if tool == "claude" and not relayed and (model or provider_models):
-                route_root_model = resolve_provider_launch_model(model, provider_models or {})
+            if tool == "claude" and (model or provider_models):
+                if relayed:
+                    # Resolve against a curated allowlist so the forwarded id is one the gateway
+                    # allows; an allow_all relay declares none, so forward as-is.
+                    relayed_forward_model = (
+                        resolve_provider_launch_model(model, provider_models, always_select=True)
+                        if provider_models
+                        else model
+                    )
+                else:
+                    route_root_model = resolve_provider_launch_model(model, provider_models or {})
             if tool == "gemini":
                 # Gemini is the exception: the request still names a concrete model
                 # in the URL, so pin one of the service's targets (--model or default).
@@ -2158,10 +2167,17 @@ def _launch_tool(
             custom_model=None,
             coding_agent_config_defaults=coding_agent_config_defaults,
         )
-        # Relayed = a Claude subscription: forward --model to Claude Code's own flag, like `-- --model X`.
-        if tool == "claude" and provider and relayed and model and not forwarded_model:
-            ctx.args = ["--model", model, *ctx.args]
-            forwarded_model = model
+        # Relayed = a Claude subscription: forward the model to Claude Code's own flag, like `-- --model X`.
+        should_forward_relayed_model = (
+            tool == "claude"
+            and provider
+            and relayed
+            and relayed_forward_model
+            and not forwarded_model
+        )
+        if should_forward_relayed_model:
+            ctx.args = ["--model", relayed_forward_model, *ctx.args]
+            forwarded_model = relayed_forward_model
         print_section(_launch_title(tool))
         if managed is not None:
             print_kv("Config", "workspace-managed")

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -2124,7 +2124,7 @@ def _launch_tool(
                     # Resolve against a curated allowlist so the forwarded id is one the gateway
                     # allows; an allow_all relay declares none, so forward as-is.
                     relayed_forward_model = (
-                        resolve_provider_launch_model(model, provider_models, always_select=True)
+                        resolve_provider_launch_model(model, provider_models)
                         if provider_models
                         else model
                     )

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -2472,31 +2472,25 @@ def map_claude_family_models(targets: list[str]) -> dict[str, str]:
     return result
 
 
-# Claude Code starts every session on its opus tier, which the gateway 403s when a Model Provider
-# Service declares no opus target. When opus is missing, fall back to the most capable tier the
-# service does offer. opus > sonnet > haiku.
-_CLAUDE_LAUNCH_TIER_PREFERENCE = ("opus", "sonnet", "haiku")
+# A bare launch pins the first tier the service offers, so it never dead-ends on a model the
+# gateway 403s. Sonnet first: it's Claude Code's own default tier, so we keep that balanced default
+# rather than jumping to opus, then fall back to the next offered tier when sonnet isn't allowed.
+_CLAUDE_LAUNCH_TIER_PREFERENCE = ("sonnet", "opus", "haiku")
 
 
-def resolve_provider_launch_model(
-    model: str | None, provider_models: dict[str, str], *, always_select: bool = False
-) -> str | None:
-    """Pick the model a provider-routed Claude session starts on, or None to keep Claude Code's default.
+def resolve_provider_launch_model(model: str | None, provider_models: dict[str, str]) -> str | None:
+    """Pick the model a provider-routed Claude session starts on, or None if it declares no tier.
 
     ``provider_models`` maps the Claude families a service declares to their target ids (see
     ``map_claude_family_models``). With an explicit ``model`` (``ucode claude --model``) the user's
     choice wins: a family alias resolves to that tier's declared target (erroring when the service
     doesn't offer it), any other value is trusted as a raw target id the service allows. Without one,
-    return the most capable tier the service offers.
+    pin the service's preferred offered tier (``_CLAUDE_LAUNCH_TIER_PREFERENCE``).
 
-    ``always_select`` decides the no-``model`` case for a curated allowlist. Claude Code's own launch
-    default is a fixed model (observed: ``claude-sonnet-5``) that a curated service may not allow. A
-    relayed launch picks its model through Claude Code's ``--model`` flag, so it sets
-    ``always_select=True`` to always resolve a concrete *offered* target and forward that — otherwise
-    the session starts on that default and the gateway 403s it. Left False (non-relayed), we return
-    None when opus is offered and defer to Claude Code's tier resolution via the pinned
-    ``ANTHROPIC_DEFAULT_*`` aliases (a known gap: that assumes an opus default, but the real default
-    is sonnet, so a non-relayed opus+haiku-without-sonnet service can still 403 on a bare launch).
+    We always pin a concrete offered target rather than letting Claude Code fall back to its own
+    launch default: that default (observed: ``claude-sonnet-5``) isn't guaranteed to be in a curated
+    service's allowlist, so deferring to it can 403, while an offered tier can't. The relayed and
+    non-relayed paths resolve identically; the user can still switch tiers in-session via ``/model``.
     """
     if model:
         if model in ANTHROPIC_FAMILIES:
@@ -2509,8 +2503,6 @@ def resolve_provider_launch_model(
                 )
             return target
         return model
-    if not always_select and provider_models.get("opus"):
-        return None
     return next(
         (
             provider_models[fam]

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -2445,16 +2445,25 @@ def map_claude_family_models(targets: list[str]) -> dict[str, str]:
 _CLAUDE_LAUNCH_TIER_PREFERENCE = ("opus", "sonnet", "haiku")
 
 
-def resolve_provider_launch_model(model: str | None, provider_models: dict[str, str]) -> str | None:
+def resolve_provider_launch_model(
+    model: str | None, provider_models: dict[str, str], *, always_select: bool = False
+) -> str | None:
     """Pick the model a provider-routed Claude session starts on, or None to keep Claude Code's default.
 
     ``provider_models`` maps the Claude families a service declares to their target ids (see
     ``map_claude_family_models``). With an explicit ``model`` (``ucode claude --model``) the user's
     choice wins: a family alias resolves to that tier's declared target (erroring when the service
     doesn't offer it), any other value is trusted as a raw target id the service allows. Without one,
-    return None when the service offers opus — Claude Code's own default already works, so we avoid
-    setting ANTHROPIC_MODEL and the duplicate ``/model`` picker row it produces — else the most
-    capable tier the service does offer, so the launch doesn't dead-end on an unservable opus.
+    return the most capable tier the service offers.
+
+    ``always_select`` decides the no-``model`` case for a curated allowlist. Claude Code's own launch
+    default is a fixed model (observed: ``claude-sonnet-5``) that a curated service may not allow. A
+    relayed launch picks its model through Claude Code's ``--model`` flag, so it sets
+    ``always_select=True`` to always resolve a concrete *offered* target and forward that — otherwise
+    the session starts on that default and the gateway 403s it. Left False (non-relayed), we return
+    None when opus is offered and defer to Claude Code's tier resolution via the pinned
+    ``ANTHROPIC_DEFAULT_*`` aliases (a known gap: that assumes an opus default, but the real default
+    is sonnet, so a non-relayed opus+haiku-without-sonnet service can still 403 on a bare launch).
     """
     if model:
         if model in ANTHROPIC_FAMILIES:
@@ -2467,7 +2476,7 @@ def resolve_provider_launch_model(model: str | None, provider_models: dict[str, 
                 )
             return target
         return model
-    if provider_models.get("opus"):
+    if not always_select and provider_models.get("opus"):
         return None
     return next(
         (

--- a/tests/test_agents_init.py
+++ b/tests/test_agents_init.py
@@ -360,7 +360,8 @@ class TestResolveProviderModels:
         )
         assert (models, error, relayed) == (None, None, False)
 
-    def test_relayed_anthropic_flagged(self, monkeypatch):
+    def test_relayed_allow_all_pins_nothing(self, monkeypatch):
+        # allow_all relay declares no Claude targets: nothing pinned, still flagged relayed.
         self._patch(
             monkeypatch, {"provider_type": "anthropic", "targets": [], "relayed": True}, None
         )
@@ -369,6 +370,24 @@ class TestResolveProviderModels:
         )
         assert error is None
         assert models is None
+        assert relayed is True
+
+    def test_relayed_anthropic_with_targets_pins_family(self, monkeypatch):
+        # A curated relay maps its declared targets by family so --model can resolve against them.
+        self._patch(
+            monkeypatch,
+            {
+                "provider_type": "anthropic",
+                "targets": ["claude-opus-4-8", "claude-haiku-4-5"],
+                "relayed": True,
+            },
+            None,
+        )
+        models, error, relayed = agents_mod.resolve_provider_models(
+            "claude", self._STATE, "main.a.relayed_ent"
+        )
+        assert error is None
+        assert models == {"opus": "claude-opus-4-8", "haiku": "claude-haiku-4-5"}
         assert relayed is True
 
     def test_bedrock_returns_pinned_models(self, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -958,7 +958,7 @@ class TestClaudeModelFlag:
         assert "ignored" not in _strip_ansi(result.output)
 
     def test_relayed_provider_without_model_forwards_nothing(self, monkeypatch):
-        # No --model on a relayed launch: nothing to forward.
+        # No --model on an allow_all relay: nothing to forward.
         result, _, mock_launch = self._provider_launch(
             monkeypatch,
             ["claude", "--provider", "cat.schema.svc"],
@@ -967,6 +967,38 @@ class TestClaudeModelFlag:
         )
         assert result.exit_code == 0, result.output
         assert mock_launch.call_args.args[2] == []
+
+    def test_relayed_allowlist_resolves_model_to_declared_target(self, monkeypatch):
+        # Curated relay: --model resolves to the declared id, which is what gets forwarded.
+        result, _, mock_launch = self._provider_launch(
+            monkeypatch,
+            ["claude", "--model", "opus", "--provider", "cat.schema.svc"],
+            {"opus": "claude-opus-4-8", "haiku": "claude-haiku-4-5"},
+            relayed=True,
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_launch.call_args.args[2] == ["--model", "claude-opus-4-8"]
+
+    def test_relayed_allowlist_auto_picks_best_tier_without_model(self, monkeypatch):
+        # Curated relay, no --model: forward the best allowed tier, not the (maybe forbidden) default.
+        result, _, mock_launch = self._provider_launch(
+            monkeypatch,
+            ["claude", "--provider", "cat.schema.svc"],
+            {"opus": "claude-opus-4-8", "sonnet": "claude-sonnet-5"},
+            relayed=True,
+        )
+        assert result.exit_code == 0, result.output
+        assert mock_launch.call_args.args[2] == ["--model", "claude-opus-4-8"]
+
+    def test_relayed_allowlist_rejects_unavailable_family(self, monkeypatch):
+        result, _, _ = self._provider_launch(
+            monkeypatch,
+            ["claude", "--model", "opus", "--provider", "cat.schema.svc"],
+            {"sonnet": "claude-sonnet-5", "haiku": "claude-haiku-4-5"},
+            relayed=True,
+        )
+        assert result.exit_code == 1
+        assert "does not offer a 'opus' model" in result.output
 
     def test_provider_sets_transient_claude_launch_marker(self):
         state = dict(MINIMAL_STATE)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -912,27 +912,27 @@ class TestClaudeModelFlag:
         assert mock_configure.call_args.kwargs["route_root_model"] == "claude-haiku-4-5"
         assert mock_configure.call_args.kwargs["custom_model"] is None
 
-    def test_provider_without_opus_auto_picks_best_servable_tier(self, monkeypatch):
-        # No --model, and the service declares no opus target: launch on the most capable tier it
-        # does offer (sonnet) instead of dead-ending on Claude Code's opus default.
+    def test_provider_without_sonnet_pins_next_tier(self, monkeypatch):
+        # No --model, sonnet not offered: pin the next preferred allowed tier (haiku here) rather
+        # than dead-ending on Claude Code's sonnet default, which this service doesn't allow.
         result, mock_configure, _ = self._provider_launch(
             monkeypatch,
             ["claude", "--provider", "cat.schema.svc"],
-            {"sonnet": "claude-sonnet-5", "haiku": "claude-haiku-4-5"},
+            {"haiku": "claude-haiku-4-5"},
         )
         assert result.exit_code == 0, result.output
-        assert mock_configure.call_args.kwargs["route_root_model"] == "claude-sonnet-5"
+        assert mock_configure.call_args.kwargs["route_root_model"] == "claude-haiku-4-5"
 
-    def test_provider_with_opus_keeps_claude_default(self, monkeypatch):
-        # Opus is offered, so Claude Code's own default already works — pin nothing (no ANTHROPIC_MODEL
-        # and no duplicate /model picker row).
+    def test_provider_with_opus_still_defaults_to_sonnet(self, monkeypatch):
+        # No --model: pin sonnet (Claude Code's default tier) whenever the service allows it, even
+        # when opus is on offer — we always pin an allowed target instead of deferring to the default.
         result, mock_configure, _ = self._provider_launch(
             monkeypatch,
             ["claude", "--provider", "cat.schema.svc"],
             {"opus": "claude-opus-4-8", "sonnet": "claude-sonnet-5"},
         )
         assert result.exit_code == 0, result.output
-        assert mock_configure.call_args.kwargs["route_root_model"] is None
+        assert mock_configure.call_args.kwargs["route_root_model"] == "claude-sonnet-5"
 
     def test_model_family_not_offered_by_provider_errors(self, monkeypatch):
         result, _, _ = self._provider_launch(
@@ -979,8 +979,9 @@ class TestClaudeModelFlag:
         assert result.exit_code == 0, result.output
         assert mock_launch.call_args.args[2] == ["--model", "claude-opus-4-8"]
 
-    def test_relayed_allowlist_auto_picks_best_tier_without_model(self, monkeypatch):
-        # Curated relay, no --model: forward the best allowed tier, not the (maybe forbidden) default.
+    def test_relayed_allowlist_auto_picks_preferred_tier_without_model(self, monkeypatch):
+        # Curated relay, no --model: forward the preferred allowed tier (sonnet), not the (maybe
+        # forbidden) default. Same resolution as the non-relayed path.
         result, _, mock_launch = self._provider_launch(
             monkeypatch,
             ["claude", "--provider", "cat.schema.svc"],
@@ -988,7 +989,7 @@ class TestClaudeModelFlag:
             relayed=True,
         )
         assert result.exit_code == 0, result.output
-        assert mock_launch.call_args.args[2] == ["--model", "claude-opus-4-8"]
+        assert mock_launch.call_args.args[2] == ["--model", "claude-sonnet-5"]
 
     def test_relayed_allowlist_rejects_unavailable_family(self, monkeypatch):
         result, _, _ = self._provider_launch(

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -694,20 +694,19 @@ class TestMapClaudeFamilyModels:
 
 
 class TestResolveProviderLaunchModel:
-    def test_none_when_service_offers_opus(self):
-        # Claude Code's own opus default already works, so we pin nothing (and avoid the duplicate
-        # /model picker row that setting ANTHROPIC_MODEL causes).
+    def test_defaults_to_sonnet_when_offered(self):
+        # No --model: pin sonnet (Claude Code's own default tier) when the service allows it.
         models = {
             "opus": "claude-opus-4-8",
             "sonnet": "claude-sonnet-5",
             "haiku": "claude-haiku-4-5",
         }
-        assert db_mod.resolve_provider_launch_model(None, models) is None
-
-    def test_falls_back_to_best_tier_when_no_opus(self):
-        # No opus target: launch on the most capable tier the service does offer (sonnet > haiku).
-        models = {"sonnet": "claude-sonnet-5", "haiku": "claude-haiku-4-5"}
         assert db_mod.resolve_provider_launch_model(None, models) == "claude-sonnet-5"
+
+    def test_falls_back_to_opus_when_no_sonnet(self):
+        # Sonnet not offered: pin the next preferred allowed tier (opus) rather than the default.
+        models = {"opus": "claude-opus-4-8", "haiku": "claude-haiku-4-5"}
+        assert db_mod.resolve_provider_launch_model(None, models) == "claude-opus-4-8"
 
     def test_falls_back_to_haiku_when_only_haiku(self):
         assert db_mod.resolve_provider_launch_model(None, {"haiku": "claude-haiku-4-5"}) == (
@@ -732,13 +731,6 @@ class TestResolveProviderLaunchModel:
 
     def test_no_models_and_no_override_is_none(self):
         assert db_mod.resolve_provider_launch_model(None, {}) is None
-
-    def test_always_select_picks_opus_instead_of_default(self):
-        # always_select: pick a tier even when opus is offered (no pinned alias to fall back on).
-        models = {"opus": "claude-opus-4-8", "sonnet": "claude-sonnet-5"}
-        assert db_mod.resolve_provider_launch_model(None, models, always_select=True) == (
-            "claude-opus-4-8"
-        )
 
 
 class TestProviderServicePagination:

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -733,6 +733,13 @@ class TestResolveProviderLaunchModel:
     def test_no_models_and_no_override_is_none(self):
         assert db_mod.resolve_provider_launch_model(None, {}) is None
 
+    def test_always_select_picks_opus_instead_of_default(self):
+        # always_select: pick a tier even when opus is offered (no pinned alias to fall back on).
+        models = {"opus": "claude-opus-4-8", "sonnet": "claude-sonnet-5"}
+        assert db_mod.resolve_provider_launch_model(None, models, always_select=True) == (
+            "claude-opus-4-8"
+        )
+
 
 class TestProviderServicePagination:
     """The listing is paginated; ignoring next_page_token hid services on later pages entirely."""


### PR DESCRIPTION
## Problem

adding enforcement for an allowed models list, if it is specified on the model provider service.

for example, if the MPS only allows for haiku, the client should launch only haiku by default, and not allow any other models to be launched

## Testing
In the tests below, we launch haiku through a parameter, or when nothing is passed in. if we try to specify opus to be launched,it gets rejected

<img width="847" height="207" alt="Screenshot 2026-09-09 at 16 33 01" src="https://github.com/user-attachments/assets/0058df03-f8b3-4440-be7d-327533c005ff" />
<img width="911" height="433" alt="Screenshot 2026-09-09 at 16 32 48" src="https://github.com/user-attachments/assets/70120864-5d7d-4c08-8c90-86e65b3adb6c" />
<img width="906" height="532" alt="Screenshot 2026-09-09 at 16 32 34" src="https://github.com/user-attachments/assets/427ad632-0000-4603-a570-f2cf1a405732" />

