### PR TITLE
only require 2.1.248 for smart routing + model discovery 

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -111,10 +111,7 @@ def _parse_version(value: str) -> tuple[int, int, int] | None:
 
 
 def _installed_version_status() -> tuple[str, bool] | None:
-    if (
-        os.environ.get(GATEWAY_MODEL_DISCOVERY_ENV_VAR) != "1"
-        and not smart_routing_v2.enabled()
-    ):
+    if os.environ.get(GATEWAY_MODEL_DISCOVERY_ENV_VAR) != "1" and not smart_routing_v2.enabled():
         return None
     version = agent_version(SPEC["binary"])
     parsed = _parse_version(version)

--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -111,6 +111,8 @@ def _parse_version(value: str) -> tuple[int, int, int] | None:
 
 
 def _installed_version_status() -> tuple[str, bool] | None:
+    if not smart_routing_v2.enabled():
+        return None
     version = agent_version(SPEC["binary"])
     parsed = _parse_version(version)
     if parsed is None:

--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -111,7 +111,10 @@ def _parse_version(value: str) -> tuple[int, int, int] | None:
 
 
 def _installed_version_status() -> tuple[str, bool] | None:
-    if not smart_routing_v2.enabled():
+    if (
+        os.environ.get(GATEWAY_MODEL_DISCOVERY_ENV_VAR) != "1"
+        and not smart_routing_v2.enabled()
+    ):
         return None
     version = agent_version(SPEC["binary"])
     parsed = _parse_version(version)

--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -123,6 +123,14 @@ def _installed_version_status() -> tuple[str, bool] | None:
     return version, parsed < MINIMUM_CLAUDE_VERSION
 
 
+def _minimum_version_requirement_message(version: str) -> str:
+    feature = "Smart routing" if smart_routing_v2.enabled() else "Model discovery"
+    return (
+        f"{feature} requires Claude Code {MINIMUM_CLAUDE_VERSION_TEXT} or newer. "
+        f"Your current version is Claude Code {version}."
+    )
+
+
 def minimum_version_error() -> str | None:
     status = _installed_version_status()
     if status is None:
@@ -130,11 +138,7 @@ def minimum_version_error() -> str | None:
     version, is_too_old = status
     if not is_too_old:
         return None
-    return (
-        f"Claude Code {version} is too old for gateway model discovery. "
-        f"Claude Code must be updated to {MINIMUM_CLAUDE_VERSION_TEXT} or newer; "
-        f"run `npm install -g {SPEC['package']}` or `ucode configure`."
-    )
+    return _minimum_version_requirement_message(version)
 
 
 def required_update_message() -> str | None:
@@ -144,10 +148,7 @@ def required_update_message() -> str | None:
     version, is_too_old = status
     if not is_too_old:
         return None
-    return (
-        f"Claude Code {version} is older than required {MINIMUM_CLAUDE_VERSION_TEXT}; "
-        "updating Claude Code is required for gateway model discovery."
-    )
+    return _minimum_version_requirement_message(version)
 
 
 def _resolve_web_search_model(state: dict) -> str | None:

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -42,24 +42,34 @@ class TestMinimumVersion:
 
     def test_older_version_requires_update(self, monkeypatch):
         monkeypatch.setenv(v2.ENV_VAR, "1")
-        monkeypatch.setattr(claude, "agent_version", lambda _binary: "2.1.247 (Claude Code)")
+        monkeypatch.setattr(claude, "agent_version", lambda _binary: "2.1.247")
 
         assert claude.minimum_version_error() == (
-            "Claude Code 2.1.247 (Claude Code) is too old for gateway model discovery. "
-            "Claude Code must be updated to 2.1.248 or newer; run "
-            "`npm install -g @anthropic-ai/claude-code` or `ucode configure`."
+            "Smart routing requires Claude Code 2.1.248 or newer. "
+            "Your current version is Claude Code 2.1.247."
         )
         assert claude.required_update_message() == (
-            "Claude Code 2.1.247 (Claude Code) is older than required 2.1.248; "
-            "updating Claude Code is required for gateway model discovery."
+            "Smart routing requires Claude Code 2.1.248 or newer. "
+            "Your current version is Claude Code 2.1.247."
         )
 
     def test_older_version_requires_update_for_model_discovery(self, monkeypatch):
         monkeypatch.setenv(claude.GATEWAY_MODEL_DISCOVERY_ENV_VAR, "1")
         monkeypatch.setattr(claude, "agent_version", lambda _binary: "2.1.247")
 
-        assert claude.minimum_version_error() is not None
-        assert claude.required_update_message() is not None
+        expected = (
+            "Model discovery requires Claude Code 2.1.248 or newer. "
+            "Your current version is Claude Code 2.1.247."
+        )
+        assert claude.minimum_version_error() == expected
+        assert claude.required_update_message() == expected
+
+    def test_smart_routing_message_wins_when_both_features_are_enabled(self, monkeypatch):
+        monkeypatch.setenv(v2.ENV_VAR, "1")
+        monkeypatch.setenv(claude.GATEWAY_MODEL_DISCOVERY_ENV_VAR, "1")
+        monkeypatch.setattr(claude, "agent_version", lambda _binary: "2.1.247")
+
+        assert claude.minimum_version_error().startswith("Smart routing requires")
 
     def test_unknown_version_does_not_block(self, monkeypatch):
         monkeypatch.setenv(v2.ENV_VAR, "1")

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -34,12 +34,14 @@ class TestClaudeSpec:
 class TestMinimumVersion:
     @pytest.mark.parametrize("version", ["2.1.248", "2.1.250", "3.0.0"])
     def test_supported_version(self, monkeypatch, version):
+        monkeypatch.setenv(v2.ENV_VAR, "1")
         monkeypatch.setattr(claude, "agent_version", lambda _binary: version)
 
         assert claude.minimum_version_error() is None
         assert claude.required_update_message() is None
 
     def test_older_version_requires_update(self, monkeypatch):
+        monkeypatch.setenv(v2.ENV_VAR, "1")
         monkeypatch.setattr(claude, "agent_version", lambda _binary: "2.1.247 (Claude Code)")
 
         assert claude.minimum_version_error() == (
@@ -53,7 +55,15 @@ class TestMinimumVersion:
         )
 
     def test_unknown_version_does_not_block(self, monkeypatch):
+        monkeypatch.setenv(v2.ENV_VAR, "1")
         monkeypatch.setattr(claude, "agent_version", lambda _binary: "unknown")
+
+        assert claude.minimum_version_error() is None
+        assert claude.required_update_message() is None
+
+    def test_older_version_is_not_validated_without_smart_routing_v2(self, monkeypatch):
+        monkeypatch.delenv(v2.ENV_VAR, raising=False)
+        monkeypatch.setattr(claude, "agent_version", lambda _binary: "2.1.247")
 
         assert claude.minimum_version_error() is None
         assert claude.required_update_message() is None

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -54,6 +54,13 @@ class TestMinimumVersion:
             "updating Claude Code is required for gateway model discovery."
         )
 
+    def test_older_version_requires_update_for_model_discovery(self, monkeypatch):
+        monkeypatch.setenv(claude.GATEWAY_MODEL_DISCOVERY_ENV_VAR, "1")
+        monkeypatch.setattr(claude, "agent_version", lambda _binary: "2.1.247")
+
+        assert claude.minimum_version_error() is not None
+        assert claude.required_update_message() is not None
+
     def test_unknown_version_does_not_block(self, monkeypatch):
         monkeypatch.setenv(v2.ENV_VAR, "1")
         monkeypatch.setattr(claude, "agent_version", lambda _binary: "unknown")
@@ -61,8 +68,9 @@ class TestMinimumVersion:
         assert claude.minimum_version_error() is None
         assert claude.required_update_message() is None
 
-    def test_older_version_is_not_validated_without_smart_routing_v2(self, monkeypatch):
+    def test_older_version_is_not_validated_without_discovery_features(self, monkeypatch):
         monkeypatch.delenv(v2.ENV_VAR, raising=False)
+        monkeypatch.delenv(claude.GATEWAY_MODEL_DISCOVERY_ENV_VAR, raising=False)
         monkeypatch.setattr(claude, "agent_version", lambda _binary: "2.1.247")
 
         assert claude.minimum_version_error() is None


### PR DESCRIPTION
```
$ uv run ucode claude
✔ Databricks auth already available for https://dbc-a5d4177a-49dc.cloud.databricks.com
✔ Unity AI Gateway detected
• Enter password to configure settings for Claude Code.
✔ Settings configured for Claude Code

╭──────────────────────────────────────────╮
│ Launching Claude Code with Unity Gateway │
╰──────────────────────────────────────────╯
  Model: system.ai.claude-opus-4-8
✔ Starting Claude Code
# lilly.luo at ip-10-93-32-211 in ~/ucode (git:lilly/only-require-2-1-248-for-smart-routing) [21:46:26]
$ uv run ucode claude --enable-smart-routing
ERROR Smart routing requires Claude Code 2.1.248 or newer. Your current version is Claude Code 2.1.246.
# lilly.luo at ip-10-93-32-211 in ~/ucode (git:lilly/only-require-2-1-248-for-smart-routing) [21:58:59]
$ uv run ucode claude --enable-model-discovery
ERROR Model discovery requires Claude Code 2.1.248 or newer. Your current version is Claude Code 2.1.246.
``` 