### PR TITLE
Scope skill remove --mcp to named agents

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -1400,15 +1400,33 @@ def skills_remove(
             help="Remove schemas from the skills MCP connection instead of downloaded files.",
         ),
     ] = False,
+    agents: Annotated[
+        str | None,
+        typer.Option(
+            "--agents",
+            help="Comma-separated coding agents to remove the schemas from (e.g. claude,codex). "
+            "A schema scoped to several agents is removed only from the named ones and kept on "
+            "the rest. Without --agents, a selected schema is removed from every agent it's on.",
+        ),
+    ] = None,
 ) -> None:
-    """Interactively remove Skill schemas from the skills MCP connection."""
+    """Interactively remove Skill schemas from the skills MCP connection.
+
+    Without ``--agents`` a selected schema is removed from every configured agent; ``--agents``
+    scopes the removal to the named agents and keeps the schema on the rest.
+    """
     try:
         if not mcp:
             raise RuntimeError(
                 "Removing downloaded skills is not supported yet. Pass --mcp to remove "
                 "schemas from the skills MCP connection."
             )
-        remove_skills_command()
+        requested_agents = (
+            None
+            if agents is None
+            else ({agent.strip().lower() for agent in agents.split(",") if agent.strip()} or None)
+        )
+        remove_skills_command(agents=requested_agents)
     except RuntimeError as exc:
         print_err(str(exc))
         raise typer.Exit(1) from None

--- a/src/ucode/mcp.py
+++ b/src/ucode/mcp.py
@@ -2365,23 +2365,26 @@ def _prompt_for_skill_removal(locations_by_client: dict[str, list[str]]) -> list
     return [str(value) for value in selection]
 
 
-def remove_skills_command() -> int:
-    """`ucode skill remove --mcp`: interactively drop skill schemas from every configured client.
+def remove_skills_command(agents: set[str] | None = None) -> int:
+    """`ucode skill remove --mcp`: interactively drop skill schemas from clients' skills scopes.
 
-    Shows the schemas currently in each configured client's skills scope and removes the ones you
-    select from every client that has them. It never adds or reconfigures anything, and needs no
-    Databricks auth."""
+    Shows the schemas in each targeted client's skills scope and removes the ones you select from
+    those clients. Without ``agents`` a selected schema is removed from every configured client;
+    with ``agents`` (from ``--agents``) removal is scoped to the named clients and kept on the rest.
+    It never adds or reconfigures anything, and needs no Databricks auth."""
     state = load_state()
     workspace, profile, clients = setup_mcp_clients(
         state,
         "Remove Skills MCP",
         require_auth=False,
         action_note="Removing from",
+        agents=agents,
     )
     locations_by_client = _skill_locations_by_client_from_state(state)
     offered = {client: locations_by_client.get(client, []) for client in clients}
     if not any(offered.values()):
-        print_note("No skill schemas are configured to remove.")
+        scope = "" if agents is None else f" for {', '.join(sorted(agents))}"
+        print_note(f"No skill schemas are configured to remove{scope}.")
         return 0
 
     selection = _prompt_for_skill_removal(offered)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1612,7 +1612,14 @@ class TestSkillsRemoveCommand:
             result = runner.invoke(app, ["skill", "remove", "--mcp"])
 
         assert result.exit_code == 0, result.output
-        remove.assert_called_once_with()
+        remove.assert_called_once_with(agents=None)
+
+    def test_mcp_remove_forwards_agent_scope(self):
+        with patch("ucode.cli.remove_skills_command") as remove:
+            result = runner.invoke(app, ["skill", "remove", "--mcp", "--agents", "claude, codex"])
+
+        assert result.exit_code == 0, result.output
+        remove.assert_called_once_with(agents={"claude", "codex"})
 
 
 class TestManagedSkillsOnLaunch:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2393,6 +2393,44 @@ class TestRemoveSkillsCommand:
         assert mcp.remove_skills_command() == 0
         assert captured["scopes"] == {"claude": ["A.a", "B.b"], "codex": ["A.a"]}
 
+    def test_agent_scope_removes_from_only_named_client(self, monkeypatch):
+        # The headline fix: add-all then remove --agents claude drops the schema for claude only.
+        state = self._state()
+        configured = self._stub(monkeypatch, state, ["A.a"])
+
+        assert mcp.remove_skills_command(agents={"claude"}) == 0
+
+        entry = _find_skills(state["mcp_servers"])[0]
+        assert mcp.skill_locations_for_client(entry, "claude") == ["B.b"]
+        assert mcp.skill_locations_for_client(entry, "codex") == ["A.a", "B.b"]
+        assert configured == [("claude", f"{WS}/ai-gateway/skills/?schema=B.b")]
+
+    def test_agent_scope_offers_only_named_clients_scope(self, monkeypatch):
+        state = self._state({"claude": ["A.a", "B.b"], "codex": ["A.a"]})
+        captured: dict[str, dict[str, list[str]]] = {}
+        _stub_location_base(monkeypatch, state)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude", "codex"])
+        monkeypatch.setattr(
+            mcp,
+            "_prompt_for_skill_removal",
+            lambda scopes: captured.setdefault("scopes", scopes) and None,
+        )
+
+        assert mcp.remove_skills_command(agents={"claude"}) == 0
+        assert captured["scopes"] == {"claude": ["A.a", "B.b"]}
+
+    def test_agent_scope_with_empty_scope_is_a_noop(self, monkeypatch):
+        state = self._state({"claude": ["A.a"], "codex": []})
+        captured: dict[str, bool] = {}
+        _stub_location_base(monkeypatch, state)
+        monkeypatch.setattr(mcp, "available_mcp_clients", lambda: ["claude", "codex"])
+        monkeypatch.setattr(
+            mcp, "_prompt_for_skill_removal", lambda scopes: captured.setdefault("called", True)
+        )
+
+        assert mcp.remove_skills_command(agents={"codex"}) == 0
+        assert "called" not in captured
+
 
 class TestRegisterSchemalessSkillsConnection:
     def _stub(self, monkeypatch):


### PR DESCRIPTION
## What

Adds an `--agents` option to `ucode skill remove --mcp` so a schema can be removed from a chosen subset of configured agents and kept on the rest, mirroring `ucode mcp remove --agents`. This is the core bug fix in the series.

## The bug

Before per-agent scopes, an all-agent add wrote a shared layer while a per-agent remove edited a separate one, so they did not compose: `skill add --mcp X` (all) followed by `skill remove --mcp --agents claude` was a silent no-op, and often printed a misleading "nothing to remove". Now that developer scope is a single per-agent map, the two operations act on the same layer.

## How

- `remove_skills_command(agents=None)` forwards `agents` to `setup_mcp_clients`, which scopes the client set. The picker offers only those clients' schemas and removal edits only their maps; other agents keep the schema and are not re-registered.
- The "nothing to remove" note names the scope when `--agents` was given.
- `cli.py`: `skill remove` gains the `--agents` option; without it, removal stays global.

## Tests

- `test_mcp.py`: add-all then `remove --agents claude` removes the schema for claude only and re-registers only claude; the picker is offered only the named clients' scope; an empty named scope is a no-op.
- `test_cli.py`: `--mcp` forwards `agents=None`; `--mcp --agents claude,codex` forwards the parsed set.

`uv run pytest tests/test_mcp.py tests/test_cli.py tests/test_lint.py` is green.

### Manual verification (installed build)

This is the headline fix, so I verified the exact previously-failing sequence end to end. In the sandbox (installed build `0.1.0+91.g5c0dc1e`, stub `claude`/`codex` binaries recording registrations, offline auth via `DATABRICKS_BEARER`), `shared.skills` had been added to both agents. Then I invoked `remove_skills_command(agents={"claude"})` with the picker stubbed to select `shared.skills`:

| Check | Result |
|---|---|
| Picker input | Offered only the named client's scope: `{claude:[shared.skills, claude.only]}` |
| State after | `shared.skills` removed from claude only: `{claude:[claude.only], codex:[shared.skills]}` |
| Registrations | Only claude re-registered; codex untouched |

Before this change the same sequence was a silent no-op (add wrote a shared layer, per-agent remove edited a different one). It now removes for the named agent while the other keeps the schema.

## Stacking

Fourth in the stacked per-agent skills series, based on `xshen/skill-remove` (#524). Reviewing the diff against that base shows just this change. It rebuilds behavior originally designed by Arthur Jenoudet on the current per-client-map state model.

This pull request and its description were written by Isaac.
