### PR TITLE
Deprecate configure skills

### DIFF
--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -2976,7 +2976,7 @@ def configure_mcp(
         raise typer.Exit(130) from None
 
 
-@configure_app.command("skills")
+@configure_app.command("skills", deprecated=True)
 def configure_skills(
     location: Annotated[
         str | None,
@@ -3017,6 +3017,16 @@ def configure_skills(
     """
     try:
         locations = _parse_skill_locations(location)
+        if locations:
+            print_warning(
+                "`ucode configure skills` is deprecated. Use `ucode skill add` to download "
+                "skills or add MCP scopes, and `ucode skill remove --mcp` to remove MCP scopes."
+            )
+        else:
+            print_warning(
+                "`ucode configure skills` is deprecated, but its bare utility-tools-only setup "
+                "has no replacement yet and remains supported."
+            )
         # `--skill` absent -> None (whole schema); present (even empty) -> the
         # explicit subset, so `--skill ""` downloads nothing.
         selected_skills = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1549,6 +1549,26 @@ class TestSkillsRemoveCommand:
         remove.assert_called_once_with(agents={"claude", "codex"})
 
 
+class TestConfigureSkillsDeprecation:
+    def test_warns_and_keeps_legacy_dispatch(self):
+        with patch("ucode.cli.configure_skills_mcp_command") as configure:
+            result = runner.invoke(app, ["configure", "skills", "--location", "a.b", "--mcp"])
+
+        assert result.exit_code == 0, result.output
+        assert "deprecated" in _strip_ansi(result.output).lower()
+        configure.assert_called_once_with(["a.b"])
+
+    def test_bare_command_explains_that_utility_setup_remains_supported(self):
+        with patch("ucode.cli.configure_skills_mcp_command") as configure:
+            result = runner.invoke(app, ["configure", "skills"])
+
+        output = _strip_ansi(result.output).lower()
+        assert result.exit_code == 0, result.output
+        assert "utility-tools-only setup" in output
+        assert "remains supported" in output
+        configure.assert_called_once_with([])
+
+
 class TestManagedSkillsOnLaunch:
     """Managed skills are delivered by download only: the launch path downloads them and never
     registers them on the skills MCP connection (only a developer's own `skill add --mcp` schemas


### PR DESCRIPTION
## What

Marks `ucode configure skills` deprecated now that `ucode skill add` / `ucode skill remove --mcp` cover its behavior with per-agent scoping. The command keeps working; only the guidance changes.

## How

- The command is registered with `deprecated=True` so its help is flagged.
- With a `--location`, it prints a note pointing at `ucode skill add` (download or add MCP scopes) and `ucode skill remove --mcp` (remove MCP scopes).
- With no `--location`, it registers the utility-tools-only connection (which has no replacement yet), so its note says that bare setup remains supported.
- Dispatch is unchanged, so existing invocations keep functioning.

## Tests

- `test_cli.py`: `configure skills --location a.b --mcp` warns "deprecated" and still dispatches `configure_skills_mcp_command(["a.b"])`; the bare form explains the utility-tools-only setup remains supported and still dispatches `configure_skills_mcp_command([])`.

`uv run pytest tests/test_mcp.py tests/test_cli.py tests/test_lint.py` is green.

### Manual verification (installed build)

Confirmed with the installed build (`0.1.0+91.g5c0dc1e`) that `configure skills` is flagged deprecated and still works.

| Check | Result |
|---|---|
| `ucode configure skills --help` | Header shows `(deprecated)` |
| `ucode configure skills --location dep.test --mcp` | Prints "`ucode configure skills` is deprecated. Use `ucode skill add` ..." then registers the scope (both agents set to `dep.test`) |

The bare no-location form's "utility-tools-only setup remains supported" message is covered by the unit test in this PR.

## Stacking

Fifth and last in the stacked per-agent skills series, based on `xshen/skill-per-agent-remove` (#525). Reviewing the diff against that base shows just this change. It rebuilds behavior originally designed by Arthur Jenoudet on the current per-client-map state model.

This pull request and its description were written by Isaac.
