### PR TITLE
Show skill MCP scopes per agent in status

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -114,6 +114,7 @@ from ucode.mcp import (
     purge_cross_workspace_mcp_residue,
     remove_mcp_command,
     revert_mcp_configs,
+    skill_locations_for_client,
 )
 from ucode.skills_download import (
     configure_skills_download_command,
@@ -997,17 +998,32 @@ def status() -> int:
     if not skill_mcp_entry:
         print_kv("Skills", "not configured")
     else:
-        locations = skill_mcp_entry.get("skill_locations") or []
-        print_kv(
-            "Skill MCP Locations",
-            ", ".join(locations) if locations else "none — utility tools only",
-        )
-        configured_agents = [
-            str(MCP_CLIENTS[client]["display"])
-            for client in (skill_mcp_entry.get("clients") or [])
-            if client in MCP_CLIENTS
+        configured_clients = [
+            client for client in (skill_mcp_entry.get("clients") or []) if client in MCP_CLIENTS
         ]
-        print_kv("Configured", ", ".join(configured_agents) if configured_agents else "none")
+        scopes = {
+            client: skill_locations_for_client(skill_mcp_entry, client)
+            for client in configured_clients
+        }
+        # Collapse to one line when every agent shares a scope; split per agent when they diverge.
+        if len({tuple(locations) for locations in scopes.values()}) <= 1:
+            locations = next(
+                iter(scopes.values()), list(skill_mcp_entry.get("skill_locations") or [])
+            )
+            print_kv(
+                "Skill MCP Locations",
+                ", ".join(locations) if locations else "none — utility tools only",
+            )
+            configured_agents = [
+                str(MCP_CLIENTS[client]["display"]) for client in configured_clients
+            ]
+            print_kv("Configured", ", ".join(configured_agents) if configured_agents else "none")
+        else:
+            for client, locations in scopes.items():
+                print_kv(
+                    f"{MCP_CLIENTS[client]['display']} skill MCP locations",
+                    ", ".join(locations) if locations else "none — utility tools only",
+                )
 
     print_heading("Tracing")
     tracing = state.get("tracing") or {}

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -106,6 +106,7 @@ from ucode.mcp import (
     SKILLS_MCP_KIND,
     add_mcp_command,
     add_skills_command,
+    agents_share_one_scope,
     apply_managed_mcp_servers,
     available_mcp_clients,
     configure_mcp_command,
@@ -998,25 +999,18 @@ def status() -> int:
     if not skill_mcp_entry:
         print_kv("Skills", "not configured")
     else:
-        configured_clients = [
-            client for client in (skill_mcp_entry.get("clients") or []) if client in MCP_CLIENTS
-        ]
         scopes = {
             client: skill_locations_for_client(skill_mcp_entry, client)
-            for client in configured_clients
+            for client in (skill_mcp_entry.get("clients") or [])
+            if client in MCP_CLIENTS
         }
-        # Collapse to one line when every agent shares a scope; split per agent when they diverge.
-        if len({tuple(locations) for locations in scopes.values()}) <= 1:
-            locations = next(
-                iter(scopes.values()), list(skill_mcp_entry.get("skill_locations") or [])
-            )
+        if agents_share_one_scope(scopes):
+            locations = next(iter(scopes.values()), [])
             print_kv(
                 "Skill MCP Locations",
                 ", ".join(locations) if locations else "none — utility tools only",
             )
-            configured_agents = [
-                str(MCP_CLIENTS[client]["display"]) for client in configured_clients
-            ]
+            configured_agents = [str(MCP_CLIENTS[client]["display"]) for client in scopes]
             print_kv("Configured", ", ".join(configured_agents) if configured_agents else "none")
         else:
             for client, locations in scopes.items():

--- a/src/ucode/mcp.py
+++ b/src/ucode/mcp.py
@@ -2095,6 +2095,10 @@ def skill_locations_for_client(entry: dict | None, client: str) -> list[str]:
     return _skill_locations_by_client(entry).get(client, [])
 
 
+def agents_share_one_scope(scopes: dict[str, list[str]]) -> bool:
+    return len({tuple(locations) for locations in scopes.values()}) <= 1
+
+
 def _build_skills_entry(
     workspace: str,
     locations_by_client: dict[str, list[str]],
@@ -2183,8 +2187,7 @@ def _print_skills_summary(entry: dict) -> None:
         for client in (entry.get("clients") or [])
         if client in MCP_CLIENTS
     }
-    distinct_scopes = {tuple(locations) for locations in scopes.values()}
-    if len(distinct_scopes) <= 1:
+    if agents_share_one_scope(scopes):
         locations = next(iter(scopes.values()), [])
         print_kv("URL", build_skills_mcp_url(_skills_workspace(entry), locations))
         print_kv("Configured", ", ".join(clients) if clients else "none")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1751,6 +1751,32 @@ class TestStatusSkillsSection:
                 assert "databricks-skill-registry" not in line
         assert "Skill MCP Locations: main.default" in out
 
+    def test_renders_per_agent_locations_when_scopes_diverge(self):
+        state = {
+            **MINIMAL_STATE,
+            "mcp_servers": [
+                {
+                    "name": "databricks-skill-registry",
+                    "kind": "skills",
+                    "skill_locations": ["main.default", "claude.only"],
+                    "skill_locations_by_client": {
+                        "claude": ["main.default", "claude.only"],
+                        "codex": ["main.default"],
+                    },
+                    "url": "https://example.databricks.com/ai-gateway/skills/?schema=main.default&schema=claude.only",
+                    "auth": "proxy",
+                    "clients": ["claude", "codex"],
+                }
+            ],
+        }
+
+        result = self._run(state)
+
+        assert result.exit_code == 0, result.output
+        out = _strip_ansi(result.output)
+        assert "Claude Code skill MCP locations: main.default, claude.only" in out
+        assert "Codex skill MCP locations: main.default" in out
+
 
 class TestRevert:
     def test_reverts_mcp_configs_before_clearing_state(self):

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2360,6 +2360,17 @@ class TestSkillsToolsDescription:
         )
 
 
+class TestAgentsShareOneScope:
+    def test_true_when_scopes_match(self):
+        assert mcp.agents_share_one_scope({"claude": ["a.b"], "codex": ["a.b"]}) is True
+
+    def test_false_when_scopes_diverge(self):
+        assert mcp.agents_share_one_scope({"claude": ["a.b"], "codex": ["c.d"]}) is False
+
+    def test_true_with_no_configured_clients(self):
+        assert mcp.agents_share_one_scope({}) is True
+
+
 class TestPrintSkillsSummary:
     def _entry(self, locations):
         clients = ["claude", "codex"]


### PR DESCRIPTION
## What

`ug status` rendered a single `Skill MCP Locations` line from the flat scope mirror. Once agents carry different skill scopes (which per-agent add now makes possible), that single line hides the divergence. This makes `status` report each agent's real scope.

## How

- The Skills section reads each configured client's scope with `skill_locations_for_client`.
- When every agent shares the same scope, it collapses to the original single `Skill MCP Locations` + `Configured` lines.
- When scopes diverge, it prints a per-agent line (`Claude Code skill MCP locations: ...`, `Codex skill MCP locations: ...`), matching how `_print_skills_summary` already reports scopes.

## Tests

- `test_cli.py`: a state whose per-client scopes diverge renders one line per agent with that agent's own locations. The existing uniform-scope and no-locations status tests still pass unchanged.

`uv run pytest tests/test_mcp.py tests/test_cli.py tests/test_lint.py` is green.

### Manual verification (installed build)

Using the sandbox from the per-agent add PR (agents scoped to divergent locations: claude `shared.skills, claude.only`, codex `shared.skills`), ran `ucode status`. The Skills section rendered one line per agent:

```
Skills
  Claude Code skill MCP locations: shared.skills, claude.only
  Codex skill MCP locations: shared.skills
```

The new `ug skill add` / `ug skill remove --mcp` hint also appeared. The uniform-scope collapse path is covered by the existing status tests.

## Stacking

Second in the stacked per-agent skills series, based on `xshen/skill-per-agent-add` (#522). Reviewing the diff against that base shows just this change. It rebuilds behavior originally designed by Arthur Jenoudet on the current per-client-map state model.

This pull request and its description were written by Isaac.
