### PR TITLE
[AIGTWY-4474] Remove AI Gateway v2 endpoint liveness fallback probe

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -3079,37 +3079,6 @@ class GatewayProbe(NamedTuple):
     conclusive: bool = True
 
 
-def _version_neutral_gateway_detail(detail: str) -> str:
-    detail = re.sub(r"\bv3\b", "model service", detail, flags=re.IGNORECASE)
-    return re.sub(r"\bv2\b", "legacy endpoint", detail, flags=re.IGNORECASE)
-
-
-def _gateway_probe_result(
-    payload: dict | list | None,
-    reason: str | None,
-    collection_key: str,
-    resource_name: str,
-) -> GatewayProbe:
-    if payload is None:
-        return GatewayProbe(False, _version_neutral_gateway_detail(reason or "unknown error"))
-    resources = payload.get(collection_key) if isinstance(payload, dict) else None
-    if resources:
-        return GatewayProbe(True, f"reachable, accessible {resource_name} returned", True)
-    return GatewayProbe(True, f"reachable, no accessible {resource_name}s returned")
-
-
-def _probe_ai_gateway_v2(workspace: str, token: str) -> GatewayProbe:
-    hostname = workspace_hostname(workspace)
-    url = f"https://{hostname}/api/ai-gateway/v2/endpoints?page_size=1"
-    payload, reason = _http_get_json(url, token)
-    return _gateway_probe_result(
-        payload=payload,
-        reason=reason,
-        collection_key="endpoints",
-        resource_name="endpoint",
-    )
-
-
 _MODEL_SERVICE_PROBE_PAGE_SIZE = 50
 _MODEL_SERVICE_PROBE_MAX_PAGES = 20
 _MODEL_SERVICE_EMPTY_DETAIL = (
@@ -3118,7 +3087,7 @@ _MODEL_SERVICE_EMPTY_DETAIL = (
 )
 
 
-def _probe_ai_gateway_v3(workspace: str, token: str) -> GatewayProbe:
+def _probe_model_services(workspace: str, token: str) -> GatewayProbe:
     hostname = workspace_hostname(workspace)
     base = f"https://{hostname}/api/2.1/unity-catalog/model-services"
     page_token: str | None = None
@@ -3129,9 +3098,7 @@ def _probe_ai_gateway_v3(workspace: str, token: str) -> GatewayProbe:
         payload, reason = _http_get_json(f"{base}?{urlencode(params)}", token)
         if payload is None:
             if page == 0:
-                return GatewayProbe(
-                    False, _version_neutral_gateway_detail(reason or "unknown error")
-                )
+                return GatewayProbe(False, reason or "unknown error")
             return GatewayProbe(True, "reachable", conclusive=False)
         if isinstance(payload, dict) and payload.get("model_services"):
             return GatewayProbe(True, "reachable, accessible model service returned", True)
@@ -3159,71 +3126,41 @@ def _raise_ai_gateway_scope_failure(workspace: str, reason: str) -> NoReturn:
     )
 
 
-def _raise_model_service_permission_failure(
-    workspace: str, model_service_reason: str, legacy_endpoint_reason: str
-) -> NoReturn:
+def _raise_model_service_permission_failure(workspace: str, model_service_reason: str) -> NoReturn:
     raise RuntimeError(
         "Databricks Unity AI Gateway model service access could not be verified on "
-        f"{workspace} ({model_service_reason}). The legacy endpoint fallback also failed "
-        f"({legacy_endpoint_reason}). The model service probe requires permission to list "
-        "Unity Catalog model services. Verify USE CATALOG on `system`, and USE SCHEMA and "
-        "EXECUTE on `system.ai`."
-    )
-
-
-def _raise_legacy_endpoint_permission_failure(
-    workspace: str, legacy_endpoint_reason: str, model_service_reason: str
-) -> NoReturn:
-    raise RuntimeError(
-        "Databricks Unity AI Gateway legacy endpoint access could not be verified on "
-        f"{workspace} ({legacy_endpoint_reason}). The model service probe also failed "
-        f"({model_service_reason}). Verify the caller's workspace permissions for the legacy "
-        "endpoints listing."
+        f"{workspace} ({model_service_reason}). Listing Unity Catalog model services requires "
+        "USE CATALOG on `system`, and USE SCHEMA and EXECUTE on `system.ai`."
     )
 
 
 def probe_unity_gateway_capabilities(workspace: str, token: str) -> GatewayProbe:
-    """Return the model service probe after verifying an available gateway path."""
-    model_service_probe = _probe_ai_gateway_v3(workspace, token)
-    if not model_service_probe.reachable and _looks_like_definitive_auth_failure(
-        model_service_probe.detail
-    ):
-        _raise_ai_gateway_auth_failure(workspace, model_service_probe.detail)
-    if model_service_probe.resource_available:
+    """Return the model service probe, raising if model service access can't be verified."""
+    model_service_probe = _probe_model_services(workspace, token)
+    if model_service_probe.reachable:
+        # resource_available, reachable-but-empty, and inconclusive are all non-fatal: the
+        # caller surfaces the detail as a warning when no accessible model service came back.
         return model_service_probe
 
-    legacy_endpoint_probe = _probe_ai_gateway_v2(workspace, token)
-    if legacy_endpoint_probe.reachable:
-        return model_service_probe
-    if model_service_probe.reachable and not model_service_probe.conclusive:
-        return model_service_probe
-    if _looks_like_definitive_auth_failure(legacy_endpoint_probe.detail):
-        _raise_ai_gateway_auth_failure(workspace, legacy_endpoint_probe.detail)
-    if _looks_like_scope_failure(model_service_probe.detail):
-        _raise_ai_gateway_scope_failure(workspace, model_service_probe.detail)
-    if _looks_like_scope_failure(legacy_endpoint_probe.detail):
-        _raise_ai_gateway_scope_failure(workspace, legacy_endpoint_probe.detail)
-    if _looks_like_permission_failure(model_service_probe.detail):
-        _raise_model_service_permission_failure(
-            workspace, model_service_probe.detail, legacy_endpoint_probe.detail
-        )
-    if _looks_like_permission_failure(legacy_endpoint_probe.detail):
-        _raise_legacy_endpoint_permission_failure(
-            workspace, legacy_endpoint_probe.detail, model_service_probe.detail
-        )
+    reason = model_service_probe.detail
+    if _looks_like_definitive_auth_failure(reason):
+        _raise_ai_gateway_auth_failure(workspace, reason)
+    if _looks_like_scope_failure(reason):
+        _raise_ai_gateway_scope_failure(workspace, reason)
+    if _looks_like_permission_failure(reason):
+        _raise_model_service_permission_failure(workspace, reason)
 
     raise RuntimeError(
-        "Databricks Unity AI Gateway is not enabled on this workspace: neither model services "
-        f"({model_service_probe.detail}) nor legacy endpoints ({legacy_endpoint_probe.detail}) "
-        f"are available. See {AI_GATEWAY_DOCS_URL}"
+        "Databricks Unity AI Gateway is not enabled on this workspace: model services "
+        f"({reason}) are not available. See {AI_GATEWAY_DOCS_URL}"
     )
 
 
 def _looks_like_definitive_auth_failure(reason: str) -> bool:
-    """True when retrying another workspace API cannot rescue this token.
+    """True when the token itself is rejected (401, or an invalid-token 400).
 
-    A 403 can be endpoint-specific authorization, so the preflight must still
-    try the fallback before surfacing it as an auth failure.
+    A 403 is left to the scope and permission routing, since it can mean a
+    missing OAuth scope or missing Unity Catalog grants rather than a bad token.
     """
     if "HTTP 401" in reason:
         return True
@@ -3235,9 +3172,7 @@ def _looks_like_scope_failure(reason: str) -> bool:
 
     Matched to the OAuth-token wording so a PAT's permission 403 -- which
     re-login cannot fix -- is not misrouted to the re-login hint and instead
-    falls through to the grant guidance. The scopes the model-service and
-    legacy-endpoint APIs require differ, so this is only conclusive once both
-    probes have failed on it.
+    falls through to the grant guidance.
     """
     lowered = reason.lower()
     return "http 403" in lowered and "oauth token" in lowered and "required scopes" in lowered

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2689,21 +2689,18 @@ class TestConfigureSharedStateUsePat:
         ("responses", "expected_model_service"),
         [
             (
-                [({}, None), ({"endpoints": []}, None)],
+                [({}, None)],
                 "reachable, no accessible model services returned; check USE CATALOG on system, "
                 "and USE SCHEMA and EXECUTE on system.ai",
             ),
             (
-                [
-                    (None, "HTTP 403 Forbidden"),
-                    ({"endpoints": [{"name": "databricks-gpt-5"}]}, None),
-                ],
-                "HTTP 403 Forbidden",
+                [({"next_page_token": "more"}, None)] * db_mod._MODEL_SERVICE_PROBE_MAX_PAGES,
+                "reachable",
             ),
         ],
         ids=[
-            "model-service-empty-legacy-empty",
-            "model-service-forbidden-legacy-resource",
+            "model-service-empty",
+            "model-service-inconclusive",
         ],
     )
     def test_prints_warning_when_model_service_not_detected(
@@ -2733,28 +2730,18 @@ class TestConfigureSharedStateUsePat:
         ("responses", "error_match"),
         [
             (
-                [
-                    ({}, None),
-                    (
-                        None,
-                        "HTTP 404 Not Found: AI Gateway V2 is not available for CSP-enabled "
-                        "workspaces",
-                    ),
-                ],
-                "no accessible model services",
+                [(None, "HTTP 404 Not Found: model service unavailable")],
+                "not enabled",
             ),
             (
-                [
-                    (None, "HTTP 404 Not Found: V3 unavailable"),
-                    (None, "HTTP 404 Not Found: V2 unavailable"),
-                ],
-                "neither model services",
+                [(None, "HTTP 403 Forbidden: Missing Unity Catalog grants")],
+                "model service access could not be verified",
             ),
             ([(None, "HTTP 401 Unauthorized")], "rejected the access token"),
         ],
         ids=[
-            "model-service-empty-legacy-unavailable",
-            "neither-path-reachable",
+            "model-service-unavailable",
+            "model-service-forbidden",
             "invalid-token",
         ],
     )

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -1953,7 +1953,7 @@ class TestListDatabricksApps:
 
 
 class TestProbeUnityGatewayCapabilities:
-    def test_model_service_resource_skips_legacy_probe(self, monkeypatch):
+    def test_model_service_resource_returns_success(self, monkeypatch):
         calls: list[str] = []
 
         def fake_get(url, token):
@@ -2008,8 +2008,6 @@ class TestProbeUnityGatewayCapabilities:
 
         def fake_get(url, token):
             calls.append(url)
-            if "/api/ai-gateway/v2/endpoints" in url:
-                return {"endpoints": []}, None
             return next(responses)
 
         monkeypatch.setattr(db_mod, "_http_get_json", fake_get)
@@ -2025,7 +2023,6 @@ class TestProbeUnityGatewayCapabilities:
             f"https://{WS_HOST}/api/2.1/unity-catalog/model-services?page_size=50",
             f"https://{WS_HOST}/api/2.1/unity-catalog/model-services?page_size=50"
             "&page_token=cursor-1",
-            f"https://{WS_HOST}/api/ai-gateway/v2/endpoints?page_size=1",
         ]
 
     def test_empty_model_service_response_includes_permission_hint(self, monkeypatch):
@@ -2043,88 +2040,27 @@ class TestProbeUnityGatewayCapabilities:
             "USE SCHEMA and EXECUTE on system.ai",
         )
 
-    def test_legacy_only_workspace_returns_model_service_probe(self, monkeypatch):
+    def test_model_service_unavailable_raises(self, monkeypatch):
         calls: list[str] = []
 
         def fake_get(url, token):
             calls.append(url)
-            if "/api/2.1/unity-catalog/model-services" in url:
-                return None, "HTTP 404: Not Found"
-            return {"endpoints": []}, None
+            return None, "HTTP 404: model services unavailable"
 
         monkeypatch.setattr(db_mod, "_http_get_json", fake_get)
 
-        model_service_probe = db_mod.probe_unity_gateway_capabilities(WS, "fake-token")
-
-        assert model_service_probe == db_mod.GatewayProbe(False, "HTTP 404: Not Found")
-        assert calls == [
-            f"https://{WS_HOST}/api/2.1/unity-catalog/model-services?page_size=50",
-            f"https://{WS_HOST}/api/ai-gateway/v2/endpoints?page_size=1",
-        ]
-
-    def test_model_service_forbidden_still_succeeds_when_legacy_is_available(self, monkeypatch):
-        calls: list[str] = []
-
-        def fake_get(url, token):
-            calls.append(url)
-            if "/api/2.1/unity-catalog/model-services" in url:
-                return None, "HTTP 403: Forbidden"
-            return {"endpoints": []}, None
-
-        monkeypatch.setattr(db_mod, "_http_get_json", fake_get)
-
-        model_service_probe = db_mod.probe_unity_gateway_capabilities(WS, "fake-token")
-
-        assert model_service_probe == db_mod.GatewayProbe(False, "HTTP 403: Forbidden")
-        assert calls == [
-            f"https://{WS_HOST}/api/2.1/unity-catalog/model-services?page_size=50",
-            f"https://{WS_HOST}/api/ai-gateway/v2/endpoints?page_size=1",
-        ]
-
-    def test_empty_model_service_requires_reachable_legacy_fallback(self, monkeypatch):
-        responses = iter(
-            [
-                ({}, None),
-                (None, "HTTP 404: AI Gateway V2 is not available for CSP-enabled workspaces"),
-            ]
-        )
-        monkeypatch.setattr(
-            db_mod,
-            "_http_get_json",
-            lambda url, token: next(responses),
-        )
-
-        with pytest.raises(RuntimeError, match="no accessible model services") as excinfo:
+        with pytest.raises(RuntimeError, match="not enabled") as excinfo:
             db_mod.probe_unity_gateway_capabilities(WS, "fake-token")
 
         message = str(excinfo.value)
-        assert "HTTP 404: AI Gateway legacy endpoint is not available" in message
+        assert "HTTP 404: model services unavailable" in message
+        # surfaced errors must stay free of internal version vocabulary
         assert "v2" not in message.lower()
         assert "v3" not in message.lower()
+        assert "legacy" not in message.lower()
+        assert calls == [f"https://{WS_HOST}/api/2.1/unity-catalog/model-services?page_size=50"]
 
-    def test_neither_gateway_available_raises(self, monkeypatch):
-        reasons = iter(
-            [
-                "HTTP 404: V3 unavailable",
-                "HTTP 404: V2 unavailable",
-            ]
-        )
-        monkeypatch.setattr(
-            db_mod,
-            "_http_get_json",
-            lambda url, token: (None, next(reasons)),
-        )
-
-        with pytest.raises(RuntimeError, match="neither model services") as excinfo:
-            db_mod.probe_unity_gateway_capabilities(WS, "fake-token")
-
-        message = str(excinfo.value)
-        assert "HTTP 404: model service unavailable" in message
-        assert "HTTP 404: legacy endpoint unavailable" in message
-        assert "v2" not in message.lower()
-        assert "v3" not in message.lower()
-
-    def test_model_service_auth_failure_does_not_probe_legacy(self, monkeypatch):
+    def test_model_service_auth_failure_raises(self, monkeypatch):
         calls: list[str] = []
 
         def fake_get(url, token):
@@ -2138,7 +2074,7 @@ class TestProbeUnityGatewayCapabilities:
 
         assert calls == [f"https://{WS_HOST}/api/2.1/unity-catalog/model-services?page_size=50"]
 
-    def test_missing_scope_403_on_both_paths_routes_to_reauth_not_grants(self, monkeypatch):
+    def test_missing_scope_403_routes_to_reauth_not_grants(self, monkeypatch):
         calls: list[str] = []
 
         def fake_get(url, token):
@@ -2157,35 +2093,9 @@ class TestProbeUnityGatewayCapabilities:
         assert "databricks auth login" in message
         assert "USE CATALOG" not in message
         assert "USE SCHEMA" not in message
-        assert calls == [
-            f"https://{WS_HOST}/api/2.1/unity-catalog/model-services?page_size=50",
-            f"https://{WS_HOST}/api/ai-gateway/v2/endpoints?page_size=1",
-        ]
+        assert calls == [f"https://{WS_HOST}/api/2.1/unity-catalog/model-services?page_size=50"]
 
-    def test_model_service_scope_403_succeeds_when_legacy_reachable(self, monkeypatch):
-        calls: list[str] = []
-
-        def fake_get(url, token):
-            calls.append(url)
-            if "/api/ai-gateway/v2/endpoints" in url:
-                return {"endpoints": [{"name": "databricks-gpt-5"}]}, None
-            return None, (
-                "HTTP 403 Forbidden: Provided OAuth token does not have required "
-                "scopes: unity-catalog"
-            )
-
-        monkeypatch.setattr(db_mod, "_http_get_json", fake_get)
-
-        model_service_probe = db_mod.probe_unity_gateway_capabilities(WS, "fake-token")
-
-        assert not model_service_probe.reachable
-        assert "required scopes" in model_service_probe.detail
-        assert calls == [
-            f"https://{WS_HOST}/api/2.1/unity-catalog/model-services?page_size=50",
-            f"https://{WS_HOST}/api/ai-gateway/v2/endpoints?page_size=1",
-        ]
-
-    def test_probe_v3_later_page_error_is_reachable_not_empty(self, monkeypatch):
+    def test_probe_model_services_later_page_error_is_reachable_not_empty(self, monkeypatch):
         responses = iter(
             [
                 ({"next_page_token": "cursor-1"}, None),
@@ -2194,11 +2104,13 @@ class TestProbeUnityGatewayCapabilities:
         )
         monkeypatch.setattr(db_mod, "_http_get_json", lambda url, token: next(responses))
 
-        assert db_mod._probe_ai_gateway_v3(WS, "fake-token") == db_mod.GatewayProbe(
+        assert db_mod._probe_model_services(WS, "fake-token") == db_mod.GatewayProbe(
             True, "reachable", conclusive=False
         )
 
-    def test_probe_v3_page_cap_with_pending_cursor_is_reachable_not_empty(self, monkeypatch):
+    def test_probe_model_services_page_cap_with_pending_cursor_is_reachable_not_empty(
+        self, monkeypatch
+    ):
         calls: list[str] = []
 
         def fake_get(url, token):
@@ -2207,27 +2119,20 @@ class TestProbeUnityGatewayCapabilities:
 
         monkeypatch.setattr(db_mod, "_http_get_json", fake_get)
 
-        assert db_mod._probe_ai_gateway_v3(WS, "fake-token") == db_mod.GatewayProbe(
+        assert db_mod._probe_model_services(WS, "fake-token") == db_mod.GatewayProbe(
             True, "reachable", conclusive=False
         )
         assert len(calls) == db_mod._MODEL_SERVICE_PROBE_MAX_PAGES
 
-    def test_inconclusive_model_service_probe_does_not_hard_fail_when_legacy_unavailable(
-        self, monkeypatch
-    ):
-        v3_responses = iter(
+    def test_inconclusive_model_service_probe_returns_reachable(self, monkeypatch):
+        responses = iter(
             [
                 ({"next_page_token": "cursor-1"}, None),
                 (None, "HTTP 500: Internal Server Error"),
             ]
         )
 
-        def fake_get(url, token):
-            if "/api/ai-gateway/v2/endpoints" in url:
-                return None, "HTTP 404: AI Gateway V2 is not available for CSP-enabled workspaces"
-            return next(v3_responses)
-
-        monkeypatch.setattr(db_mod, "_http_get_json", fake_get)
+        monkeypatch.setattr(db_mod, "_http_get_json", lambda url, token: next(responses))
 
         assert db_mod.probe_unity_gateway_capabilities(WS, "fake-token") == db_mod.GatewayProbe(
             True, "reachable", conclusive=False
@@ -2242,55 +2147,27 @@ class TestProbeUnityGatewayCapabilities:
         )
         assert not db_mod._looks_like_scope_failure("HTTP 403: Missing Unity Catalog grants")
 
-    def test_model_service_forbidden_and_legacy_unavailable_reports_permission_error(
-        self, monkeypatch
-    ):
-        reasons = iter(
-            [
-                "HTTP 403: Missing Unity Catalog grants",
-                "HTTP 404: legacy endpoints unavailable",
-            ]
-        )
-        monkeypatch.setattr(
-            db_mod,
-            "_http_get_json",
-            lambda url, token: (None, next(reasons)),
-        )
+    def test_model_service_forbidden_reports_permission_error(self, monkeypatch):
+        calls: list[str] = []
 
-        with pytest.raises(RuntimeError, match="permission") as excinfo:
+        def fake_get(url, token):
+            calls.append(url)
+            return None, "HTTP 403: Missing Unity Catalog grants"
+
+        monkeypatch.setattr(db_mod, "_http_get_json", fake_get)
+
+        with pytest.raises(RuntimeError, match="model service access could not be verified") as e:
             db_mod.probe_unity_gateway_capabilities(WS, "fake-token")
 
-        message = str(excinfo.value)
+        message = str(e.value)
         assert "USE SCHEMA" in message
         assert "EXECUTE" in message
         assert "v2" not in message.lower()
         assert "v3" not in message.lower()
+        assert "legacy" not in message.lower()
         assert "rejected the access token" not in message
         assert "not enabled" not in message
-
-    def test_legacy_forbidden_and_model_service_unavailable_reports_permission_error(
-        self, monkeypatch
-    ):
-        reasons = iter(
-            [
-                "HTTP 404: V3 unavailable",
-                "HTTP 403: V2 forbidden",
-            ]
-        )
-        monkeypatch.setattr(
-            db_mod,
-            "_http_get_json",
-            lambda url, token: (None, next(reasons)),
-        )
-
-        with pytest.raises(RuntimeError, match="workspace permissions") as excinfo:
-            db_mod.probe_unity_gateway_capabilities(WS, "fake-token")
-
-        message = str(excinfo.value)
-        assert "legacy endpoint access could not be verified" in message
-        assert "v2" not in message.lower()
-        assert "v3" not in message.lower()
-        assert "USE SCHEMA" not in message
+        assert calls == [f"https://{WS_HOST}/api/2.1/unity-catalog/model-services?page_size=50"]
 
 
 class TestHttpGetJsonReason:


### PR DESCRIPTION
## What

Remove the obsolete AI Gateway v2 endpoint-list liveness fallback probe (`GET /api/ai-gateway/v2/endpoints?page_size=1`) from the connectivity preflight. The preflight now relies solely on the Unity Catalog model-services probe (`GET /api/2.1/unity-catalog/model-services`).

## Why

The v2 endpoint-list fallback returned 403 for consumer-only users without workspace access, and it duplicated the model-services probe that already establishes gateway reachability. Ticket: AIGTWY-4474.

## Behavior

- First launch, configure, and setup no longer call the AI Gateway endpoint-list API.
- A reachable model-services probe, including empty or inconclusive results, is non-fatal; the caller surfaces the detail as a warning.
- An unreachable probe routes the single reason to the right error: token rejected (401), missing OAuth scope, missing Unity Catalog grants, or gateway not enabled.
- Consumer-only users with UC grants pass the probe; bad credentials still error.

## Also

Dropped the v2/v3 vocabulary from the probe path: the helper is now `_probe_model_services`, and surfaced errors are no longer version-neutralized (there is a single endpoint).

## Testing

`uv run pytest tests/test_databricks.py tests/test_cli.py` (probe and configure suites green). Reviewed with a Codex pass and a simplify pass.

The other `/api/ai-gateway/v2/*` endpoints (budgets, coding-agent-configs, external-provider-models, recommendModel) are intentionally left in place; they back live features and are out of scope for this ticket.

This pull request and its description were written by Isaac.
