### PR TITLE
skill: add interactive metastore picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,24 @@ ucode configure skills --location main.default,ml.prod --mcp
 Each run prints the registered server, its URL, the configured agents, and its tools, and reminds
 you to run `ucode <agent>` (existing agent sessions need a restart before the MCP tools load).
 
+#### Add skill scopes without replacing existing ones
+
+`ucode skill add` registers skills additively, keeping anything already configured. With `--mcp` it
+adds the schemas to the connection's scope, otherwise it downloads their skills to disk. `--skills`
+narrows a download to a subset of one schema's skills.
+
+```bash
+# Add schemas to the skills MCP scope, keeping any already configured.
+ucode skill add --location main.default,ml.prod --mcp
+
+# Download a schema's skills to disk, keeping existing downloads.
+ucode skill add --location main.default
+
+# Download a named subset, by bare name (with --location) or fully-qualified name.
+ucode skill add --location main.default --skills my-skill,other-skill
+ucode skill add --skills main.default.my-skill,main.default.other-skill
+```
+
 ### Managed config for a workspace (admins)
 
 Author the coding config your developers pick up automatically, instead of asking each of them to
@@ -356,6 +374,9 @@ The output looks like:
 | `ucode configure skills --location main.default [--path <dir>]` | Download a schema's skills to disk (under `<dir>`, or your home dir) and register a schema-less skills MCP connection |
 | `ucode configure skills --location main.default --skill my-skill` | Download only the named skill(s) from a schema (comma-separated for several) |
 | `ucode configure skills --location main.default --mcp` | Expose a schema's skills as MCP tools (override-only) instead of downloading |
+| `ucode skill add --location main.default --mcp` | Add schemas to the skills MCP scope, keeping any already configured (additive; never replaces) |
+| `ucode skill add --location main.default` | Download a schema's skills to disk without removing existing downloads |
+| `ucode skill add --skills main.default.my-skill` | Download a named subset of skills (bare names need `--location`; fully-qualified names stand alone) |
 | `ucode setup` | Author the managed config's agents and models (workspace admins only) |
 | `ucode setup mcps` | Add or change the managed config's MCP servers |
 | `ucode setup skills [--location a.b,c.d]` | Add or change the managed config's skills |

--- a/README.md
+++ b/README.md
@@ -226,9 +226,13 @@ you to run `ucode <agent>` (existing agent sessions need a restart before the MC
 
 `ucode skill add` registers skills additively, keeping anything already configured. With `--mcp` it
 adds the schemas to the connection's scope, otherwise it downloads their skills to disk. `--skills`
-narrows a download to a subset of one schema's skills.
+narrows a download to a subset of one schema's skills. With no selection flags, a searchable picker
+lists finalized skills visible in the metastore.
 
 ```bash
+# Browse the metastore and choose skills to download.
+ucode skill add
+
 # Add schemas to the skills MCP scope, keeping any already configured.
 ucode skill add --location main.default,ml.prod --mcp
 
@@ -374,6 +378,7 @@ The output looks like:
 | `ucode configure skills --location main.default [--path <dir>]` | Download a schema's skills to disk (under `<dir>`, or your home dir) and register a schema-less skills MCP connection |
 | `ucode configure skills --location main.default --skill my-skill` | Download only the named skill(s) from a schema (comma-separated for several) |
 | `ucode configure skills --location main.default --mcp` | Expose a schema's skills as MCP tools (override-only) instead of downloading |
+| `ucode skill add` | Interactively choose finalized metastore skills to download |
 | `ucode skill add --location main.default --mcp` | Add schemas to the skills MCP scope, keeping any already configured (additive; never replaces) |
 | `ucode skill add --location main.default` | Download a schema's skills to disk without removing existing downloads |
 | `ucode skill add --skills main.default.my-skill` | Download a named subset of skills (bare names need `--location`; fully-qualified names stand alone) |

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -97,6 +97,7 @@ from ucode.mcp import (
     MCP_CLIENTS,
     SKILLS_MCP_KIND,
     add_mcp_command,
+    add_skills_command,
     apply_managed_mcp_servers,
     apply_managed_skills,
     configure_mcp_command,
@@ -1159,6 +1160,8 @@ configure_app = typer.Typer(add_completion=False, no_args_is_help=False)
 app.add_typer(configure_app, name="configure", help="Configure workspace and tool settings.")
 mcp_app = typer.Typer(add_completion=False, no_args_is_help=True)
 app.add_typer(mcp_app, name="mcp", help="MCP servers exposed by ucode.")
+skill_app = typer.Typer(add_completion=False, no_args_is_help=True)
+app.add_typer(skill_app, name="skill", help="Databricks Skills for your coding tools.")
 setup_app = typer.Typer(add_completion=False, no_args_is_help=False)
 app.add_typer(
     setup_app,
@@ -1310,6 +1313,101 @@ def mcp_web_search_cmd() -> None:
     from ucode.mcp_web_search import serve
 
     serve()
+
+
+@skill_app.command("add")
+def skills_add(
+    location: Annotated[
+        str | None,
+        typer.Option(
+            "--location", help="Comma-separated `<catalog>.<schema>` skill scopes to add."
+        ),
+    ] = None,
+    mcp: Annotated[
+        bool,
+        typer.Option(
+            "--mcp",
+            help="Add the schemas to the skills MCP connection's scope instead of downloading.",
+        ),
+    ] = False,
+    path: Annotated[
+        str | None,
+        typer.Option(
+            "--path",
+            help="(download) Existing absolute dir to download into; defaults to your home dir.",
+        ),
+    ] = None,
+    skills: Annotated[
+        str | None,
+        typer.Option(
+            "--skills",
+            help="(download) Download only this comma-separated subset of skills instead of "
+            "every skill in the schema. Bare securable names (e.g. `my-skill`) need a single "
+            "--location; fully-qualified `<catalog>.<schema>.<name>` names work on their own. "
+            "Not valid with --mcp.",
+        ),
+    ] = None,
+) -> None:
+    """Add Databricks Skills to your coding tools, keeping any already configured.
+
+    With ``--mcp``, adds the given schemas to the skills MCP connection's scope.
+    Otherwise downloads each schema's skills to disk (under ``--path``, or your home
+    dir), keeping already-downloaded skills. ``--skills`` narrows a download to a
+    subset of one schema's skills, by bare name (with ``--location``) or
+    fully-qualified ``<catalog>.<schema>.<name>``.
+    """
+    try:
+        locations = _parse_skill_locations(location)
+        requested_skills = (
+            None if skills is None else {s.strip() for s in skills.split(",") if s.strip()}
+        )
+        if mcp and path is not None:
+            raise RuntimeError("--path is not supported when using --mcp")
+        if mcp and requested_skills is not None:
+            raise RuntimeError("--skills is not supported when using --mcp")
+        if requested_skills is not None and not locations:
+            schemas = {".".join(s.split(".")[:2]) for s in requested_skills if s.count(".") >= 2}
+            bare = sorted(s for s in requested_skills if s.count(".") < 2)
+            if bare:
+                raise RuntimeError(
+                    "--skills short names need --location (or pass full names like "
+                    f"`<catalog>.<schema>.<name>`): {', '.join(bare)}"
+                )
+            if len(schemas) != 1:
+                raise RuntimeError(
+                    "--skills without --location must all share one `<catalog>.<schema>` "
+                    f"(got: {', '.join(sorted(schemas)) or 'none'}); pass --location instead."
+                )
+            locations = list(schemas)
+        if not locations:
+            raise RuntimeError("--location is required for `ucode skill add`.")
+        if requested_skills is not None and len(locations) != 1:
+            raise RuntimeError(
+                f"--skills requires a single --location (got: {', '.join(locations)})."
+            )
+        mismatched_skills = sorted(
+            skill
+            for skill in requested_skills or set()
+            if skill.count(".") >= 2 and ".".join(skill.split(".")[:2]) != locations[0]
+        )
+        if mismatched_skills:
+            raise RuntimeError(
+                f"--skills entries must match --location `{locations[0]}` "
+                f"(got: {', '.join(mismatched_skills)})."
+            )
+        selected_skills = (
+            None if requested_skills is None else {s.split(".")[-1] for s in requested_skills}
+        )
+        if mcp:
+            add_skills_command(locations)
+        else:
+            configure_skills_download_command(locations, path=path, skills=selected_skills)
+    except (RuntimeError, ValueError) as exc:
+        print_err(str(exc))
+        raise typer.Exit(1) from None
+    except KeyboardInterrupt:
+        print_err("Interrupted.")
+        raise typer.Exit(130) from None
 
 
 @app.command("mcp-proxy", hidden=True)

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -108,6 +108,7 @@ from ucode.mcp import (
 )
 from ucode.skills_download import (
     configure_skills_download_command,
+    configure_skills_download_interactive_command,
     download_managed_skills_on_launch,
 )
 from ucode.smart_routing import v2 as smart_routing_v2
@@ -1352,9 +1353,10 @@ def skills_add(
 
     With ``--mcp``, adds the given schemas to the skills MCP connection's scope.
     Otherwise downloads each schema's skills to disk (under ``--path``, or your home
-    dir), keeping already-downloaded skills. ``--skills`` narrows a download to a
-    subset of one schema's skills, by bare name (with ``--location``) or
-    fully-qualified ``<catalog>.<schema>.<name>``.
+    dir), keeping already-downloaded skills. With no selection flags, opens a searchable
+    metastore picker. ``--skills`` narrows a download to a subset of one schema's skills,
+    by bare name (with ``--location``) or fully-qualified
+    ``<catalog>.<schema>.<name>``.
     """
     try:
         locations = _parse_skill_locations(location)
@@ -1380,7 +1382,10 @@ def skills_add(
                 )
             locations = list(schemas)
         if not locations:
-            raise RuntimeError("--location is required for `ucode skill add`.")
+            if mcp:
+                raise RuntimeError("--location is required when using --mcp.")
+            configure_skills_download_interactive_command(path=path)
+            return
         if requested_skills is not None and len(locations) != 1:
             raise RuntimeError(
                 f"--skills requires a single --location (got: {', '.join(locations)})."

--- a/src/ucode/mcp.py
+++ b/src/ucode/mcp.py
@@ -2210,3 +2210,22 @@ def register_schemaless_skills_connection(
     ``--mcp`` ``skill_locations`` and otherwise registers the bare schema-less
     route (utility tools only)."""
     _update_skills_mcp(state, workspace, profile, clients, _skill_mcp_locations(state))
+
+
+def _union_locations(base: list[str], new: list[str]) -> list[str]:
+    have = set(base)
+    merged = list(base)
+    for location in new:
+        if location not in have:
+            merged.append(location)
+            have.add(location)
+    return merged
+
+
+def add_skills_command(locations: list[str]) -> int:
+    """Add ``locations`` to the skills MCP connection's scope, keeping any already configured."""
+    state = load_state()
+    workspace, profile, clients = setup_mcp_clients(state, "Add Skills MCP")
+    merged = _union_locations(_skill_mcp_locations(state), locations)
+    _update_skills_mcp(state, workspace, profile, clients, merged)
+    return 0

--- a/src/ucode/skills_download.py
+++ b/src/ucode/skills_download.py
@@ -21,6 +21,7 @@ from ucode.ui import (
     print_success,
     print_warning,
     progress_bar,
+    prompt_for_multi_selection,
     prompt_yes_no,
 )
 
@@ -50,6 +51,18 @@ class SkillRef:
 
     securable_name: str
     bundle_name: str
+
+
+@dataclass(frozen=True)
+class MetastoreSkill:
+    """A finalized skill discovered without a schema filter."""
+
+    full_name: str
+    ref: SkillRef
+
+    @property
+    def location(self) -> str:
+        return self.full_name.rsplit(".", 1)[0]
 
 
 def _non_empty_str(value: object) -> str | None:
@@ -116,6 +129,58 @@ def list_schema_skills(
         page_token = data.get("next_page_token")
         if not page_token:
             return refs, None
+
+
+def list_metastore_skills(workspace: str, token: str) -> tuple[list[MetastoreSkill], str | None]:
+    """List finalized, downloadable skills visible in the current metastore."""
+    hostname = workspace_hostname(workspace)
+    base_url = f"https://{hostname}/api/2.1/unity-catalog/skills"
+
+    skills: list[MetastoreSkill] = []
+    page_token: str | None = None
+    while True:
+        url = base_url
+        if page_token:
+            url = f"{url}?{urlencode({'page_token': page_token})}"
+        payload, reason = _http_get_json(url, token, timeout=30)
+        if payload is None:
+            return [], reason
+        data = payload if isinstance(payload, dict) else {}
+        for skill in data.get("skills") or []:
+            if not isinstance(skill, dict):
+                continue
+            resource_name = _non_empty_str(skill.get("name"))
+            ref = _skill_ref(skill)
+            if ref is None:
+                continue
+            full_name = resource_name.removeprefix("skills/") if resource_name else None
+            if full_name is None or full_name.count(".") != 2:
+                print_warning(
+                    f"Skipping `{resource_name or '<unnamed skill>'}`: expected a fully-qualified "
+                    "`<catalog>.<schema>.<name>` from the skills API."
+                )
+                continue
+            skills.append(MetastoreSkill(full_name=full_name, ref=ref))
+        page_token = data.get("next_page_token")
+        if not page_token:
+            return sorted(skills, key=lambda skill: skill.full_name.lower()), None
+
+
+def prompt_for_skill_download(
+    skills: list[MetastoreSkill],
+) -> list[MetastoreSkill] | None:
+    """Select metastore skills to download, or return None when cancelled."""
+    by_name = {skill.full_name: skill for skill in skills}
+    options = []
+    for skill in skills:
+        label = skill.full_name
+        if skill.ref.bundle_name != skill.ref.securable_name:
+            label = f"{label} (bundle: {skill.ref.bundle_name})"
+        options.append((skill.full_name, label))
+    selected = prompt_for_multi_selection("Skills:", options, searchable=True)
+    if selected is None:
+        return None
+    return [by_name[name] for name in selected if name in by_name]
 
 
 def list_skill_files(
@@ -447,6 +512,36 @@ def configure_skills_download_command(
     token = get_databricks_token(workspace, profile)
 
     download_skills(workspace, token, locations, path, skills)
+
+    register_schemaless_skills_connection(state, workspace, profile, clients)
+    return 0
+
+
+def configure_skills_download_interactive_command(*, path: str | None) -> int:
+    """Discover metastore skills, let the user select some, and download them."""
+    state = load_state()
+    workspace, profile, clients = setup_mcp_clients(state, "Add Skills")
+    token = get_databricks_token(workspace, profile)
+
+    available, reason = list_metastore_skills(workspace, token)
+    if reason:
+        raise RuntimeError(f"Could not list workspace skills: {reason}.")
+    if not available:
+        print_note("No finalized skills are available to download in this metastore.")
+        return 0
+
+    selected = prompt_for_skill_download(available)
+    if selected is None:
+        return 0
+    if not selected:
+        print_note("No skills selected. Press space to toggle an item, then enter to download.")
+        return 0
+
+    selected_by_location: dict[str, set[str]] = {}
+    for skill in selected:
+        selected_by_location.setdefault(skill.location, set()).add(skill.ref.securable_name)
+    for location, securable_names in selected_by_location.items():
+        download_skills(workspace, token, [location], path, securable_names)
 
     register_schemaless_skills_connection(state, workspace, profile, clients)
     return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1112,16 +1112,26 @@ class TestSkillsAddCommand:
         assert "must all share one" in _strip_ansi(result.output)
         mock_download.assert_not_called()
 
-    def test_without_location_exit_1(self):
+    def test_without_location_opens_download_picker(self):
         with (
             patch("ucode.cli.add_skills_command") as mock_add,
             patch("ucode.cli.configure_skills_download_command") as mock_download,
+            patch("ucode.cli.configure_skills_download_interactive_command") as mock_interactive,
         ):
             result = runner.invoke(app, ["skill", "add"])
+
+        assert result.exit_code == 0, result.output
+        mock_add.assert_not_called()
+        mock_download.assert_not_called()
+        mock_interactive.assert_called_once_with(path=None)
+
+    def test_mcp_without_location_exit_1(self):
+        with patch("ucode.cli.add_skills_command") as mock_add:
+            result = runner.invoke(app, ["skill", "add", "--mcp"])
+
         assert result.exit_code == 1
         assert "--location is required" in _strip_ansi(result.output)
         mock_add.assert_not_called()
-        mock_download.assert_not_called()
 
     def test_skill_with_mcp_exit_1(self):
         with (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1047,6 +1047,121 @@ class TestConfigureSkillsCommand:
         mock_download.assert_not_called()
 
 
+class TestSkillsAddCommand:
+    """`ucode skill add` is the additive sibling of `configure skills`: `--mcp`
+    unions schemas into the connection scope, the default mode downloads."""
+
+    def test_mcp_flag_unions_locations(self):
+        with patch("ucode.cli.add_skills_command") as mock_add:
+            result = runner.invoke(app, ["skill", "add", "--location", "a.b", "--mcp"])
+        assert result.exit_code == 0, result.output
+        mock_add.assert_called_once_with(["a.b"])
+
+    def test_comma_location_yields_multiple_schemas(self):
+        with patch("ucode.cli.add_skills_command") as mock_add:
+            result = runner.invoke(app, ["skill", "add", "--location", "a.b, c.d", "--mcp"])
+        assert result.exit_code == 0, result.output
+        mock_add.assert_called_once_with(["a.b", "c.d"])
+
+    def test_default_mode_dispatches_download(self):
+        with patch("ucode.cli.configure_skills_download_command") as mock_download:
+            result = runner.invoke(app, ["skill", "add", "--location", "a.b", "--path", "/tmp/s"])
+        assert result.exit_code == 0, result.output
+        mock_download.assert_called_once_with(["a.b"], path="/tmp/s", skills=None)
+
+    def test_skill_filter_dispatches_download_with_subset(self):
+        with patch("ucode.cli.configure_skills_download_command") as mock_download:
+            result = runner.invoke(app, ["skill", "add", "--location", "a.b", "--skills", "s1, s2"])
+        assert result.exit_code == 0, result.output
+        mock_download.assert_called_once_with(["a.b"], path=None, skills={"s1", "s2"})
+
+    def test_fully_qualified_skills_derive_location(self):
+        with patch("ucode.cli.configure_skills_download_command") as mock_download:
+            result = runner.invoke(app, ["skill", "add", "--skills", "a.b.s1, a.b.s2"])
+        assert result.exit_code == 0, result.output
+        mock_download.assert_called_once_with(["a.b"], path=None, skills={"s1", "s2"})
+
+    def test_fully_qualified_skills_match_explicit_location(self):
+        with patch("ucode.cli.configure_skills_download_command") as mock_download:
+            result = runner.invoke(
+                app, ["skill", "add", "--location", "a.b", "--skills", "a.b.s1, a.b.s2"]
+            )
+        assert result.exit_code == 0, result.output
+        mock_download.assert_called_once_with(["a.b"], path=None, skills={"s1", "s2"})
+
+    def test_fully_qualified_skills_must_match_explicit_location(self):
+        with patch("ucode.cli.configure_skills_download_command") as mock_download:
+            result = runner.invoke(
+                app, ["skill", "add", "--location", "a.b", "--skills", "c.d.s1"]
+            )
+        assert result.exit_code == 1
+        assert "must match --location `a.b`" in _strip_ansi(result.output)
+        mock_download.assert_not_called()
+
+    def test_bare_skills_without_location_exit_1(self):
+        with patch("ucode.cli.configure_skills_download_command") as mock_download:
+            result = runner.invoke(app, ["skill", "add", "--skills", "s1"])
+        assert result.exit_code == 1
+        assert "--skills short names need --location" in _strip_ansi(result.output)
+        mock_download.assert_not_called()
+
+    def test_fully_qualified_skills_across_schemas_exit_1(self):
+        with patch("ucode.cli.configure_skills_download_command") as mock_download:
+            result = runner.invoke(app, ["skill", "add", "--skills", "a.b.s1, c.d.s2"])
+        assert result.exit_code == 1
+        assert "must all share one" in _strip_ansi(result.output)
+        mock_download.assert_not_called()
+
+    def test_without_location_exit_1(self):
+        with (
+            patch("ucode.cli.add_skills_command") as mock_add,
+            patch("ucode.cli.configure_skills_download_command") as mock_download,
+        ):
+            result = runner.invoke(app, ["skill", "add"])
+        assert result.exit_code == 1
+        assert "--location is required" in _strip_ansi(result.output)
+        mock_add.assert_not_called()
+        mock_download.assert_not_called()
+
+    def test_skill_with_mcp_exit_1(self):
+        with (
+            patch("ucode.cli.add_skills_command") as mock_add,
+            patch("ucode.cli.configure_skills_download_command") as mock_download,
+        ):
+            result = runner.invoke(
+                app, ["skill", "add", "--location", "a.b", "--mcp", "--skills", "s1"]
+            )
+        assert result.exit_code == 1
+        assert "--skills" in _strip_ansi(result.output)
+        mock_add.assert_not_called()
+        mock_download.assert_not_called()
+
+    def test_path_with_mcp_exit_1(self):
+        with patch("ucode.cli.add_skills_command") as mock_add:
+            result = runner.invoke(
+                app, ["skill", "add", "--location", "a.b", "--mcp", "--path", "/tmp/s"]
+            )
+        assert result.exit_code == 1
+        assert "--path" in _strip_ansi(result.output)
+        mock_add.assert_not_called()
+
+    def test_skill_with_multiple_locations_exit_1(self):
+        with patch("ucode.cli.configure_skills_download_command") as mock_download:
+            result = runner.invoke(
+                app, ["skill", "add", "--location", "a.b, c.d", "--skills", "s1"]
+            )
+        assert result.exit_code == 1
+        assert "--skills requires a single --location" in _strip_ansi(result.output)
+        mock_download.assert_not_called()
+
+    def test_malformed_location_exit_1(self):
+        with patch("ucode.cli.add_skills_command") as mock_add:
+            result = runner.invoke(app, ["skill", "add", "--location", "a.b.c", "--mcp"])
+        assert result.exit_code == 1
+        assert "--location" in _strip_ansi(result.output)
+        mock_add.assert_not_called()
+
+
 class TestApplyManagedSkills:
     """The launch path both registers the skills MCP connection and downloads bundles to disk."""
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2489,6 +2489,55 @@ class TestSkillMcpLocations:
         assert mcp._skill_mcp_locations(_skills_state()) == []
 
 
+class TestUnionLocations:
+    def test_appends_new_after_existing(self):
+        assert mcp._union_locations(["a.b"], ["c.d"]) == ["a.b", "c.d"]
+
+    def test_drops_locations_already_present(self):
+        assert mcp._union_locations(["a.b", "c.d"], ["c.d", "e.f"]) == ["a.b", "c.d", "e.f"]
+
+    def test_empty_base_returns_new(self):
+        assert mcp._union_locations([], ["a.b", "c.d"]) == ["a.b", "c.d"]
+
+    def test_drops_duplicate_new_locations(self):
+        assert mcp._union_locations(["a.b"], ["c.d", "c.d"]) == ["a.b", "c.d"]
+
+
+class TestAddSkillsCommand:
+    """`ucode skill add --mcp` unions schemas into the connection scope rather
+    than replacing it (unlike `configure_skills_mcp_command`)."""
+
+    def test_unions_into_existing_scope(self, monkeypatch):
+        state = _skills_state(mcp._resolve_skills_mcp_servers(WS, ["claude"], ["A.a"], []))
+        _stub_location_base(monkeypatch, state)
+        monkeypatch.setattr(mcp, "configure_client_mcp_server", lambda *a, **kw: [])
+        monkeypatch.setattr(mcp, "save_state", lambda s: None)
+
+        assert mcp.add_skills_command(["B.b"]) == 0
+
+        assert _find_skills(state["mcp_servers"])[0]["skill_locations"] == ["A.a", "B.b"]
+
+    def test_existing_schema_leaves_scope_unchanged(self, monkeypatch):
+        state = _skills_state(mcp._resolve_skills_mcp_servers(WS, ["claude"], ["A.a", "B.b"], []))
+        _stub_location_base(monkeypatch, state)
+        monkeypatch.setattr(mcp, "configure_client_mcp_server", lambda *a, **kw: [])
+        monkeypatch.setattr(mcp, "save_state", lambda s: None)
+
+        assert mcp.add_skills_command(["A.a"]) == 0
+
+        assert _find_skills(state["mcp_servers"])[0]["skill_locations"] == ["A.a", "B.b"]
+
+    def test_registers_scope_from_empty_state(self, monkeypatch):
+        state = _skills_state()
+        _stub_location_base(monkeypatch, state)
+        monkeypatch.setattr(mcp, "configure_client_mcp_server", lambda *a, **kw: [])
+        monkeypatch.setattr(mcp, "save_state", lambda s: None)
+
+        assert mcp.add_skills_command(["A.a"]) == 0
+
+        assert _find_skills(state["mcp_servers"])[0]["skill_locations"] == ["A.a"]
+
+
 class TestRegisterSchemalessSkillsConnection:
     def _stub(self, monkeypatch):
         saved_states: list[dict] = []

--- a/tests/test_skills_download.py
+++ b/tests/test_skills_download.py
@@ -156,6 +156,59 @@ class TestListSchemaSkills:
         assert reason == "HTTP 500 Server Error"
 
 
+class TestListMetastoreSkills:
+    def test_lists_finalized_skills_across_schemas_and_follows_pagination(self, monkeypatch):
+        pages = [
+            {
+                "skills": [
+                    {
+                        "name": "skills/ml.prod.triage",
+                        "bundle_name": "triage",
+                        "finalize_time": "t",
+                    },
+                    {"name": "skills/ml.prod.draft", "bundle_name": "draft"},
+                ],
+                "next_page_token": "next",
+            },
+            {
+                "skills": [
+                    {
+                        "name": "skills/main.default.pii",
+                        "bundle_name": "pii-handling",
+                        "finalize_time": "t",
+                    }
+                ]
+            },
+        ]
+        urls = []
+
+        def fake_get(url, token, timeout=30):
+            urls.append(url)
+            return pages.pop(0), None
+
+        monkeypatch.setattr(sd, "_http_get_json", fake_get)
+
+        skills, reason = sd.list_metastore_skills(WS, "token")
+
+        assert reason is None
+        assert skills == [
+            sd.MetastoreSkill("main.default.pii", ref("pii", "pii-handling")),
+            sd.MetastoreSkill("ml.prod.triage", ref("triage")),
+        ]
+        assert urls == [
+            f"{WS}/api/2.1/unity-catalog/skills",
+            f"{WS}/api/2.1/unity-catalog/skills?page_token=next",
+        ]
+
+    def test_http_failure_propagates_reason(self, monkeypatch):
+        monkeypatch.setattr(sd, "_http_get_json", lambda *a, **k: (None, "HTTP 500 Server Error"))
+
+        skills, reason = sd.list_metastore_skills(WS, "token")
+
+        assert skills == []
+        assert reason == "HTTP 500 Server Error"
+
+
 class TestListSkillFiles:
     def test_lists_under_the_skills_place(self, monkeypatch):
         captured = {}
@@ -744,3 +797,79 @@ class TestConfigureSkillsDownloadCommand:
 
         assert calls["download"] == (WS, "token", ["a.b"], None, {"triage"})
         assert calls["register"] == (WS, "profile", ["claude"])
+
+
+class TestConfigureSkillsDownloadInteractiveCommand:
+    def _stub(self, monkeypatch):
+        calls: dict[str, object] = {"downloads": []}
+        state = {"state": True}
+        monkeypatch.setattr(sd, "load_state", lambda: state)
+        monkeypatch.setattr(
+            sd, "setup_mcp_clients", lambda actual, section: (WS, "profile", ["claude"])
+        )
+        monkeypatch.setattr(sd, "get_databricks_token", lambda ws, profile: "token")
+        monkeypatch.setattr(
+            sd,
+            "download_skills",
+            lambda ws, token, locations, path, skills: calls["downloads"].append(
+                (ws, token, locations, path, skills)
+            ),
+        )
+        monkeypatch.setattr(
+            sd,
+            "register_schemaless_skills_connection",
+            lambda actual, ws, profile, clients: calls.update(
+                register=(actual, ws, profile, clients)
+            ),
+        )
+        return state, calls
+
+    def test_downloads_picker_selection_grouped_by_schema(self, monkeypatch):
+        state, calls = self._stub(monkeypatch)
+        available = [
+            sd.MetastoreSkill("main.default.pii", ref("pii")),
+            sd.MetastoreSkill("main.default.triage", ref("triage")),
+            sd.MetastoreSkill("ml.prod.eval", ref("eval")),
+        ]
+        monkeypatch.setattr(sd, "list_metastore_skills", lambda *a: (available, None))
+        monkeypatch.setattr(
+            sd, "prompt_for_skill_download", lambda actual: [available[0], available[2]]
+        )
+
+        assert sd.configure_skills_download_interactive_command(path="/tmp/project") == 0
+
+        assert calls["downloads"] == [
+            (WS, "token", ["main.default"], "/tmp/project", {"pii"}),
+            (WS, "token", ["ml.prod"], "/tmp/project", {"eval"}),
+        ]
+        assert calls["register"] == (state, WS, "profile", ["claude"])
+
+    def test_cancel_is_a_noop(self, monkeypatch):
+        _, calls = self._stub(monkeypatch)
+        available = [sd.MetastoreSkill("main.default.pii", ref("pii"))]
+        monkeypatch.setattr(sd, "list_metastore_skills", lambda *a: (available, None))
+        monkeypatch.setattr(sd, "prompt_for_skill_download", lambda actual: None)
+
+        assert sd.configure_skills_download_interactive_command(path=None) == 0
+
+        assert calls["downloads"] == []
+        assert "register" not in calls
+
+    def test_picker_is_searchable_and_shows_bundle_name_when_different(self, monkeypatch):
+        captured = {}
+        skill = sd.MetastoreSkill("main.default.task", ref("task", "task-triage"))
+        monkeypatch.setattr(
+            sd,
+            "prompt_for_multi_selection",
+            lambda prompt, options, searchable: (
+                captured.update(prompt=prompt, options=options, searchable=searchable)
+                or ["main.default.task"]
+            ),
+        )
+
+        assert sd.prompt_for_skill_download([skill]) == [skill]
+        assert captured == {
+            "prompt": "Skills:",
+            "options": [("main.default.task", "main.default.task (bundle: task-triage)")],
+            "searchable": True,
+        }


### PR DESCRIPTION
## Summary

- Make bare `ucode skill add` discover finalized skills across the metastore.
- Add a searchable multi-select picker.
- Download selected skills grouped by schema.

Part 2 of the skill CLI series. Builds on #459.

## Testing

- `uv run ruff check .`
- `uv run ty check src/`
- `uv run pytest tests/test_skills_download.py tests/test_mcp.py tests/test_cli.py -q`