### PR TITLE
fix nested config items in codex app

### DIFF
--- a/src/ucode/codex_config.py
+++ b/src/ucode/codex_config.py
@@ -3,19 +3,26 @@
 from __future__ import annotations
 
 import tomlkit
+from tomlkit.items import Item
+
+
+def _toml_item(value: object) -> Item:
+    """Convert nested Python values without creating regular TOML tables."""
+    if isinstance(value, dict):
+        item = tomlkit.inline_table()
+        for key, entry in value.items():
+            item[key] = _toml_item(entry)
+        return item
+    if isinstance(value, list):
+        item = tomlkit.array()
+        for entry in value:
+            item.append(_toml_item(entry))
+        return item
+    return tomlkit.item(value)
 
 
 def _toml_value(value: str | int | float | bool | list[object] | dict[str, object]) -> str:
-    if isinstance(value, dict):
-        item = tomlkit.inline_table()
-        item.update(value)
-        return item.as_string()
-    if isinstance(value, list) and any(isinstance(entry, dict) for entry in value):
-        wrapper = tomlkit.inline_table()
-        wrapper["value"] = value
-        rendered = wrapper.as_string()
-        return rendered.removeprefix("{value = ").removesuffix("}")
-    return tomlkit.item(value).as_string()
+    return _toml_item(value).as_string()
 
 
 def codex_config_args(config: dict) -> list[str]:

--- a/src/ucode/codex_config.py
+++ b/src/ucode/codex_config.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import tomlkit
 from tomlkit.items import Item
 
+type TomlValue = str | int | float | bool | list[TomlValue] | dict[str, TomlValue]
 
-def _toml_item(value: object) -> Item:
+
+def _toml_item(value: TomlValue) -> Item:
     """Convert nested Python values without creating regular TOML tables."""
     if isinstance(value, dict):
         item = tomlkit.inline_table()
@@ -18,10 +20,16 @@ def _toml_item(value: object) -> Item:
         for entry in value:
             item.append(_toml_item(entry))
         return item
+    if isinstance(value, bool):
+        return tomlkit.item(value)
+    if isinstance(value, int):
+        return tomlkit.item(value)
+    if isinstance(value, float):
+        return tomlkit.item(value)
     return tomlkit.item(value)
 
 
-def _toml_value(value: str | int | float | bool | list[object] | dict[str, object]) -> str:
+def _toml_value(value: TomlValue) -> str:
     return _toml_item(value).as_string()
 
 

--- a/tests/test_codex_config.py
+++ b/tests/test_codex_config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import tomlkit
+
 from ucode.agents import codex
 from ucode.codex_config import codex_config_args
 
@@ -29,3 +31,30 @@ class TestCodexConfigArgs:
         assert "/ai-gateway/codex/v1" in provider_override
         assert 'command = "' in provider_override
         assert '"myprof"' in provider_override
+
+        key, rendered_provider = provider_override.split("=", 1)
+        parsed = tomlkit.parse(f"{key} = {rendered_provider}")
+        provider = parsed["model_providers"]["ucode-databricks"]
+        assert provider["auth"]["timeout_ms"] == 5000
+        assert provider["http_headers"]["User-Agent"].startswith("ucode/0.1.0")
+
+    def test_renders_nested_tables_inside_arrays(self):
+        args = codex_config_args(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Read",
+                            "hooks": [{"type": "command", "command": "route"}],
+                        }
+                    ]
+                }
+            }
+        )
+
+        assert args[0] == "--config"
+        key, rendered_hooks = args[1].split("=", 1)
+        parsed = tomlkit.parse(f"{key} = {rendered_hooks}")
+        hook = parsed["hooks"]["PreToolUse"][0]
+        assert hook["matcher"] == "Read"
+        assert hook["hooks"][0]["command"] == "route"


### PR DESCRIPTION
https://github.com/databricks/ucode/pull/473 was a previous attempt to fix codex app in ucode. i tested by running `uv run ucode codex app` and it worked. however, when i installed a new ucode and ran `ucode codex app`, it failed with the error below. 

this is because when i tested previously, `uv run` uses the uv.lock where as a freshly installed ucode does not respect uv.lock. we specify tomlkit>=0.13.0. the uv.lock has 0.14 pinned which works but a freshly installed ucode has tomlkit 0.15.1 which is not compatible with this change. 

i've since updated the uv.lock https://github.com/databricks/ucode/pull/496 so that uv run will be consistent with future installs so we don't have this discrepancy in the future. this PR makes a fix such that `ucode codex app` will actually work 

before:

```
➜  ucode git:(lilly/fix-codex-app-again) ucode codex app

╭────────────────────────────────────╮
│ Launching Codex with Unity Gateway │
╰────────────────────────────────────╯
✔ Starting Codex
╭────────────────────────────────────────────────────── Traceback (most recent call last) ───────────────────────────────────────────────────────╮
│ /Users/lilly.luo/.local/share/uv/tools/ucode/lib/python3.12/site-packages/ucode/cli.py:2402 in codex_cmd                                       │
│                                                                                                                                                │
│   2399 │   │   print_success("Codex smart routing disabled; ucode routing hooks removed")                                                      │
.......
ValueError: Inline tables cannot contain a table

``` 

after (with the updated uv.lock):
```
➜  ucode git:(lilly/fix-codex-app-again) uv run codex app 
Opening Codex Desktop at /Applications/Codex.app...
Opening workspace /Users/lilly.luo/ucode...
```

<img width="443" height="966" alt="Screenshot 2026-09-04 at 12 48 52 PM" src="https://github.com/user-attachments/assets/45ed5308-a65e-4a8c-a71f-aae874843b79" />