### PR TITLE
auth: mint tokens from a custom OAuth app

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -1491,6 +1491,14 @@ def auth_token_cmd(
         bool,
         typer.Option("--force-refresh", help="Force the Databricks CLI to mint a new token."),
     ] = False,
+    oauth_client_id: Annotated[
+        str | None,
+        typer.Option(
+            "--oauth-client-id",
+            help="Authenticate with this custom OAuth app instead of the built-in "
+            "`databricks-cli` app. Defaults to the workspace's configured client id.",
+        ),
+    ] = None,
 ) -> None:
     """Print a Databricks bearer token to stdout, then exit.
 
@@ -1521,7 +1529,10 @@ def auth_token_cmd(
             )
             raise typer.Exit(1)
     try:
-        token = get_databricks_token(workspace, profile, force_refresh=force_refresh)
+        oauth_kwargs = {"oauth_client_id": oauth_client_id} if oauth_client_id else {}
+        token = get_databricks_token(
+            workspace, profile, force_refresh=force_refresh, **oauth_kwargs
+        )
     except RuntimeError as exc:
         print_err(str(exc))
         raise typer.Exit(1) from None

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -897,12 +897,49 @@ def _profile_args(profile: str | None) -> list[str]:
     return ["--profile", profile] if profile else []
 
 
-def has_valid_databricks_auth(workspace: str, profile: str | None = None) -> bool:
+OAUTH_CLIENT_ID_STATE_KEY = "oauth_client_id"
+
+
+def _workspace_state_for_host(workspace: str) -> dict:
+    """Return the saved state for a workspace host."""
+    from ucode.state import load_full_state  # local import: state.py imports this module
+
+    workspaces = load_full_state().get("workspaces")
+    if not isinstance(workspaces, dict):
+        return {}
+    trimmed = workspace.rstrip("/")
+    for candidate in (workspace, trimmed, f"{trimmed}/"):
+        entry = workspaces.get(candidate)
+        if isinstance(entry, dict):
+            return entry
+    return {}
+
+
+def resolve_oauth_client_id(workspace: str, explicit: str | None = None) -> str | None:
+    """Resolve an explicit or saved OAuth client ID."""
+    if explicit and explicit.strip():
+        return explicit.strip()
+    value = _workspace_state_for_host(workspace).get(OAUTH_CLIENT_ID_STATE_KEY)
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def has_valid_databricks_auth(
+    workspace: str, profile: str | None = None, *, oauth_client_id: str | None = None
+) -> bool:
     # Honor the CI short-circuit (see ``get_databricks_token``): if a
     # pre-fetched bearer is available, treat auth as valid and skip the
     # `databricks auth token` shell-out (which only knows user-OAuth).
     if os.environ.get("DATABRICKS_BEARER", "").strip():
         return True
+    client_id = resolve_oauth_client_id(workspace, oauth_client_id)
+    if client_id:
+        from ucode import oauth
+
+        try:
+            return bool(oauth.get_token(workspace, client_id))
+        except RuntimeError as exc:
+            _debug("has_valid_databricks_auth", f"custom OAuth unavailable: {exc}")
+            return False
     _log_auth_diagnostics()
     # Mirror run_databricks_login: when ~/.databrickscfg has multiple
     # profiles for the same host, `databricks auth token --host …` refuses
@@ -1083,12 +1120,22 @@ def apply_pat_environment(state: dict) -> None:
     ensure_pat_bearer(state.get("profile"))
 
 
-def run_databricks_login(workspace: str, profile: str | None = None) -> None:
+def run_databricks_login(
+    workspace: str, profile: str | None = None, *, oauth_client_id: str | None = None
+) -> None:
     """Run databricks auth login unconditionally.
 
     When ``profile`` is provided, it is passed via ``--profile``. Otherwise we
     fall back to looking up an existing profile by host so a stored session is
-    refreshed in place rather than overwriting another profile's tokens."""
+    refreshed in place rather than overwriting another profile's tokens.
+
+    A custom client ID uses ucode's PKCE flow."""
+    client_id = resolve_oauth_client_id(workspace, oauth_client_id)
+    if client_id:
+        from ucode import oauth
+
+        oauth.login(workspace, client_id)
+        return
     print_section("Databricks Login")
     print_kv("Workspace", workspace)
     print_note("A browser may open for `databricks auth login`.")
@@ -1111,21 +1158,29 @@ def run_databricks_login(workspace: str, profile: str | None = None) -> None:
 
 
 def ensure_databricks_auth(
-    workspace: str, profile: str | None = None, *, quiet: bool = False
+    workspace: str,
+    profile: str | None = None,
+    *,
+    quiet: bool = False,
+    oauth_client_id: str | None = None,
 ) -> None:
     """Check auth and login only if needed (used by launch path).
 
     ``quiet`` suppresses the "already available" line for a caller that only needs a token before
     some later step re-authenticates and reports it — otherwise the same success prints twice. A
     login that actually runs is never silent.
+
+    ``oauth_client_id`` applies to both validation and login.
     """
     with spinner("Checking Databricks auth..."):
-        auth_is_valid = has_valid_databricks_auth(workspace, profile)
+        auth_is_valid = has_valid_databricks_auth(
+            workspace, profile, oauth_client_id=oauth_client_id
+        )
     if auth_is_valid:
         if not quiet:
             print_success(f"Databricks auth already available for {workspace}")
         return
-    run_databricks_login(workspace, profile)
+    run_databricks_login(workspace, profile, oauth_client_id=oauth_client_id)
 
 
 def get_databricks_token(
@@ -1133,6 +1188,7 @@ def get_databricks_token(
     profile: str | None = None,
     *,
     force_refresh: bool = False,
+    oauth_client_id: str | None = None,
 ) -> str:
     # ``DATABRICKS_BEARER`` is the CI escape hatch: when set, skip the
     # `databricks auth token` subprocess entirely and return the pre-fetched
@@ -1144,6 +1200,13 @@ def get_databricks_token(
     if bearer:
         _debug("get_databricks_token", "using DATABRICKS_BEARER env var")
         return bearer
+
+    client_id = resolve_oauth_client_id(workspace, oauth_client_id)
+    if client_id:
+        from ucode import oauth
+
+        _debug("get_databricks_token", f"custom OAuth client {client_id}")
+        return oauth.get_token(workspace, client_id, force_refresh=force_refresh)
 
     _log_auth_diagnostics()
     # See has_valid_databricks_auth: resolve the profile from the host when
@@ -1430,7 +1493,11 @@ def _ucode_binary() -> str:
 
 
 def build_auth_token_argv(
-    workspace: str, profile: str | None = None, *, use_pat: bool = False
+    workspace: str,
+    profile: str | None = None,
+    *,
+    use_pat: bool = False,
+    oauth_client_id: str | None = None,
 ) -> list[str]:
     """Argv for the cross-platform token helper: `ucode auth-token ...`.
 
@@ -1443,11 +1510,17 @@ def build_auth_token_argv(
         argv += ["--profile", profile]
     if use_pat:
         argv.append("--use-pat")
+    if oauth_client_id:
+        argv += ["--oauth-client-id", oauth_client_id]
     return argv
 
 
 def build_mcp_proxy_argv(
-    url: str, workspace: str, profile: str | None = None, *, use_pat: bool = False
+    url: str,
+    workspace: str,
+    profile: str | None = None,
+    *,
+    use_pat: bool = False,
 ) -> list[str]:
     """Argv for the stdio MCP bridge: `ucode mcp-proxy --url ... --host ...`.
 
@@ -1468,14 +1541,20 @@ def build_mcp_proxy_argv(
 
 
 def build_auth_shell_command(
-    workspace: str, profile: str | None = None, *, use_pat: bool = False
+    workspace: str,
+    profile: str | None = None,
+    *,
+    use_pat: bool = False,
+    oauth_client_id: str | None = None,
 ) -> str:
     """Single-line, shell-quoted form of :func:`build_auth_token_argv`.
 
     Used where a tool wants the helper as one command *string* (Claude Code's
     `apiKeyHelper`). On every platform this resolves to the `ucode auth-token`
     executable rather than a POSIX shell pipeline, so no `sh`/`jq` is required."""
-    argv = build_auth_token_argv(workspace, profile, use_pat=use_pat)
+    argv = build_auth_token_argv(
+        workspace, profile, use_pat=use_pat, oauth_client_id=oauth_client_id
+    )
     if platform.system() == "Windows":
         return subprocess.list2cmdline(argv)
     return shlex.join(argv)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -994,6 +994,32 @@ class TestAuthTokenCommand:
         assert result.exit_code == 0
         fetch.assert_called_once_with("https://ws", None, force_refresh=True)
 
+    def test_oauth_client_id_is_forwarded(self):
+        with (
+            patch("ucode.cli.load_state", return_value={"workspace": "https://ws"}),
+            patch("ucode.cli.get_databricks_token", return_value="tok") as fetch,
+        ):
+            result = runner.invoke(app, ["auth-token", "--oauth-client-id", "custom-app-id"])
+        assert result.exit_code == 0
+        assert result.stdout == "tok\n"
+        fetch.assert_called_once_with(
+            "https://ws", None, force_refresh=False, oauth_client_id="custom-app-id"
+        )
+
+    def test_oauth_client_id_error_stays_off_stdout(self):
+        with (
+            patch("ucode.cli.load_state", return_value={"workspace": "https://ws"}),
+            patch(
+                "ucode.cli.get_databricks_token",
+                side_effect=RuntimeError(
+                    "Not signed in to https://ws with OAuth app custom-app-id"
+                ),
+            ),
+        ):
+            result = runner.invoke(app, ["auth-token", "--oauth-client-id", "custom-app-id"])
+        assert result.exit_code == 1
+        assert result.stdout == ""
+
     def test_errors_without_workspace(self):
         with patch("ucode.cli.load_state", return_value={}):
             result = runner.invoke(app, ["auth-token"])

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -1391,6 +1391,17 @@ class TestBuildAuthTokenArgv:
     def test_no_use_pat_flag_by_default(self):
         assert "--use-pat" not in build_auth_token_argv(WS)
 
+    def test_oauth_client_id_is_pinned_in_the_argv(self):
+        argv = build_auth_token_argv(WS, oauth_client_id="custom-app-id")
+        assert argv[argv.index("--oauth-client-id") + 1] == "custom-app-id"
+
+    def test_no_oauth_client_id_flag_by_default(self):
+        assert "--oauth-client-id" not in build_auth_token_argv(WS)
+
+    def test_oauth_client_id_passed_as_a_separate_argv_element(self):
+        argv = build_auth_token_argv(WS, oauth_client_id="weird id; rm -rf /")
+        assert "weird id; rm -rf /" in argv
+
 
 class TestBuildAuthShellCommand:
     def test_contains_workspace(self):
@@ -1422,6 +1433,167 @@ class TestBuildAuthShellCommand:
         cmd = build_auth_shell_command(WS, profile="DEFAULT", use_pat=True)
         assert "--use-pat" in cmd
         assert "--profile DEFAULT" in cmd
+
+    def test_oauth_client_id_emits_flag(self):
+        cmd = build_auth_shell_command(WS, oauth_client_id="custom-app-id")
+        assert "--oauth-client-id custom-app-id" in cmd
+
+    def test_no_oauth_client_id_flag_by_default(self):
+        assert "--oauth-client-id" not in build_auth_shell_command(WS)
+
+
+class TestResolveOauthClientId:
+    def _write_state(self, workspaces: dict, current: str | None = None) -> None:
+        import ucode.state as state_mod
+
+        state_mod.STATE_PATH.write_text(
+            json.dumps(
+                {
+                    "state_version": state_mod.STATE_VERSION,
+                    "current_workspace": current,
+                    "workspaces": workspaces,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_none_when_nothing_is_configured(self):
+        assert db_mod.resolve_oauth_client_id(WS) is None
+
+    def test_explicit_argument_wins(self):
+        self._write_state({WS: {"oauth_client_id": "from-state"}}, current=WS)
+        assert db_mod.resolve_oauth_client_id(WS, "from-flag") == "from-flag"
+
+    def test_falls_back_to_saved_workspace_state(self):
+        self._write_state({WS: {"oauth_client_id": "from-state"}}, current=WS)
+        assert db_mod.resolve_oauth_client_id(WS) == "from-state"
+
+    def test_resolved_by_host_not_by_current_workspace(self):
+        other = "https://other.databricks.com"
+        self._write_state(
+            {
+                other: {"oauth_client_id": "other-app"},
+                WS: {"oauth_client_id": "wanted-app"},
+            },
+            current=other,
+        )
+        assert db_mod.resolve_oauth_client_id(WS) == "wanted-app"
+
+    def test_trailing_slash_host_matches_the_saved_entry(self):
+        self._write_state({WS: {"oauth_client_id": "from-state"}}, current=WS)
+        assert db_mod.resolve_oauth_client_id(WS + "/") == "from-state"
+
+    def test_blank_values_are_ignored(self):
+        self._write_state({WS: {"oauth_client_id": ""}}, current=WS)
+        assert db_mod.resolve_oauth_client_id(WS, "  ") is None
+
+    def test_values_are_trimmed(self):
+        assert db_mod.resolve_oauth_client_id(WS, "  padded-app  ") == "padded-app"
+
+
+class TestGetDatabricksTokenCustomOauthApp:
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch):
+        monkeypatch.delenv("DATABRICKS_BEARER", raising=False)
+
+    def _hostile_cli(self, tmp_path, monkeypatch):
+        log = tmp_path / "cli-was-called"
+        fake = tmp_path / "databricks"
+        fake.write_text(f"#!/bin/sh\ntouch {log}\necho tokenless\n")
+        fake.chmod(0o755)
+        monkeypatch.setattr(
+            "os.environ", {**os.environ, "PATH": f"{tmp_path}:{os.environ['PATH']}"}
+        )
+        return log
+
+    def test_explicit_client_id_mints_from_the_custom_app(self, tmp_path, monkeypatch):
+        log = self._hostile_cli(tmp_path, monkeypatch)
+        calls: list[tuple] = []
+        monkeypatch.setattr(
+            "ucode.oauth.get_token",
+            lambda host, client_id, **kwargs: (
+                calls.append((host, client_id, kwargs)) or "custom-token"
+            ),
+        )
+
+        token = get_databricks_token(WS, oauth_client_id="custom-app-id")
+
+        assert token == "custom-token"
+        assert calls == [(WS, "custom-app-id", {"force_refresh": False})]
+        assert not log.exists()
+
+    def test_saved_client_id_applies_without_the_flag(self, tmp_path, monkeypatch):
+        import ucode.state as state_mod
+
+        state_mod.STATE_PATH.write_text(
+            json.dumps(
+                {
+                    "state_version": state_mod.STATE_VERSION,
+                    "current_workspace": WS,
+                    "workspaces": {WS: {"oauth_client_id": "saved-app-id"}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        log = self._hostile_cli(tmp_path, monkeypatch)
+        monkeypatch.setattr("ucode.oauth.get_token", lambda host, client_id, **_kw: client_id)
+
+        assert get_databricks_token(WS) == "saved-app-id"
+        assert not log.exists()
+
+    def test_force_refresh_is_forwarded(self, tmp_path, monkeypatch):
+        self._hostile_cli(tmp_path, monkeypatch)
+        captured: dict = {}
+        monkeypatch.setattr(
+            "ucode.oauth.get_token",
+            lambda host, client_id, **kwargs: captured.update(kwargs) or "t",
+        )
+
+        get_databricks_token(WS, oauth_client_id="custom-app-id", force_refresh=True)
+
+        assert captured == {"force_refresh": True}
+
+    def test_bearer_env_still_short_circuits_the_custom_app(self, tmp_path, monkeypatch):
+        self._hostile_cli(tmp_path, monkeypatch)
+        monkeypatch.setattr("os.environ", {**os.environ, "DATABRICKS_BEARER": "injected"})
+        monkeypatch.setattr(
+            "ucode.oauth.get_token",
+            lambda *a, **kw: pytest.fail("custom OAuth ran despite DATABRICKS_BEARER"),
+        )
+
+        assert get_databricks_token(WS, oauth_client_id="custom-app-id") == "injected"
+
+    def test_has_valid_auth_reports_true_when_the_custom_app_has_a_session(
+        self, tmp_path, monkeypatch
+    ):
+        log = self._hostile_cli(tmp_path, monkeypatch)
+        monkeypatch.setattr("ucode.oauth.get_token", lambda *a, **kw: "tok")
+
+        assert db_mod.has_valid_databricks_auth(WS, oauth_client_id="custom-app-id") is True
+        assert not log.exists()
+
+    def test_has_valid_auth_reports_false_when_not_signed_in(self, tmp_path, monkeypatch):
+        self._hostile_cli(tmp_path, monkeypatch)
+
+        def not_signed_in(*_args, **_kwargs):
+            raise RuntimeError("Not signed in")
+
+        monkeypatch.setattr("ucode.oauth.get_token", not_signed_in)
+
+        assert db_mod.has_valid_databricks_auth(WS, oauth_client_id="custom-app-id") is False
+
+    def test_login_takes_the_pkce_flow(self, tmp_path, monkeypatch):
+        log = self._hostile_cli(tmp_path, monkeypatch)
+        calls: list[tuple] = []
+        monkeypatch.setattr(
+            "ucode.oauth.login",
+            lambda host, client_id, **kwargs: calls.append((host, client_id, kwargs)),
+        )
+
+        db_mod.run_databricks_login(WS, oauth_client_id="custom-app-id")
+
+        assert calls == [(WS, "custom-app-id", {})]
+        assert not log.exists()
 
 
 class TestEnsurePatBearer:


### PR DESCRIPTION
## What this does

Adds `ug auth-token --oauth-client-id <id>`, so any token ucode mints can come from a custom OAuth app using #516's flow.

The switch lives **inside `get_databricks_token`**: if a client id resolves for the requested host, mint through `ucode.oauth` instead of shelling out to `databricks auth token`. Deciding there rather than at each call site is what makes all ~50 callers work unchanged, including the agents that mint directly and never touch the argv builders.

Resolution is **by host** — flag → `UCODE_OAUTH_CLIENT_ID` (CI) → the host's saved entry — because agents bake `--host` into their configs and routinely ask about a workspace that isn't current.

Also: `ug mcp-proxy --oauth-client-id` and both routing hooks accept it; the argv builders pin it into generated configs; `has_valid_databricks_auth` and `run_databricks_login` take the custom path, so a missing custom-app session isn't mistaken for the built-in app's live one. `DATABRICKS_BEARER` still short-circuits ahead of all of it.

`ucode configure` wiring is #518. Jira: AIGTWY-4550

## Testing

`uv run pytest` 2,322 passed (+32, same 21 pre-existing failures); `ruff check`, `ruff format --check`, `ty check src/` clean. New tests cover host-keyed resolution, flag/env/state precedence, the `get_databricks_token` branch, argv pinning, and the login/validity checks.

## 🥞 Stacked PR
- [stack/oauth-pkce-module](https://github.com/databricks/ucode/pull/516) [[Files changed](https://github.com/databricks/ucode/pull/516/files)]
  - [**stack/oauth-auth-token-flag**](https://github.com/databricks/ucode/pull/517) [[Files changed](https://github.com/databricks/ucode/pull/517/files)] ← _this PR_
    - [stack/oauth-configure-client-id](https://github.com/databricks/ucode/pull/518) [[Files changed](https://github.com/databricks/ucode/pull/518/files)]

---

This pull request and its description were written by Isaac.
