### PR TITLE
Skip gpt-6-astra in the Copilot e2e (incompatible with /chat/completions)

### DIFF
--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -957,6 +957,9 @@ class TestCopilotLaunch:
         "gpt-5-5",
         # gpt-5.6 models similarly reject /chat/completions with 404.
         "gpt-5-6",
+        # gpt-6-astra rejects function tools + reasoning_effort on /chat/completions
+        # ("use /v1/responses or set reasoning_effort to 'none'"), like gpt-5-5/gpt-5-6.
+        "gpt-6-astra",
         # Bedrock Grok rejects the gateway's llm/v1/chat task type.
         "grok",
     )


### PR DESCRIPTION
## Problem

The `e2e` job's `test_launch_copilot_per_model` iterates every discovered model and launches Copilot against each. It fails on `databricks-gpt-6-astra` with a gateway 400:

    Function tools with reasoning_effort are not supported for gpt-6-astra in /v1/chat/completions. To use function tools, use /v1/responses or set reasoning_effort to 'none'.

Copilot CLI's `openai` provider only speaks `/chat/completions`, so a reasoning model that requires `/v1/responses` for function tools cannot be launched through Copilot. This is the exact incompatibility already recorded for `gpt-5-5` and `gpt-5-6` in `COPILOT_INCOMPATIBLE_MODEL_FRAGMENTS`; `gpt-6-astra` is a newer model that simply isn't in the list yet.

## Fix

Add `gpt-6-astra` to `COPILOT_INCOMPATIBLE_MODEL_FRAGMENTS` so the Copilot e2e skips it, matching the established pattern. codex and pi launch the model fine via the responses / native APIs, so only the Copilot list changes. Three-line, test-only change.

This is intended to merge before the AI-Gateway managed-config PRs, since the failing e2e blocks their CI too.

This pull request and its description were written by Isaac.
