### PR TITLE
Fix Windows Codex executable resolution via shutil.which()

### DIFF
--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -8,6 +8,7 @@ import re
 import subprocess
 import sys
 import time
+import shutil
 from collections.abc import Callable
 from pathlib import Path
 
@@ -554,7 +555,6 @@ def launch(state: dict, tool_args: list[str]) -> None:
     # inherited (no capture), so Ctrl-C reaches codex directly and the resulting
     # KeyboardInterrupt propagates past the retry check — quitting an interactive
     # session is never mistaken for a --profile rejection.
-    import shutil
     resolved_binary = shutil.which(binary) or binary
     if not resolved_binary:
         raise RuntimeError(f"Unable to locate {binary} on PATH")

--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -554,8 +554,12 @@ def launch(state: dict, tool_args: list[str]) -> None:
     # inherited (no capture), so Ctrl-C reaches codex directly and the resulting
     # KeyboardInterrupt propagates past the retry check — quitting an interactive
     # session is never mistaken for a --profile rejection.
+    import shutil
+    resolved_binary = shutil.which(binary) or binary
+    if not resolved_binary:
+        raise RuntimeError(f"Unable to locate {binary} on PATH")
     started = time.monotonic()
-    returncode = subprocess.run([binary, "--profile", CODEX_PROFILE_NAME, *tool_args]).returncode
+    returncode = subprocess.run([resolved_binary, "--profile", CODEX_PROFILE_NAME, *tool_args]).returncode
     if returncode != 0 and time.monotonic() - started < _PROFILE_REJECTED_MAX_SECONDS:
         # Fast failure: most likely codex rejected --profile on this subcommand.
         # Relaunch without it, handing over the terminal. (A fast failure for
@@ -570,7 +574,7 @@ def launch(state: dict, tool_args: list[str]) -> None:
             f"without it: Codex will resolve {LEGACY_CODEX_CONFIG_PATH} and any OS-managed "
             "settings instead of the ucode profile."
         )
-        exec_or_spawn([binary, *tool_args])
+        exec_or_spawn([resolved_binary, *tool_args])
         return  # unreachable in production (exec replaces the process)
     sys.exit(returncode)
 


### PR DESCRIPTION
**Problem**

On Windows, Codex installed via npm may only be available as `codex.cmd` / `codex.ps1`.

```python
subprocess.run(["codex", ...])
```

can fail with:

```
FileNotFoundError: [WinError 2]
```

even when `codex --version` works fine in PowerShell.

**Fix**

Resolve the executable path first using:

```python
shutil.which(binary)
```

and use the resolved path for both `subprocess.run()` and `exec_or_spawn()`.

**Testing**

Tested with:
- Windows
- codex-cli 0.153.3
- ucode 0.1.0+83.g2f993ce