### PR TITLE
strip anthropic prefixes from models client-side 

### DIFF
--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import signal
 import socket
 import subprocess
@@ -50,6 +51,10 @@ CLAUDE_ROUTED_AGENT_PROMPT = (
     "Complete the delegated task exactly as requested. Follow the parent agent's instructions and "
     "return a concise report of your findings or changes."
 )
+# Keep this pattern in sync with the server-side Anthropic model prefixing logic. The prefix is
+# needed because Anthropic omits models from its catalog unless the model id contains "anthropic"
+# or "claude".
+_ANTHROPIC_AIGW_MODEL_RE = re.compile(r"^anthropic-aigw-[0-9a-fA-F]{8}-(.+)$")
 
 
 def enabled() -> bool:
@@ -109,16 +114,8 @@ def _canonical_claude_models(model_ids: list[str]) -> list[str]:
 
 def _claude_router_model_id(model: str) -> str:
     """Unwrap an Anthropic gateway id, then apply standard model normalization."""
-    prefix = "anthropic-aigw-"
-    if model.startswith(prefix):
-        digest, separator, unwrapped = model[len(prefix) :].partition("-")
-        if (
-            separator
-            and digest
-            and all(character in "0123456789abcdefABCDEF" for character in digest)
-            and unwrapped
-        ):
-            model = unwrapped
+    if match := _ANTHROPIC_AIGW_MODEL_RE.fullmatch(model):
+        model = match.group(1)
     return routing.normalize_model(model)
 
 

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -194,7 +194,6 @@ def _request_claude_routing_decision(
     token: str,
     prompt: str,
     model_ids: list[str],
-    log: Callable[[str], None] | None = None,
 ) -> tuple[routing.RoutingDecision | None, str | None]:
     available: dict[str, str] = {}
     for model in _canonical_claude_models(model_ids):
@@ -202,24 +201,13 @@ def _request_claude_routing_decision(
     if not available:
         return None, "Anthropic models endpoint returned no Claude models"
     route_options = [(model, "claude") for model in available]
-    router_name = routing.configured_router_name()
-    if log is not None:
-        payload = {
-            "route_options": [
-                {"model": model, "harness": harness} for model, harness in route_options
-            ],
-            "task": {"prompt": prompt},
-            "route_selector": {"router_name": router_name},
-        }
-        url = workspace.rstrip("/") + routing.ROUTING_PATH
-        log(f"[ROUTE] request POST {url}: {json.dumps(payload, separators=(',', ':'))}")
     return routing.select_route(
         workspace,
         token,
         prompt,
         route_options,
         lambda selected: available.get(routing.normalize_model(selected)),
-        router_name=router_name,
+        router_name=routing.configured_router_name(),
         timeout=CLAUDE_ROUTE_SELECTION_TIMEOUT_S,
     )
 
@@ -229,7 +217,6 @@ def _route_claude_prompt(
     token: str,
     prompt: str,
     model_ids: list[str] | None = None,
-    log: Callable[[str], None] | None = None,
 ) -> routing.RoutingDecision:
     workspace = state.get("workspace")
     if not isinstance(workspace, str):
@@ -241,9 +228,7 @@ def _route_claude_prompt(
             raise RuntimeError(
                 discovery_error or "Anthropic models endpoint returned no Claude models"
             )
-    decision, error = _request_claude_routing_decision(
-        workspace, token, prompt, model_ids, log
-    )
+    decision, error = _request_claude_routing_decision(workspace, token, prompt, model_ids)
     if decision is None:
         raise RuntimeError(error or "router returned no Claude model selection")
     return decision
@@ -399,15 +384,8 @@ def launch_claude(
 
     model_setting = _ClaudeModelSettingGuard(user_settings_path)
 
-    def log_route_request(message: str) -> None:
-        try:
-            with open(CLAUDE_PTY_LOG, "a", encoding="utf-8") as handle:
-                handle.write(f"{time.strftime('%H:%M:%S')} {message}\n")
-        except OSError:
-            pass
-
     def route_prompt(prompt: str) -> tuple[str, str]:
-        decision = _route_claude_prompt(state, token, prompt, model_ids, log_route_request)
+        decision = _route_claude_prompt(state, token, prompt, model_ids)
         return model_name(decision.model), decision.rationale
 
     print_note(

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -107,6 +107,21 @@ def _canonical_claude_models(model_ids: list[str]) -> list[str]:
     )
 
 
+def _claude_router_model_id(model: str) -> str:
+    """Unwrap an Anthropic gateway id, then apply standard model normalization."""
+    prefix = "anthropic-aigw-"
+    if model.startswith(prefix):
+        digest, separator, unwrapped = model[len(prefix) :].partition("-")
+        if (
+            separator
+            and digest
+            and all(character in "0123456789abcdefABCDEF" for character in digest)
+            and unwrapped
+        ):
+            model = unwrapped
+    return routing.normalize_model(model)
+
+
 def _claude_model_overrides(model_ids: list[str]) -> dict[str, str]:
     overrides: dict[str, str] = {}
     prefix = "system.ai."
@@ -179,19 +194,32 @@ def _request_claude_routing_decision(
     token: str,
     prompt: str,
     model_ids: list[str],
+    log: Callable[[str], None] | None = None,
 ) -> tuple[routing.RoutingDecision | None, str | None]:
     available: dict[str, str] = {}
     for model in _canonical_claude_models(model_ids):
-        available.setdefault(routing.normalize_model(model), model)
+        available.setdefault(_claude_router_model_id(model), model)
     if not available:
         return None, "Anthropic models endpoint returned no Claude models"
+    route_options = [(model, "claude") for model in available]
+    router_name = routing.configured_router_name()
+    if log is not None:
+        payload = {
+            "route_options": [
+                {"model": model, "harness": harness} for model, harness in route_options
+            ],
+            "task": {"prompt": prompt},
+            "route_selector": {"router_name": router_name},
+        }
+        url = workspace.rstrip("/") + routing.ROUTING_PATH
+        log(f"[ROUTE] request POST {url}: {json.dumps(payload, separators=(',', ':'))}")
     return routing.select_route(
         workspace,
         token,
         prompt,
-        [(model, "claude") for model in available],
+        route_options,
         lambda selected: available.get(routing.normalize_model(selected)),
-        router_name=routing.configured_router_name(),
+        router_name=router_name,
         timeout=CLAUDE_ROUTE_SELECTION_TIMEOUT_S,
     )
 
@@ -201,6 +229,7 @@ def _route_claude_prompt(
     token: str,
     prompt: str,
     model_ids: list[str] | None = None,
+    log: Callable[[str], None] | None = None,
 ) -> routing.RoutingDecision:
     workspace = state.get("workspace")
     if not isinstance(workspace, str):
@@ -212,7 +241,9 @@ def _route_claude_prompt(
             raise RuntimeError(
                 discovery_error or "Anthropic models endpoint returned no Claude models"
             )
-    decision, error = _request_claude_routing_decision(workspace, token, prompt, model_ids)
+    decision, error = _request_claude_routing_decision(
+        workspace, token, prompt, model_ids, log
+    )
     if decision is None:
         raise RuntimeError(error or "router returned no Claude model selection")
     return decision
@@ -368,8 +399,15 @@ def launch_claude(
 
     model_setting = _ClaudeModelSettingGuard(user_settings_path)
 
+    def log_route_request(message: str) -> None:
+        try:
+            with open(CLAUDE_PTY_LOG, "a", encoding="utf-8") as handle:
+                handle.write(f"{time.strftime('%H:%M:%S')} {message}\n")
+        except OSError:
+            pass
+
     def route_prompt(prompt: str) -> tuple[str, str]:
-        decision = _route_claude_prompt(state, token, prompt, model_ids)
+        decision = _route_claude_prompt(state, token, prompt, model_ids, log_route_request)
         return model_name(decision.model), decision.rationale
 
     print_note(

--- a/tests/test_claude_smart_routing_v2.py
+++ b/tests/test_claude_smart_routing_v2.py
@@ -261,6 +261,20 @@ class TestV2Launch:
 
 
 class TestSubagentRouting:
+    @pytest.mark.parametrize(
+        ("model", "expected"),
+        [
+            ("anthropic-aigw-73ea02b2-system.ai.glm-5-2", "glm-5-2"),
+            (
+                "anthropic-aigw-73ea02b-system.ai.glm-5-2",
+                "anthropic-aigw-73ea02b-system.ai.glm-5-2",
+            ),
+            ("system.ai.claude-opus-4-8", "claude-opus-4-8"),
+        ],
+    )
+    def test_normalizes_router_model_id(self, model, expected):
+        assert v2._claude_router_model_id(model) == expected
+
     def test_routes_anthropic_gateway_alias_by_embedded_model_id(self, monkeypatch):
         gateway_alias = "anthropic-aigw-73ea02b2-system.ai.glm-5-2"
         captured = {}

--- a/tests/test_claude_smart_routing_v2.py
+++ b/tests/test_claude_smart_routing_v2.py
@@ -264,7 +264,6 @@ class TestSubagentRouting:
     def test_routes_anthropic_gateway_alias_by_embedded_model_id(self, monkeypatch):
         gateway_alias = "anthropic-aigw-73ea02b2-system.ai.glm-5-2"
         captured = {}
-        logged: list[str] = []
         monkeypatch.setenv("SMART_ROUTER_NAME", "task_v2")
 
         def fake_select(workspace, token, task, route_options, resolve, **kwargs):
@@ -284,7 +283,6 @@ class TestSubagentRouting:
             "secret-token",
             "inspect the parser",
             ["system.ai.claude-opus-4-8", gateway_alias],
-            logged.append,
         )
 
         assert error is None
@@ -296,9 +294,6 @@ class TestSubagentRouting:
             ],
             "router_name": "task_v2",
         }
-        assert '"model":"glm-5-2","harness":"claude"' in logged[0]
-        assert '"router_name":"task_v2"' in logged[0]
-        assert "secret-token" not in logged[0]
 
     def test_routes_agent_prompt_with_initialized_model_menu(self, tmp_path, monkeypatch):
         captured = {}

--- a/tests/test_claude_smart_routing_v2.py
+++ b/tests/test_claude_smart_routing_v2.py
@@ -261,6 +261,45 @@ class TestV2Launch:
 
 
 class TestSubagentRouting:
+    def test_routes_anthropic_gateway_alias_by_embedded_model_id(self, monkeypatch):
+        gateway_alias = "anthropic-aigw-73ea02b2-system.ai.glm-5-2"
+        captured = {}
+        logged: list[str] = []
+        monkeypatch.setenv("SMART_ROUTER_NAME", "task_v2")
+
+        def fake_select(workspace, token, task, route_options, resolve, **kwargs):
+            captured["route_options"] = list(route_options)
+            captured["router_name"] = kwargs["router_name"]
+            return (
+                routing.RoutingDecision(
+                    model=resolve("glm-5-2"),
+                    raw_model="glm-5-2",
+                ),
+                None,
+            )
+
+        monkeypatch.setattr(routing, "select_route", fake_select)
+        decision, error = v2._request_claude_routing_decision(
+            "https://example.com",
+            "secret-token",
+            "inspect the parser",
+            ["system.ai.claude-opus-4-8", gateway_alias],
+            logged.append,
+        )
+
+        assert error is None
+        assert decision.model == gateway_alias
+        assert captured == {
+            "route_options": [
+                ("claude-opus-4-8", "claude"),
+                ("glm-5-2", "claude"),
+            ],
+            "router_name": "task_v2",
+        }
+        assert '"model":"glm-5-2","harness":"claude"' in logged[0]
+        assert '"router_name":"task_v2"' in logged[0]
+        assert "secret-token" not in logged[0]
+
     def test_routes_agent_prompt_with_initialized_model_menu(self, tmp_path, monkeypatch):
         captured = {}
         decisions_path = tmp_path / "decisions.jsonl"


### PR DESCRIPTION
we need to add an `anthropic-aigw-(8char hash)-` prefix to non-claude model ids so they appear in the anthropic model picker. the problem is that these ids don't get cleaned up properly when they get sent to the smart router so the smart router doesnt recognize say glm-5-3-flash as a legit model. 

this PR cleans up the prefix client-side. i'm going to add this clean up server-side in the router, but this is until the server-side change lands. 

before - routes to sonnet because it can't recognize the oss models 
<img width="611" height="209" alt="Screenshot 2026-09-03 at 2 18 10 PM" src="https://github.com/user-attachments/assets/4432755b-805d-46c3-a3d3-d15d2426ffff" />


after - routes to glm-5-3-flash because it's a recognized model 
<img width="623" height="207" alt="Screenshot 2026-09-03 at 2 16 57 PM" src="https://github.com/user-attachments/assets/e902a35a-389c-488a-a745-19f048eb34c3" />
