### PR TITLE
Keep relayed launch out of Claude Code gateway login mode

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -156,7 +156,12 @@ CLAUDE_DEFAULT_MODEL_ENV_KEYS = {
 }
 # Launch-scoped feature flags that ucode may write into Claude settings. These
 # must be removed again when the corresponding launch flag is absent.
-CLAUDE_CONDITIONAL_ENV_KEYS = ("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY",)
+CLAUDE_CONDITIONAL_ENV_KEYS = (
+    "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY",
+    # Written only for credentialed (non-relayed) launches; pruned on a relayed launch so
+    # gateway login mode can't shadow the subscription OAuth (see render_overlay).
+    "CLAUDE_CODE_USE_GATEWAY",
+)
 # Env keys ucode used to write but no longer does; stripped from the managed
 # settings file on every launch so stale values never linger.
 CLAUDE_REMOVED_ENV_KEYS = ("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS",)
@@ -368,8 +373,17 @@ def render_overlay(
         # not set CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS (see CLAUDE_REMOVED_ENV_KEYS).
         "ENABLE_PROMPT_CACHING_1H": "1",
         "ENABLE_TOOL_SEARCH": "true",
-        "CLAUDE_CODE_USE_GATEWAY": "1",
     }
+    # Gateway login mode — only for credentialed (non-relayed) paths, where an
+    # apiKeyHelper supplies the gateway credential this mode expects. Relayed has no
+    # such credential: it relies on Claude Code's own subscription OAuth as the
+    # Authorization credential. Claude Code 2.1.261+ makes gateway login mode ignore a
+    # subscription login and demand a gateway `/login`, which the relayed loopback proxy
+    # can't satisfy — so relayed sessions loop on login. Requests still route through the
+    # gateway via ANTHROPIC_BASE_URL without this flag. In CLAUDE_CONDITIONAL_ENV_KEYS so
+    # a value a prior non-relayed launch wrote is pruned when a relayed launch omits it.
+    if not relayed:
+        env["CLAUDE_CODE_USE_GATEWAY"] = "1"
     # Intentionally NOT setting ANTHROPIC_MODEL by default. Setting it produces a
     # duplicate catalog row in Claude Code's /model picker (e.g. "Opus 4.8 (1M
     # context) ✓") on top of the family-alias row from ANTHROPIC_DEFAULT_OPUS_MODEL.

--- a/tests/test_agent_claude.py
+++ b/tests/test_agent_claude.py
@@ -263,6 +263,19 @@ class TestRenderOverlay:
         assert "Databricks-Model-Provider-Service: c.s.mps" in headers
         assert "X-Databricks-AI-Gateway-Token" not in headers
 
+    def test_relayed_omits_use_gateway(self):
+        # Gateway login mode (Claude Code 2.1.261+) ignores the subscription OAuth relayed
+        # depends on and loops on /login, so relayed must not enter it. Non-relayed still does.
+        overlay, keys = claude.render_overlay(
+            WS,
+            None,
+            provider="c.s.mps",
+            relayed=True,
+            relayed_base_url="http://127.0.0.1:9",
+        )
+        assert "CLAUDE_CODE_USE_GATEWAY" not in overlay["env"]
+        assert ["env", "CLAUDE_CODE_USE_GATEWAY"] not in keys
+
     def test_model_overrides_when_all_provided(self):
         models = {
             "sonnet": "databricks-claude-sonnet-4-6",
@@ -642,6 +655,16 @@ class TestWriteToolConfigStripsRemovedEnvKeys:
         claude.write_tool_config(state, "databricks-claude-sonnet-4")
 
         assert "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY" not in written[0]["env"]
+
+    def test_relayed_prunes_stale_use_gateway(self, monkeypatch):
+        # A prior non-relayed launch may have written CLAUDE_CODE_USE_GATEWAY; a relayed
+        # launch must drop it so gateway login mode can't shadow the subscription OAuth.
+        existing = {"env": {"CLAUDE_CODE_USE_GATEWAY": "1"}}
+        written: list = []
+        self._patch(monkeypatch, existing, written)
+        state = {"workspace": WS, "codex_models": [], "relayed_proxy_port": 9999}
+        claude.write_tool_config(state, None, provider="c.s.mps", relayed=True)
+        assert "CLAUDE_CODE_USE_GATEWAY" not in written[0]["env"]
 
 
 FAKE_MANAGED_PATH = Path("/tmp/ucode-test/managed-settings.json")


### PR DESCRIPTION
## Problem

Users on Claude Max/Enterprise using ucode **relayed** MPS report that after Claude Code auto-updated to **2.1.265**, the session loops on `/login`: OAuth completes on Anthropic's side but the session still insists it needs to log in. A session on the previous version keeps working. (Reported in the AIGW coding-agents thread.)

## Root cause

Claude Code **2.1.261+** changed **gateway login mode** to ignore a claude.ai *subscription* login and demand a gateway `/login`. ucode's relayed launch is the only config that mixes:
- gateway mode (`CLAUDE_CODE_USE_GATEWAY=1`, set unconditionally in `render_overlay`), **and**
- **no** gateway credential — relayed deliberately writes no `apiKeyHelper`/API key and relies on Claude Code's own subscription OAuth as the `Authorization`, while the loopback proxy swaps the Databricks token in by header.

So gateway login mode now rejects the very credential relayed depends on → the loop. The api-key MPS and normal gateway paths are unaffected because they carry an `apiKeyHelper`, which matches "only Enterprise/relayed broke."

## Fix

Set `CLAUDE_CODE_USE_GATEWAY` **only for credentialed (non-relayed) launches**, and add it to `CLAUDE_CONDITIONAL_ENV_KEYS` so a value a prior non-relayed launch wrote is pruned when a relayed launch omits it. Requests still route through the gateway via `ANTHROPIC_BASE_URL` without the flag — per Claude Code's LLM-gateway docs, a custom base URL *alone* (no gateway credential) keeps the subscription login active.

## Testing

- `test_relayed_omits_use_gateway` (overlay omits the flag + it's not in the managed keys), `test_relayed_prunes_stale_use_gateway` (a relayed write drops a stale value). Existing non-relayed assertions unchanged. Full `test_agent_claude.py` 133/133; ruff clean.
- **Not yet validated against a live relayed session on 2.1.265** — needs a subscription box, and `CLAUDE_CODE_USE_GATEWAY` is undocumented so the exact lever is inferred from the changelog + behavior. Validate before rollout.

This pull request and its description were written by Isaac.