### PR TITLE
Show skill scopes per agent

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -107,6 +107,7 @@ from ucode.mcp import (
     purge_cross_workspace_mcp_residue,
     remove_mcp_command,
     revert_mcp_configs,
+    skill_locations_for_client,
 )
 from ucode.skills_download import (
     configure_skills_download_command,
@@ -1068,17 +1069,31 @@ def status() -> int:
     if not skill_mcp_entry:
         print_kv("Skills", "not configured")
     else:
-        locations = skill_mcp_entry.get("skill_locations") or []
-        print_kv(
-            "Skill MCP Locations",
-            ", ".join(locations) if locations else "none — utility tools only",
-        )
-        configured_agents = [
-            str(MCP_CLIENTS[client]["display"])
-            for client in (skill_mcp_entry.get("clients") or [])
-            if client in MCP_CLIENTS
+        configured_clients = [
+            client for client in (skill_mcp_entry.get("clients") or []) if client in MCP_CLIENTS
         ]
-        print_kv("Configured", ", ".join(configured_agents) if configured_agents else "none")
+        scopes = {
+            client: skill_locations_for_client(skill_mcp_entry, client)
+            for client in configured_clients
+        }
+        if len({tuple(locations) for locations in scopes.values()}) <= 1:
+            locations = next(
+                iter(scopes.values()), list(skill_mcp_entry.get("skill_locations") or [])
+            )
+            print_kv(
+                "Skill MCP Locations",
+                ", ".join(locations) if locations else "none — utility tools only",
+            )
+            configured_agents = [
+                str(MCP_CLIENTS[client]["display"]) for client in configured_clients
+            ]
+            print_kv("Configured", ", ".join(configured_agents) if configured_agents else "none")
+        else:
+            for client, locations in scopes.items():
+                print_kv(
+                    f"{MCP_CLIENTS[client]['display']} skill MCP locations",
+                    ", ".join(locations) if locations else "none — utility tools only",
+                )
 
     print_heading("Tracing")
     tracing = state.get("tracing") or {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1402,6 +1402,29 @@ class TestStatusSkillsSection:
                 assert "databricks-skill-registry" not in line
         assert "Skill MCP Locations: main.default" in out
 
+    def test_renders_per_agent_locations_when_scopes_diverge(self):
+        state = {
+            **MINIMAL_STATE,
+            "mcp_servers": [
+                {
+                    "name": "databricks-skill-registry",
+                    "kind": "skills",
+                    "skill_locations": ["main.default"],
+                    "skill_location_overrides": {"claude": ["main.default", "claude.only"]},
+                    "url": "https://example.databricks.com/ai-gateway/skills/?schema=main.default",
+                    "auth": "proxy",
+                    "clients": ["claude", "codex"],
+                }
+            ],
+        }
+
+        result = self._run(state)
+
+        assert result.exit_code == 0, result.output
+        out = _strip_ansi(result.output)
+        assert "Claude Code skill MCP locations: main.default, claude.only" in out
+        assert "Codex skill MCP locations: main.default" in out
+
 
 class TestRevert:
     def test_reverts_mcp_configs_before_clearing_state(self):


### PR DESCRIPTION
## Why

Once agents can have different skill scopes, the old status output is misleading because it shows only the shared list. Developers need to see the effective scope each agent will actually receive.

## What changed

This PR makes `ucode status` display skill MCP locations per agent when those effective scopes differ.

## How it works

- Status computes each configured client's effective scope through the shared scope helper.
- Divergent scopes render as separate Claude Code, Codex, and other client rows.
- Identical scopes retain the existing compact shared row.

Builds on agent-scoped configuration in https://github.com/databricks/ucode/pull/484.

## Testing

- `uv run pytest tests/test_skills_download.py tests/test_mcp.py tests/test_cli.py -q` — 502 passed
- `uv run ruff check .`
- `uv run ty check src/`

### Manual staging validation

Validated the stack through this PR against `https://eng-ml-inference.staging.cloud.databricks.com` with `artjen.default.ucode-pr3-cli-smoke`.

- Added `artjen.default` to Codex only, then to Claude Code only.
- Confirmed `ucode status` and each client's MCP URL showed only the intended agent-specific schema.
- Confirmed the selected agent exposed `skill_artjen.default.ucode-pr3-cli-smoke` and returned `UCODE_PR3_SCOPE_OK`.
- Confirmed the other agent did not expose the schema-specific dynamic tool.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
