### PR TITLE
Set Claude tool search flag from 1-> true

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -403,7 +403,7 @@ def render_overlay(
         # Claude Code only sends when experimental betas are enabled — so we must
         # not set CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS (see CLAUDE_REMOVED_ENV_KEYS).
         "ENABLE_PROMPT_CACHING_1H": "1",
-        "ENABLE_TOOL_SEARCH": "1",
+        "ENABLE_TOOL_SEARCH": "true",
         "CLAUDE_CODE_USE_GATEWAY": "1",
     }
     # Intentionally NOT setting ANTHROPIC_MODEL by default. Setting it produces a

--- a/src/ucode/state.py
+++ b/src/ucode/state.py
@@ -194,7 +194,7 @@ def build_agent_state(state: dict) -> dict[str, dict]:
                 "CLAUDE_CODE_API_KEY_HELPER_TTL_MS": str(AUTH_REFRESH_INTERVAL_MS),
                 # Kept in sync with agents/claude.py render_overlay.
                 "ENABLE_PROMPT_CACHING_1H": "1",
-                "ENABLE_TOOL_SEARCH": "1",
+                "ENABLE_TOOL_SEARCH": "true",
                 "CLAUDE_CODE_USE_GATEWAY": "1",
             },
         },

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -188,7 +188,7 @@ class TestRenderOverlay:
 
     def test_enables_tool_search(self):
         overlay, _ = claude.render_overlay(WS, "s4")
-        assert overlay["env"]["ENABLE_TOOL_SEARCH"] == "1"
+        assert overlay["env"]["ENABLE_TOOL_SEARCH"] == "true"
 
     def test_enables_use_gateway(self):
         overlay, _ = claude.render_overlay(WS, "s4")
@@ -620,7 +620,7 @@ class TestWriteToolConfigStripsRemovedEnvKeys:
         claude.write_tool_config(state, "databricks-claude-sonnet-4")
         assert "CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS" not in written[0]["env"]
         assert written[0]["env"]["ENABLE_PROMPT_CACHING_1H"] == "1"
-        assert written[0]["env"]["ENABLE_TOOL_SEARCH"] == "1"
+        assert written[0]["env"]["ENABLE_TOOL_SEARCH"] == "true"
         assert written[0]["env"]["CLAUDE_CODE_USE_GATEWAY"] == "1"
 
     def test_strips_stale_gateway_model_discovery(self, monkeypatch):


### PR DESCRIPTION
Update ENABLE_TOOL_SEARCH from "1" to "true" in Claude configuration. this is technically what Anthropic [recommends](https://code.claude.com/docs/en/agent-sdk/tool-search#configure-tool-search) and it makes us have the same setting as Isaac who uses "true" instead of 1. 

i confirmed with a proxy that the `advanced-tool-use-2025-11-20` header is still sent when "true" is set 