### PR TITLE
Use task_v2 as the default smart router

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ ug claude --enable-smart-routing
 ```
 
 The flag applies only to that launch; later launches use normal model selection unless the flag is
-passed again. Smart routing uses the `task_v1` router by default. Power users can select another
+passed again. Smart routing uses the `task_v2` router by default. Power users can select another
 router for a launch by setting `SMART_ROUTER_NAME`, for example
-`SMART_ROUTER_NAME=task_v2 ug codex --enable-smart-routing`.
+`SMART_ROUTER_NAME=task_v1 ug codex --enable-smart-routing`.
 
 To configure all tools at once:
 

--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1829,7 +1829,7 @@ def discover_model_services(
     # Smart routing's CLAUDE_ROUTE_ARMS require claude-opus-4-8, but the
     # newest-wins sort above picks opus-5 when both exist — making the
     # routing availability check fail. Pin opus-4-8 when it's available so
-    # routing works with the currently-deployed task_v1 router. Revert to
+    # routing works with the current task_v2 router. Revert to
     # newest-wins once the router accepts opus-5 (PR databricks-eng/universe#2365446).
     _prefer_opus_4_8(claude_models, ids)
 

--- a/src/ucode/smart_routing/claude_routing.py
+++ b/src/ucode/smart_routing/claude_routing.py
@@ -1,7 +1,7 @@
 """Databricks AI Gateway routing helpers for Claude Code sessions and subagents.
 
 Claude-specific configuration on top of the shared
-:mod:`ucode.smart_routing.routing` core. The ``task_v1`` router infers a
+:mod:`ucode.smart_routing.routing` core. The ``task_v2`` router infers a
 "Claude Code" (``cc``) scenario when it is offered only Claude arms, and that
 scenario REQUIRES its full menu — both ``claude-opus-4-8`` and
 ``claude-sonnet-5`` — or it returns BAD_REQUEST. So both arms are always offered.
@@ -21,7 +21,7 @@ from ucode.smart_routing.routing import RoutingDecision
 
 ROUTER_NAME = routing.ROUTER_NAME
 REQUEST_TIMEOUT_S = routing.REQUEST_TIMEOUT_S
-# Frozen task_v1 "cc" scenario menu (ai-gateway CanonicalModelNames): the router
+# Frozen task_v2 "cc" scenario menu (ai-gateway CanonicalModelNames): the router
 # rejects the request unless BOTH are offered as route_options.
 CLAUDE_ROUTE_ARMS = ("claude-opus-4-8", "claude-sonnet-5")
 # Claude Code's subagent-spawn tool (renamed Task -> Agent); match both.

--- a/src/ucode/smart_routing/routing.py
+++ b/src/ucode/smart_routing/routing.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-ROUTER_NAME = "task_v1"
+ROUTER_NAME = "task_v2"
 ROUTER_NAME_ENV_VAR = "SMART_ROUTER_NAME"
 ROUTING_PATH = "/ai-gateway/routing/v1/routes:select"
 REQUEST_TIMEOUT_S = 30.0
@@ -100,7 +100,7 @@ def normalize_model(model: str) -> str:
 
 
 def configured_router_name() -> str:
-    """Return the environment-selected router, falling back to ``task_v1``."""
+    """Return the environment-selected router, falling back to ``task_v2``."""
     return os.environ.get(ROUTER_NAME_ENV_VAR, "").strip() or ROUTER_NAME
 
 

--- a/tests/test_claude_routing.py
+++ b/tests/test_claude_routing.py
@@ -24,7 +24,7 @@ class _Response:
         return json.dumps(self.payload).encode("utf-8")
 
 
-def test_routes_with_task_v1_claude_menu(monkeypatch):
+def test_routes_with_default_claude_menu(monkeypatch):
     monkeypatch.delenv("SMART_ROUTER_NAME", raising=False)
     captured = {}
 
@@ -66,7 +66,7 @@ def test_routes_with_task_v1_claude_menu(monkeypatch):
             {"model": "claude-sonnet-5", "harness": "claude"},
         ],
         "task": {"prompt": "Refactor the parser"},
-        "route_selector": {"router_name": "task_v1"},
+        "route_selector": {"router_name": claude_routing.ROUTER_NAME},
     }
 
 

--- a/tests/test_codex_routing.py
+++ b/tests/test_codex_routing.py
@@ -78,13 +78,13 @@ def test_routes_with_models_from_stored_state(monkeypatch):
             {"model": "gpt-5-6-sol", "harness": "codex"},
         ],
         "task": {"prompt": task},
-        "route_selector": {"router_name": "task_v1"},
+        "route_selector": {"router_name": codex_routing.routing.ROUTER_NAME},
     }
 
 
-def test_router_name_can_be_selected_with_environment_variable(monkeypatch):
+def test_router_name_can_be_overridden_with_environment_variable(monkeypatch):
     captured = {}
-    monkeypatch.setenv("SMART_ROUTER_NAME", "  task_v2  ")
+    monkeypatch.setenv("SMART_ROUTER_NAME", "  custom_router  ")
 
     def fake_urlopen(request, timeout):
         captured["body"] = json.loads(request.data)
@@ -98,13 +98,13 @@ def test_router_name_can_be_selected_with_environment_variable(monkeypatch):
 
     assert error is None
     assert decision is not None
-    assert captured["body"]["route_selector"] == {"router_name": "task_v2"}
+    assert captured["body"]["route_selector"] == {"router_name": "custom_router"}
 
 
 def test_blank_router_name_environment_variable_uses_default(monkeypatch):
     monkeypatch.setenv("SMART_ROUTER_NAME", "  ")
 
-    assert codex_routing.routing.configured_router_name() == "task_v1"
+    assert codex_routing.routing.configured_router_name() == codex_routing.routing.ROUTER_NAME
 
 
 def test_router_model_is_not_substituted_when_exact_model_is_unavailable():

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -600,7 +600,7 @@ def test_routing_request_uses_models_prompt_and_same_token(monkeypatch):
         "workspace": WS,
         "token": "same-oauth-token",
         "task": "Fix the parser",
-        "router_name": "task_v1",
+        "router_name": codex_routing.routing.ROUTER_NAME,
         "timeout": codex_routing.REQUEST_TIMEOUT_S,
         "route_options": [
             ("kimi-k3-neo", "codex"),
@@ -620,6 +620,6 @@ def test_routing_request_uses_models_prompt_and_same_token(monkeypatch):
             {"model": "glm-5-2", "harness": "codex"},
         ],
         "task": {"prompt": "Fix the parser"},
-        "route_selector": {"router_name": "task_v1"},
+        "route_selector": {"router_name": codex_routing.routing.ROUTER_NAME},
     }
     assert "same-oauth-token" not in logged[0]


### PR DESCRIPTION
## Summary
- Change the smart-routing default router from `task_v1` to `task_v2`.
- Update related comments, README documentation, and test expectations.
- Preserve `SMART_ROUTER_NAME` as an override for selecting another router.

## Test plan
- `UV_CACHE_DIR=/tmp/ucode-uv-cache uv run pytest tests/test_codex_routing.py tests/test_claude_routing.py tests/test_codex_smart_routing_v2.py`