### PR TITLE
smart routing: fix codex first prompt route

### DIFF
--- a/src/ucode/smart_routing/codex_interposer.py
+++ b/src/ucode/smart_routing/codex_interposer.py
@@ -48,7 +48,7 @@ def _prompt_from_turn(params: dict) -> str | None:
 @dataclass
 class TuiFrameResult:
     frame: str
-    needs_settings_update: bool = False
+    needs_settings_update: bool
 
 
 class _Session:
@@ -74,30 +74,31 @@ class _Session:
         self.notice_pending = False
         self.injected = False
         self.settings_update_id: str | None = None
+        self.settings_update_event: asyncio.Event = asyncio.Event()
 
     def on_tui_frame(self, raw: str) -> TuiFrameResult:
         try:
             msg = json.loads(raw)
         except ValueError:
-            return TuiFrameResult(raw)
+            return TuiFrameResult(raw, needs_settings_update=False)
         if not isinstance(msg, dict):
-            return TuiFrameResult(raw)
+            return TuiFrameResult(raw, needs_settings_update=False)
         params = msg.get("params")
         if msg.get("method") == TURN_START and isinstance(params, dict):
             if isinstance(params.get("threadId"), str):
                 self.thread_id = params["threadId"]
             if self.first_turn_seen:
-                return TuiFrameResult(raw)
+                return TuiFrameResult(raw, needs_settings_update=False)
             self.first_turn_seen = True
             if self.route_decision is not None:
                 prompt = _prompt_from_turn(params)
                 if prompt is None:
                     self.log("[ROUTE] first turn had no plaintext prompt; keeping current model")
-                    return TuiFrameResult(raw)
+                    return TuiFrameResult(raw, needs_settings_update=False)
                 decision, reason = self.route_decision(prompt)
                 if decision is None:
                     self.log(f"[ROUTE] selection failed; keeping current model: {reason}")
-                    return TuiFrameResult(raw)
+                    return TuiFrameResult(raw, needs_settings_update=False)
                 decision = replace(decision, model=codex_routing.codex_model_id(decision.model))
                 self.target = decision.model
                 if self.switch_message_fn is not None:
@@ -115,7 +116,7 @@ class _Session:
                 self.switch_pending = True
                 self.log(f"[REWRITE] model {old!r} -> {self.target!r}")
                 return TuiFrameResult(json.dumps(msg), needs_settings_update=True)
-        return TuiFrameResult(raw)
+        return TuiFrameResult(raw, needs_settings_update=False)
 
     def on_engine_frame(self, raw: str) -> list[dict]:
         try:
@@ -140,6 +141,7 @@ class _Session:
             and msg["id"] == self.settings_update_id
         ):
             self.settings_update_id = None
+            self.settings_update_event.set()
         if (
             msg.get("method") == TURN_STARTED
             and not self.injected
@@ -256,15 +258,11 @@ async def _handle_tui(
                         sess.settings_update_id = update_id
                         log(f"[ROUTE] sending {SETTINGS_UPDATE} model={sess.target!r} to app-server")
                         await upstream.send(update_req)
-                        deadline = asyncio.get_event_loop().time() + 10
-                        while sess.settings_update_id is not None:
-                            remaining = deadline - asyncio.get_event_loop().time()
-                            if remaining <= 0:
-                                log("[ROUTE] settings/update timed out; forwarding turn/start anyway")
-                                break
-                            await asyncio.sleep(0.05)
-                        if sess.settings_update_id is None:
+                        try:
+                            await asyncio.wait_for(sess.settings_update_event.wait(), timeout=10)
                             log("[ROUTE] settings/update confirmed by app-server")
+                        except TimeoutError:
+                            log("[ROUTE] settings/update timed out; forwarding turn/start anyway")
                     await upstream.send(result.frame)
                 else:
                     await upstream.send(frame)

--- a/src/ucode/smart_routing/codex_interposer.py
+++ b/src/ucode/smart_routing/codex_interposer.py
@@ -16,6 +16,7 @@ from websockets.asyncio.server import serve
 from ucode.smart_routing import codex_routing, routing
 
 SETTINGS_UPDATED = "thread/settings/updated"
+SETTINGS_UPDATE = "thread/settings/update"
 ITEM_STARTED = "item/started"
 ITEM_COMPLETED = "item/completed"
 TURN_START = "turn/start"
@@ -24,6 +25,42 @@ TURN_STARTED = "turn/started"
 RouteDecisionFn = Callable[[str], tuple[routing.RoutingDecision | None, str | None]]
 SwitchMessageFn = Callable[[str, str], str]
 TokenProvider = Callable[[], str]
+
+def _frame_summary(raw: str) -> str:
+    """Return a compact one-line summary of a JSON-RPC frame for logging."""
+    try:
+        msg = json.loads(raw)
+    except ValueError:
+        return raw[:80]
+    if not isinstance(msg, dict):
+        return raw[:80]
+    method = msg.get("method") or "?"
+    parts: list[str] = [f"method={method}"]
+    if "id" in msg:
+        parts.append(f"id={msg['id']}")
+    params = msg.get("params")
+    if isinstance(params, dict):
+        model = params.get("model")
+        if isinstance(model, str):
+            parts.append(f"model={model}")
+        tid = params.get("threadId")
+        if isinstance(tid, str):
+            parts.append(f"threadId={tid}")
+        turn = params.get("turn")
+        if isinstance(turn, dict) and isinstance(turn.get("id"), str):
+            parts.append(f"turnId={turn['id']}")
+        ts = params.get("threadSettings")
+        if isinstance(ts, dict) and isinstance(ts.get("model"), str):
+            parts.append(f"threadSettings.model={ts['model']}")
+    result = msg.get("result")
+    if isinstance(result, dict):
+        thread = result.get("thread")
+        if isinstance(thread, dict):
+            if isinstance(thread.get("id"), str):
+                parts.append(f"result.thread.id={thread['id']}")
+            if isinstance(thread.get("model"), str):
+                parts.append(f"result.thread.model={thread['model']}")
+    return " ".join(parts)
 
 
 def _prompt_from_turn(params: dict) -> str | None:
@@ -66,31 +103,38 @@ class _Session:
         self.switch_pending = False
         self.notice_pending = False
         self.injected = False
+        self.settings_update_id: str | None = None
 
-    def on_tui_frame(self, raw: str) -> str:
+    def on_tui_frame(self, raw: str) -> tuple[str, bool]:
+        """Process a TUI-to-app frame. Returns (frame, needs_settings_update).
+
+        When routing selects a different model, the caller must send
+        ``thread/settings/update`` to the app-server (and wait for its
+        confirmation) before forwarding the returned frame.
+        """
         try:
             msg = json.loads(raw)
         except ValueError:
-            return raw
+            return raw, False
         if not isinstance(msg, dict):
-            return raw
+            return raw, False
         params = msg.get("params")
         if msg.get("method") == TURN_START and isinstance(params, dict):
             if isinstance(params.get("threadId"), str):
                 self.thread_id = params["threadId"]
             # Route only the first turn; later /model selections belong to the user.
             if self.first_turn_seen:
-                return raw
+                return raw, False
             self.first_turn_seen = True
             if self.route_decision is not None:
                 prompt = _prompt_from_turn(params)
                 if prompt is None:
                     self.log("[ROUTE] first turn had no plaintext prompt; keeping current model")
-                    return raw
+                    return raw, False
                 decision, reason = self.route_decision(prompt)
                 if decision is None:
                     self.log(f"[ROUTE] selection failed; keeping current model: {reason}")
-                    return raw
+                    return raw, False
                 decision = replace(decision, model=codex_routing.codex_model_id(decision.model))
                 self.target = decision.model
                 if self.switch_message_fn is not None:
@@ -100,10 +144,21 @@ class _Session:
             old = params.get("model")
             if self.target is not None and old != self.target:
                 params["model"] = self.target
+                # Also rewrite the nested collaborationMode.settings.model —
+                # the app-server uses it to re-derive the thread model on
+                # every turn/start, overwriting any thread/settings/update
+                # we sent beforehand.
+                collab = params.get("collaborationMode")
+                if isinstance(collab, dict):
+                    settings = collab.get("settings")
+                    if isinstance(settings, dict) and isinstance(
+                        settings.get("model"), str
+                    ):
+                        settings["model"] = self.target
                 self.switch_pending = True
                 self.log(f"[REWRITE] model {old!r} -> {self.target!r}")
-                return json.dumps(msg)
-        return raw
+                return json.dumps(msg), True
+        return raw, False
 
     def on_engine_frame(self, raw: str) -> list[dict]:
         try:
@@ -122,6 +177,14 @@ class _Session:
             ts = src.get("threadSettings")
             if isinstance(ts, dict):
                 self.settings = ts
+        # When the app-server confirms our thread/settings/update request,
+        # record it so the tui_to_app loop can stop waiting.
+        if (
+            self.settings_update_id is not None
+            and isinstance(msg.get("id"), str)
+            and msg["id"] == self.settings_update_id
+        ):
+            self.settings_update_id = None
         if (
             msg.get("method") == TURN_STARTED
             and not self.injected
@@ -225,17 +288,54 @@ async def _handle_tui(
         async def tui_to_app():
             async for frame in tui:
                 if isinstance(frame, str):
+                    log(f"[TUI->APP] {_frame_summary(frame)}")
                     # Route selection is a blocking HTTP call. Keep it off the
                     # WebSocket event loop while holding this first frame until
                     # its selected model has been written into ``turn/start``.
-                    frame = await asyncio.to_thread(sess.on_tui_frame, frame)
+                    frame, needs_settings_update = await asyncio.to_thread(
+                        sess.on_tui_frame, frame
+                    )
+                    # When routing picks a different model, send
+                    # thread/settings/update to the app-server BEFORE
+                    # forwarding turn/start.  The app-server pins the model
+                    # at thread creation time and ignores the per-turn
+                    # ``model`` field, so we must update the thread model
+                    # at the app-server level before the turn begins.
+                    if needs_settings_update and sess.thread_id:
+                        update_id = f"ucode-route-{uuid.uuid4().hex}"
+                        update_req = json.dumps({
+                            "id": update_id,
+                            "method": SETTINGS_UPDATE,
+                            "params": {
+                                "threadId": sess.thread_id,
+                                "model": sess.target,
+                            },
+                        })
+                        sess.settings_update_id = update_id
+                        log(f"[ROUTE] sending {SETTINGS_UPDATE} model={sess.target!r} to app-server")
+                        await upstream.send(update_req)
+                        # Wait for the app-server to confirm the update.
+                        # The response arrives on the app_to_tui loop and
+                        # clears settings_update_id in on_engine_frame.
+                        deadline = asyncio.get_event_loop().time() + 10
+                        while sess.settings_update_id is not None:
+                            remaining = deadline - asyncio.get_event_loop().time()
+                            if remaining <= 0:
+                                log("[ROUTE] settings/update timed out; forwarding turn/start anyway")
+                                break
+                            await asyncio.sleep(0.05)
+                        if sess.settings_update_id is None:
+                            log("[ROUTE] settings/update confirmed by app-server")
                 await upstream.send(frame)
 
         async def app_to_tui():
             async for frame in upstream:
+                if isinstance(frame, str):
+                    log(f"[APP->TUI] {_frame_summary(frame)}")
                 await tui.send(frame)
                 if isinstance(frame, str):
                     for inj in sess.on_engine_frame(frame):
+                        log(f"[TUI<-INJ] {_frame_summary(json.dumps(inj))}")
                         await tui.send(json.dumps(inj))
 
         a = asyncio.create_task(tui_to_app())

--- a/src/ucode/smart_routing/codex_interposer.py
+++ b/src/ucode/smart_routing/codex_interposer.py
@@ -247,16 +247,20 @@ async def _handle_tui(
                     result = await asyncio.to_thread(sess.on_tui_frame, frame)
                     if result.needs_settings_update and sess.thread_id:
                         update_id = f"ucode-route-{uuid.uuid4().hex}"
-                        update_req = json.dumps({
-                            "id": update_id,
-                            "method": SETTINGS_UPDATE,
-                            "params": {
-                                "threadId": sess.thread_id,
-                                "model": sess.target,
-                            },
-                        })
+                        update_req = json.dumps(
+                            {
+                                "id": update_id,
+                                "method": SETTINGS_UPDATE,
+                                "params": {
+                                    "threadId": sess.thread_id,
+                                    "model": sess.target,
+                                },
+                            }
+                        )
                         sess.settings_update_id = update_id
-                        log(f"[ROUTE] sending {SETTINGS_UPDATE} model={sess.target!r} to app-server")
+                        log(
+                            f"[ROUTE] sending {SETTINGS_UPDATE} model={sess.target!r} to app-server"
+                        )
                         await upstream.send(update_req)
                         try:
                             await asyncio.wait_for(sess.settings_update_event.wait(), timeout=10)

--- a/src/ucode/smart_routing/codex_interposer.py
+++ b/src/ucode/smart_routing/codex_interposer.py
@@ -7,7 +7,7 @@ import threading
 import time
 import uuid
 from collections.abc import Callable
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 
 from websockets.asyncio.client import connect
@@ -26,42 +26,6 @@ RouteDecisionFn = Callable[[str], tuple[routing.RoutingDecision | None, str | No
 SwitchMessageFn = Callable[[str, str], str]
 TokenProvider = Callable[[], str]
 
-def _frame_summary(raw: str) -> str:
-    """Return a compact one-line summary of a JSON-RPC frame for logging."""
-    try:
-        msg = json.loads(raw)
-    except ValueError:
-        return raw[:80]
-    if not isinstance(msg, dict):
-        return raw[:80]
-    method = msg.get("method") or "?"
-    parts: list[str] = [f"method={method}"]
-    if "id" in msg:
-        parts.append(f"id={msg['id']}")
-    params = msg.get("params")
-    if isinstance(params, dict):
-        model = params.get("model")
-        if isinstance(model, str):
-            parts.append(f"model={model}")
-        tid = params.get("threadId")
-        if isinstance(tid, str):
-            parts.append(f"threadId={tid}")
-        turn = params.get("turn")
-        if isinstance(turn, dict) and isinstance(turn.get("id"), str):
-            parts.append(f"turnId={turn['id']}")
-        ts = params.get("threadSettings")
-        if isinstance(ts, dict) and isinstance(ts.get("model"), str):
-            parts.append(f"threadSettings.model={ts['model']}")
-    result = msg.get("result")
-    if isinstance(result, dict):
-        thread = result.get("thread")
-        if isinstance(thread, dict):
-            if isinstance(thread.get("id"), str):
-                parts.append(f"result.thread.id={thread['id']}")
-            if isinstance(thread.get("model"), str):
-                parts.append(f"result.thread.model={thread['model']}")
-    return " ".join(parts)
-
 
 def _prompt_from_turn(params: dict) -> str | None:
     """Extract the plaintext portions of a Codex ``turn/start`` input."""
@@ -79,6 +43,12 @@ def _prompt_from_turn(params: dict) -> str | None:
             parts.append(item["text"])
     prompt = "\n".join(part for part in parts if part.strip())
     return prompt or None
+
+
+@dataclass
+class TuiFrameResult:
+    frame: str
+    needs_settings_update: bool = False
 
 
 class _Session:
@@ -105,36 +75,29 @@ class _Session:
         self.injected = False
         self.settings_update_id: str | None = None
 
-    def on_tui_frame(self, raw: str) -> tuple[str, bool]:
-        """Process a TUI-to-app frame. Returns (frame, needs_settings_update).
-
-        When routing selects a different model, the caller must send
-        ``thread/settings/update`` to the app-server (and wait for its
-        confirmation) before forwarding the returned frame.
-        """
+    def on_tui_frame(self, raw: str) -> TuiFrameResult:
         try:
             msg = json.loads(raw)
         except ValueError:
-            return raw, False
+            return TuiFrameResult(raw)
         if not isinstance(msg, dict):
-            return raw, False
+            return TuiFrameResult(raw)
         params = msg.get("params")
         if msg.get("method") == TURN_START and isinstance(params, dict):
             if isinstance(params.get("threadId"), str):
                 self.thread_id = params["threadId"]
-            # Route only the first turn; later /model selections belong to the user.
             if self.first_turn_seen:
-                return raw, False
+                return TuiFrameResult(raw)
             self.first_turn_seen = True
             if self.route_decision is not None:
                 prompt = _prompt_from_turn(params)
                 if prompt is None:
                     self.log("[ROUTE] first turn had no plaintext prompt; keeping current model")
-                    return raw, False
+                    return TuiFrameResult(raw)
                 decision, reason = self.route_decision(prompt)
                 if decision is None:
                     self.log(f"[ROUTE] selection failed; keeping current model: {reason}")
-                    return raw, False
+                    return TuiFrameResult(raw)
                 decision = replace(decision, model=codex_routing.codex_model_id(decision.model))
                 self.target = decision.model
                 if self.switch_message_fn is not None:
@@ -144,21 +107,15 @@ class _Session:
             old = params.get("model")
             if self.target is not None and old != self.target:
                 params["model"] = self.target
-                # Also rewrite the nested collaborationMode.settings.model —
-                # the app-server uses it to re-derive the thread model on
-                # every turn/start, overwriting any thread/settings/update
-                # we sent beforehand.
                 collab = params.get("collaborationMode")
                 if isinstance(collab, dict):
                     settings = collab.get("settings")
-                    if isinstance(settings, dict) and isinstance(
-                        settings.get("model"), str
-                    ):
+                    if isinstance(settings, dict) and isinstance(settings.get("model"), str):
                         settings["model"] = self.target
                 self.switch_pending = True
                 self.log(f"[REWRITE] model {old!r} -> {self.target!r}")
-                return json.dumps(msg), True
-        return raw, False
+                return TuiFrameResult(json.dumps(msg), needs_settings_update=True)
+        return TuiFrameResult(raw)
 
     def on_engine_frame(self, raw: str) -> list[dict]:
         try:
@@ -177,8 +134,6 @@ class _Session:
             ts = src.get("threadSettings")
             if isinstance(ts, dict):
                 self.settings = ts
-        # When the app-server confirms our thread/settings/update request,
-        # record it so the tui_to_app loop can stop waiting.
         if (
             self.settings_update_id is not None
             and isinstance(msg.get("id"), str)
@@ -218,7 +173,6 @@ class _Session:
                     "memoryCitation": None,
                 }
                 self.log(f"[INJECT] agentMessage note (started+completed): {self.switch_message!r}")
-                # Codex renders the message only when it receives both lifecycle events.
                 injected.append(
                     {
                         "method": ITEM_STARTED,
@@ -288,20 +242,8 @@ async def _handle_tui(
         async def tui_to_app():
             async for frame in tui:
                 if isinstance(frame, str):
-                    log(f"[TUI->APP] {_frame_summary(frame)}")
-                    # Route selection is a blocking HTTP call. Keep it off the
-                    # WebSocket event loop while holding this first frame until
-                    # its selected model has been written into ``turn/start``.
-                    frame, needs_settings_update = await asyncio.to_thread(
-                        sess.on_tui_frame, frame
-                    )
-                    # When routing picks a different model, send
-                    # thread/settings/update to the app-server BEFORE
-                    # forwarding turn/start.  The app-server pins the model
-                    # at thread creation time and ignores the per-turn
-                    # ``model`` field, so we must update the thread model
-                    # at the app-server level before the turn begins.
-                    if needs_settings_update and sess.thread_id:
+                    result = await asyncio.to_thread(sess.on_tui_frame, frame)
+                    if result.needs_settings_update and sess.thread_id:
                         update_id = f"ucode-route-{uuid.uuid4().hex}"
                         update_req = json.dumps({
                             "id": update_id,
@@ -314,9 +256,6 @@ async def _handle_tui(
                         sess.settings_update_id = update_id
                         log(f"[ROUTE] sending {SETTINGS_UPDATE} model={sess.target!r} to app-server")
                         await upstream.send(update_req)
-                        # Wait for the app-server to confirm the update.
-                        # The response arrives on the app_to_tui loop and
-                        # clears settings_update_id in on_engine_frame.
                         deadline = asyncio.get_event_loop().time() + 10
                         while sess.settings_update_id is not None:
                             remaining = deadline - asyncio.get_event_loop().time()
@@ -326,16 +265,15 @@ async def _handle_tui(
                             await asyncio.sleep(0.05)
                         if sess.settings_update_id is None:
                             log("[ROUTE] settings/update confirmed by app-server")
-                await upstream.send(frame)
+                    await upstream.send(result.frame)
+                else:
+                    await upstream.send(frame)
 
         async def app_to_tui():
             async for frame in upstream:
-                if isinstance(frame, str):
-                    log(f"[APP->TUI] {_frame_summary(frame)}")
                 await tui.send(frame)
                 if isinstance(frame, str):
                     for inj in sess.on_engine_frame(frame):
-                        log(f"[TUI<-INJ] {_frame_summary(json.dumps(inj))}")
                         await tui.send(json.dumps(inj))
 
         a = asyncio.create_task(tui_to_app())

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -313,15 +313,21 @@ class TestInterposerSession:
     def test_does_not_schedule_notification_when_model_is_already_selected(self):
         sess = codex_interposer._Session("gpt-5.5", log=lambda _m: None)
         frame = self._turn_start("gpt-5.5")
-        assert sess.on_tui_frame(frame) == codex_interposer.TuiFrameResult(frame, needs_settings_update=False)
+        assert sess.on_tui_frame(frame) == codex_interposer.TuiFrameResult(
+            frame, needs_settings_update=False
+        )
         assert sess.on_engine_frame(self._turn_started("turn-1")) == []
         later_selection = self._turn_start("gpt-5.6")
-        assert sess.on_tui_frame(later_selection) == codex_interposer.TuiFrameResult(later_selection, needs_settings_update=False)
+        assert sess.on_tui_frame(later_selection) == codex_interposer.TuiFrameResult(
+            later_selection, needs_settings_update=False
+        )
 
     def test_non_turn_frames_pass_through(self):
         sess = codex_interposer._Session("gpt-5.5", log=lambda _m: None)
         frame = json.dumps({"method": "initialize", "id": 1, "params": {}})
-        assert sess.on_tui_frame(frame) == codex_interposer.TuiFrameResult(frame, needs_settings_update=False)
+        assert sess.on_tui_frame(frame) == codex_interposer.TuiFrameResult(
+            frame, needs_settings_update=False
+        )
 
     def _turn_started(self, turn_id: str, thread_id: str = "t1") -> str:
         return json.dumps(
@@ -366,7 +372,9 @@ class TestInterposerSession:
         sess.on_tui_frame(self._turn_start("luna"))
         assert sess.on_engine_frame(self._turn_started("turn-1"))
         second_turn = self._turn_start("luna")
-        assert sess.on_tui_frame(second_turn) == codex_interposer.TuiFrameResult(second_turn, needs_settings_update=False)
+        assert sess.on_tui_frame(second_turn) == codex_interposer.TuiFrameResult(
+            second_turn, needs_settings_update=False
+        )
         assert sess.on_engine_frame(self._turn_started("turn-2")) == []
 
     def test_routes_first_prompt_and_uses_returned_model_and_rationale(self):
@@ -461,7 +469,9 @@ class TestInterposerSession:
         )
         frame = self._turn_start("gpt-start")
 
-        assert sess.on_tui_frame(frame) == codex_interposer.TuiFrameResult(frame, needs_settings_update=False)
+        assert sess.on_tui_frame(frame) == codex_interposer.TuiFrameResult(
+            frame, needs_settings_update=False
+        )
 
     def test_rewrites_nested_collaboration_mode_model(self):
         """The app-server re-derives the thread model from
@@ -481,22 +491,24 @@ class TestInterposerSession:
             ),
             switch_message_fn=v2._switch_message,
         )
-        frame = json.dumps({
-            "method": codex_interposer.TURN_START,
-            "id": 1,
-            "params": {
-                "threadId": "t1",
-                "input": [{"type": "text", "text": "hello"}],
-                "model": "gpt-6-astra",
-                "collaborationMode": {
-                    "mode": "default",
-                    "settings": {
-                        "model": "gpt-6-astra",
-                        "reasoning_effort": "high",
+        frame = json.dumps(
+            {
+                "method": codex_interposer.TURN_START,
+                "id": 1,
+                "params": {
+                    "threadId": "t1",
+                    "input": [{"type": "text", "text": "hello"}],
+                    "model": "gpt-6-astra",
+                    "collaborationMode": {
+                        "mode": "default",
+                        "settings": {
+                            "model": "gpt-6-astra",
+                            "reasoning_effort": "high",
+                        },
                     },
                 },
-            },
-        })
+            }
+        )
         result = sess.on_tui_frame(frame)
         parsed = json.loads(result.frame)
         assert parsed["params"]["model"] == "gpt-5.6-luna"

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -306,21 +306,22 @@ class TestInterposerSession:
 
     def test_switches_first_turn(self):
         sess = codex_interposer._Session("gpt-5.5", log=lambda _m: None)
-        output = sess.on_tui_frame(self._turn_start("system.ai.gpt-5-6-luna"))
+        output, needs_update = sess.on_tui_frame(self._turn_start("system.ai.gpt-5-6-luna"))
         assert json.loads(output)["params"]["model"] == "gpt-5.5"
+        assert needs_update
 
     def test_does_not_schedule_notification_when_model_is_already_selected(self):
         sess = codex_interposer._Session("gpt-5.5", log=lambda _m: None)
         frame = self._turn_start("gpt-5.5")
-        assert sess.on_tui_frame(frame) == frame
+        assert sess.on_tui_frame(frame) == (frame, False)
         assert sess.on_engine_frame(self._turn_started("turn-1")) == []
         later_selection = self._turn_start("gpt-5.6")
-        assert sess.on_tui_frame(later_selection) == later_selection
+        assert sess.on_tui_frame(later_selection) == (later_selection, False)
 
     def test_non_turn_frames_pass_through(self):
         sess = codex_interposer._Session("gpt-5.5", log=lambda _m: None)
         frame = json.dumps({"method": "initialize", "id": 1, "params": {}})
-        assert sess.on_tui_frame(frame) == frame
+        assert sess.on_tui_frame(frame) == (frame, False)
 
     def _turn_started(self, turn_id: str, thread_id: str = "t1") -> str:
         return json.dumps(
@@ -365,7 +366,7 @@ class TestInterposerSession:
         sess.on_tui_frame(self._turn_start("luna"))
         assert sess.on_engine_frame(self._turn_started("turn-1"))
         second_turn = self._turn_start("luna")
-        assert sess.on_tui_frame(second_turn) == second_turn
+        assert sess.on_tui_frame(second_turn) == (second_turn, False)
         assert sess.on_engine_frame(self._turn_started("turn-2")) == []
 
     def test_routes_first_prompt_and_uses_returned_model_and_rationale(self):
@@ -390,10 +391,11 @@ class TestInterposerSession:
             switch_message_fn=v2.format_routing_notice,
         )
 
-        output = sess.on_tui_frame(self._turn_start("gpt-5.5", prompt="Fix issue #42"))
+        output, needs_update = sess.on_tui_frame(self._turn_start("gpt-5.5", prompt="Fix issue #42"))
 
         assert calls == ["Fix issue #42"]
         assert json.loads(output)["params"]["model"] == "claude-opus-4-8"
+        assert needs_update
         assert "Task classified as bugfix." in sess.switch_message
 
     def test_maps_selected_uc_gpt_model_and_shows_routing_notice(self):
@@ -415,7 +417,7 @@ class TestInterposerSession:
         )
         frame = self._turn_start("system.ai.gpt-5-6-luna")
 
-        output = sess.on_tui_frame(frame)
+        output, needs_update = sess.on_tui_frame(frame)
         assert json.loads(output)["params"]["model"] == "gpt-5.6-luna"
         injected = sess.on_engine_frame(self._turn_started("turn-1"))
 
@@ -445,9 +447,10 @@ class TestInterposerSession:
             switch_message_fn=v2._switch_message,
         )
 
-        output = sess.on_tui_frame(self._turn_start("system.ai.gpt-5-6-sol"))
+        output, needs_update = sess.on_tui_frame(self._turn_start("system.ai.gpt-5-6-sol"))
 
         assert json.loads(output)["params"]["model"] == "system.ai.glm-5-2"
+        assert needs_update
         assert "Selected Model : system.ai.glm-5-2" in sess.switch_message
 
     def test_router_failure_keeps_original_model(self):
@@ -458,7 +461,47 @@ class TestInterposerSession:
         )
         frame = self._turn_start("gpt-start")
 
-        assert sess.on_tui_frame(frame) == frame
+        assert sess.on_tui_frame(frame) == (frame, False)
+
+    def test_rewrites_nested_collaboration_mode_model(self):
+        """The app-server re-derives the thread model from
+        collaborationMode.settings.model on every turn/start, so the
+        interposer must rewrite that nested field too — not just the
+        top-level ``model`` field."""
+        sess = codex_interposer._Session(
+            None,
+            log=lambda _m: None,
+            route_decision=lambda _p: (
+                codex_interposer.routing.RoutingDecision(
+                    model="gpt-5.6-luna",
+                    raw_model="gpt-5-6-luna",
+                    rationale="trivial",
+                ),
+                None,
+            ),
+            switch_message_fn=v2._switch_message,
+        )
+        frame = json.dumps({
+            "method": codex_interposer.TURN_START,
+            "id": 1,
+            "params": {
+                "threadId": "t1",
+                "input": [{"type": "text", "text": "hello"}],
+                "model": "gpt-6-astra",
+                "collaborationMode": {
+                    "mode": "default",
+                    "settings": {
+                        "model": "gpt-6-astra",
+                        "reasoning_effort": "high",
+                    },
+                },
+            },
+        })
+        output, needs_update = sess.on_tui_frame(frame)
+        result = json.loads(output)
+        assert result["params"]["model"] == "gpt-5.6-luna"
+        assert result["params"]["collaborationMode"]["settings"]["model"] == "gpt-5.6-luna"
+        assert needs_update
 
 
 def test_routing_request_uses_models_prompt_and_same_token(monkeypatch):

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -313,15 +313,15 @@ class TestInterposerSession:
     def test_does_not_schedule_notification_when_model_is_already_selected(self):
         sess = codex_interposer._Session("gpt-5.5", log=lambda _m: None)
         frame = self._turn_start("gpt-5.5")
-        assert sess.on_tui_frame(frame) == codex_interposer.TuiFrameResult(frame)
+        assert sess.on_tui_frame(frame) == codex_interposer.TuiFrameResult(frame, needs_settings_update=False)
         assert sess.on_engine_frame(self._turn_started("turn-1")) == []
         later_selection = self._turn_start("gpt-5.6")
-        assert sess.on_tui_frame(later_selection) == codex_interposer.TuiFrameResult(later_selection)
+        assert sess.on_tui_frame(later_selection) == codex_interposer.TuiFrameResult(later_selection, needs_settings_update=False)
 
     def test_non_turn_frames_pass_through(self):
         sess = codex_interposer._Session("gpt-5.5", log=lambda _m: None)
         frame = json.dumps({"method": "initialize", "id": 1, "params": {}})
-        assert sess.on_tui_frame(frame) == codex_interposer.TuiFrameResult(frame)
+        assert sess.on_tui_frame(frame) == codex_interposer.TuiFrameResult(frame, needs_settings_update=False)
 
     def _turn_started(self, turn_id: str, thread_id: str = "t1") -> str:
         return json.dumps(
@@ -366,7 +366,7 @@ class TestInterposerSession:
         sess.on_tui_frame(self._turn_start("luna"))
         assert sess.on_engine_frame(self._turn_started("turn-1"))
         second_turn = self._turn_start("luna")
-        assert sess.on_tui_frame(second_turn) == codex_interposer.TuiFrameResult(second_turn)
+        assert sess.on_tui_frame(second_turn) == codex_interposer.TuiFrameResult(second_turn, needs_settings_update=False)
         assert sess.on_engine_frame(self._turn_started("turn-2")) == []
 
     def test_routes_first_prompt_and_uses_returned_model_and_rationale(self):
@@ -461,7 +461,7 @@ class TestInterposerSession:
         )
         frame = self._turn_start("gpt-start")
 
-        assert sess.on_tui_frame(frame) == codex_interposer.TuiFrameResult(frame)
+        assert sess.on_tui_frame(frame) == codex_interposer.TuiFrameResult(frame, needs_settings_update=False)
 
     def test_rewrites_nested_collaboration_mode_model(self):
         """The app-server re-derives the thread model from

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -306,22 +306,22 @@ class TestInterposerSession:
 
     def test_switches_first_turn(self):
         sess = codex_interposer._Session("gpt-5.5", log=lambda _m: None)
-        output, needs_update = sess.on_tui_frame(self._turn_start("system.ai.gpt-5-6-luna"))
-        assert json.loads(output)["params"]["model"] == "gpt-5.5"
-        assert needs_update
+        result = sess.on_tui_frame(self._turn_start("system.ai.gpt-5-6-luna"))
+        assert json.loads(result.frame)["params"]["model"] == "gpt-5.5"
+        assert result.needs_settings_update
 
     def test_does_not_schedule_notification_when_model_is_already_selected(self):
         sess = codex_interposer._Session("gpt-5.5", log=lambda _m: None)
         frame = self._turn_start("gpt-5.5")
-        assert sess.on_tui_frame(frame) == (frame, False)
+        assert sess.on_tui_frame(frame) == codex_interposer.TuiFrameResult(frame)
         assert sess.on_engine_frame(self._turn_started("turn-1")) == []
         later_selection = self._turn_start("gpt-5.6")
-        assert sess.on_tui_frame(later_selection) == (later_selection, False)
+        assert sess.on_tui_frame(later_selection) == codex_interposer.TuiFrameResult(later_selection)
 
     def test_non_turn_frames_pass_through(self):
         sess = codex_interposer._Session("gpt-5.5", log=lambda _m: None)
         frame = json.dumps({"method": "initialize", "id": 1, "params": {}})
-        assert sess.on_tui_frame(frame) == (frame, False)
+        assert sess.on_tui_frame(frame) == codex_interposer.TuiFrameResult(frame)
 
     def _turn_started(self, turn_id: str, thread_id: str = "t1") -> str:
         return json.dumps(
@@ -366,7 +366,7 @@ class TestInterposerSession:
         sess.on_tui_frame(self._turn_start("luna"))
         assert sess.on_engine_frame(self._turn_started("turn-1"))
         second_turn = self._turn_start("luna")
-        assert sess.on_tui_frame(second_turn) == (second_turn, False)
+        assert sess.on_tui_frame(second_turn) == codex_interposer.TuiFrameResult(second_turn)
         assert sess.on_engine_frame(self._turn_started("turn-2")) == []
 
     def test_routes_first_prompt_and_uses_returned_model_and_rationale(self):
@@ -391,11 +391,11 @@ class TestInterposerSession:
             switch_message_fn=v2.format_routing_notice,
         )
 
-        output, needs_update = sess.on_tui_frame(self._turn_start("gpt-5.5", prompt="Fix issue #42"))
+        result = sess.on_tui_frame(self._turn_start("gpt-5.5", prompt="Fix issue #42"))
 
         assert calls == ["Fix issue #42"]
-        assert json.loads(output)["params"]["model"] == "claude-opus-4-8"
-        assert needs_update
+        assert json.loads(result.frame)["params"]["model"] == "claude-opus-4-8"
+        assert result.needs_settings_update
         assert "Task classified as bugfix." in sess.switch_message
 
     def test_maps_selected_uc_gpt_model_and_shows_routing_notice(self):
@@ -417,8 +417,8 @@ class TestInterposerSession:
         )
         frame = self._turn_start("system.ai.gpt-5-6-luna")
 
-        output, needs_update = sess.on_tui_frame(frame)
-        assert json.loads(output)["params"]["model"] == "gpt-5.6-luna"
+        result = sess.on_tui_frame(frame)
+        assert json.loads(result.frame)["params"]["model"] == "gpt-5.6-luna"
         injected = sess.on_engine_frame(self._turn_started("turn-1"))
 
         assert [message["method"] for message in injected] == [
@@ -447,10 +447,10 @@ class TestInterposerSession:
             switch_message_fn=v2._switch_message,
         )
 
-        output, needs_update = sess.on_tui_frame(self._turn_start("system.ai.gpt-5-6-sol"))
+        result = sess.on_tui_frame(self._turn_start("system.ai.gpt-5-6-sol"))
 
-        assert json.loads(output)["params"]["model"] == "system.ai.glm-5-2"
-        assert needs_update
+        assert json.loads(result.frame)["params"]["model"] == "system.ai.glm-5-2"
+        assert result.needs_settings_update
         assert "Selected Model : system.ai.glm-5-2" in sess.switch_message
 
     def test_router_failure_keeps_original_model(self):
@@ -461,7 +461,7 @@ class TestInterposerSession:
         )
         frame = self._turn_start("gpt-start")
 
-        assert sess.on_tui_frame(frame) == (frame, False)
+        assert sess.on_tui_frame(frame) == codex_interposer.TuiFrameResult(frame)
 
     def test_rewrites_nested_collaboration_mode_model(self):
         """The app-server re-derives the thread model from
@@ -497,11 +497,11 @@ class TestInterposerSession:
                 },
             },
         })
-        output, needs_update = sess.on_tui_frame(frame)
-        result = json.loads(output)
-        assert result["params"]["model"] == "gpt-5.6-luna"
-        assert result["params"]["collaborationMode"]["settings"]["model"] == "gpt-5.6-luna"
-        assert needs_update
+        result = sess.on_tui_frame(frame)
+        parsed = json.loads(result.frame)
+        assert parsed["params"]["model"] == "gpt-5.6-luna"
+        assert parsed["params"]["collaborationMode"]["settings"]["model"] == "gpt-5.6-luna"
+        assert result.needs_settings_update
 
 
 def test_routing_request_uses_models_prompt_and_same_token(monkeypatch):


### PR DESCRIPTION
the intended flow for smart routing is :
1/ user sends first prompt 
2/ smart router returns recommended model 
3/ first prompt runs on the recommeded model 
4/ subsequent prompts run on the recommended model. 

instead, what was happening was: 
1/ user sends first prompt 
2/ smart router returns recommended model 
3/ first prompt runs on the DEFAULT model for the session (not the recommended model) 
4/ subsequent prompts run on the recommended model. 

this is because the [interposer](https://docs.google.com/document/d/1lO1l3sOH0V9_YIx2SQQIvDOBlBJfIwpITLFl1rYTZ7s/edit?tab=t.whcgscnu6a6r) only overwrote the top-level model in turn/start which was not used for the first prompt, only for subsequent prompts. this PR makes it so that when the smart router picks a model, we send a `thread/settings/update` request to the app-server (similar to invoking /model) before sending the first prompt so that the model actually changes. 


test
before:
<img width="1448" height="691" alt="Screenshot 2026-09-07 at 7 38 56 PM" src="https://github.com/user-attachments/assets/0960590e-ab0b-4bd8-b3ea-eb6e8f2a5728" />

after:
<img width="1449" height="649" alt="Screenshot 2026-09-07 at 7 38 36 PM" src="https://github.com/user-attachments/assets/6fe6917a-2045-4a65-b7de-a29f15105e00" />
