### PR TITLE
[AIGTWY-4467] Drop spec_version from coding-agent-config update mask

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1936,15 +1936,11 @@ def fetch_external_model_prices(workspace: str, token: str) -> tuple[list[dict],
     return models, None
 
 
-# Every field ucode's manifest can set, as `update_mask` paths for a PATCH. The server rejects a
-# missing or empty mask, and rejects paths outside its own mutable set — this is that set minus the
-# fields ucode doesn't author: `budget_id` (deprecated in favour of `budget_policy.budget_id`, and
-# rejected on write) and `default_options`/`tiers` (the legacy model-only shape superseded by
-# `enabled_agents`/`budget_policy`). Sending every path ucode owns, rather than only the ones
-# currently populated, is what lets a re-run *clear* a field the admin removed: the server merges
-# per path, so an omitted path leaves the old value in place.
+# The `update_mask` paths a config PATCH sends. The server rejects paths outside its mutable set,
+# so this omits `spec_version` (an estore-internal format marker, still sent in the body; naming it
+# in the mask is the 400 this fixes) and the deprecated `budget_id`/`default_options`/`tiers`.
+# Sending all owned paths lets a re-run clear an admin-removed field, since the server merges per path.
 MANAGED_CONFIG_UPDATE_MASK_PATHS: tuple[str, ...] = (
-    "spec_version",
     "display_name",
     "default_agent",
     "enabled_agents",

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -3031,6 +3031,7 @@ class TestCodingAgentConfigCrudClients:
         assert "budget_id" not in db_mod.MANAGED_CONFIG_UPDATE_MASK_PATHS
         assert "default_options" not in db_mod.MANAGED_CONFIG_UPDATE_MASK_PATHS
         assert "tiers" not in db_mod.MANAGED_CONFIG_UPDATE_MASK_PATHS
+        assert "spec_version" not in db_mod.MANAGED_CONFIG_UPDATE_MASK_PATHS
 
     def test_update_mask_covers_every_field_the_manifest_can_set(self):
         # A path ucode omits is a field a re-run silently cannot clear, since the server merges per
@@ -3056,7 +3057,7 @@ class TestCodingAgentConfigCrudClients:
                 }
             )
         )
-        assert set(db_mod.MANAGED_CONFIG_UPDATE_MASK_PATHS) == emitted | {"spec_version"}
+        assert set(db_mod.MANAGED_CONFIG_UPDATE_MASK_PATHS) == emitted
 
     def test_delete_returns_only_a_reason(self, monkeypatch):
         seen = {}


### PR DESCRIPTION
Publishing over an existing workspace coding-agent config returned HTTP 400 INVALID_PARAMETER_VALUE (update_mask contains unsupported path spec_version). The server's Update RPC only accepts its fixed mutable-mask set, and spec_version is an estore-internal format marker rather than a mutable API field.

- Remove spec_version from MANAGED_CONFIG_UPDATE_MASK_PATHS (the default update_mask); it stays in the request body, which the server ignores off the mask.
- Add a regression assertion that the mask never names spec_version.
- Tighten the mask-coverage test to assert the mask equals exactly the fields the serializer emits.