### PR TITLE
fix typer._click module does not exist 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "mcp>=1.28.0",
   "questionary>=2.0.0",
   "tomlkit>=0.13.0",
-  "typer>=0.12.0",
+  "typer>=0.12.0,<0.26",
   # enable changing codex model after first prompt
   "websockets>=13",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "mcp>=1.28.0",
   "questionary>=2.0.0",
   "tomlkit>=0.13.0",
-  "typer>=0.12.0,<0.26",
+  "typer>=0.26.0",
   # enable changing codex model after first prompt
   "websockets>=13",
 ]

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -9,11 +9,10 @@ import subprocess
 from collections.abc import Iterator
 from contextlib import contextmanager
 from importlib import metadata
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 from rich.panel import Panel
-from typer._click import Context as ClickContext
 from typer.core import TyperCommand
 
 from ucode.agents import (
@@ -2174,7 +2173,7 @@ _PROMPT_SUFFIX_KEY = "ucode_explicit_prompt_suffix"
 class _PromptAwareCommand(TyperCommand):
     """Record an agent's ``--`` prompt separator before Click removes it."""
 
-    def parse_args(self, ctx: ClickContext, args: list[str]) -> list[str]:
+    def parse_args(self, ctx: Any, args: list[str]) -> list[str]:
         try:
             separator = args.index("--")
         except ValueError:

--- a/uv.lock
+++ b/uv.lock
@@ -3298,17 +3298,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.25.1"
+version = "0.27.2"
 source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://pypi-proxy.cloud.databricks.com/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+sdist = { url = "https://pypi-proxy.cloud.databricks.com/packages/16/f7/57713ba479fd405eb76de31404b2c744c289e336b2d999511ebf51e496f7/typer-0.27.2.tar.gz", hash = "sha256:269b7eb9d3c202ca84b4bc9618cb04ebb43d3d4d1e567e4c768607232c05f945", size = 204045, upload-time = "2026-08-28T10:26:55.046Z" }
 wheels = [
-    { url = "https://pypi-proxy.cloud.databricks.com/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
+    { url = "https://pypi-proxy.cloud.databricks.com/packages/dc/bf/205d0004930ede8f542fb58f601526fccf4ae7626075ca1e6c4de5d3d652/typer-0.27.2-py3-none-any.whl", hash = "sha256:b3a5fc4342d5fc8fda8fc3010b1cf117e9249aab7fae800c2eff62fd3842d97d", size = 123130, upload-time = "2026-08-28T10:26:53.752Z" },
 ]
 
 [[package]]
@@ -3387,7 +3387,7 @@ requires-dist = [
     { name = "mlflow", extras = ["databricks"], marker = "extra == 'tracing'", specifier = ">=3.4" },
     { name = "questionary", specifier = ">=2.0.0" },
     { name = "tomlkit", specifier = ">=0.13.0" },
-    { name = "typer", specifier = ">=0.12.0,<0.26" },
+    { name = "typer", specifier = ">=0.26.0" },
     { name = "websockets", specifier = ">=13" },
 ]
 provides-extras = ["tracing"]

--- a/uv.lock
+++ b/uv.lock
@@ -3298,17 +3298,17 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.27.2"
+version = "0.25.1"
 source = { registry = "https://pypi-proxy.cloud.databricks.com/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "click" },
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://pypi-proxy.cloud.databricks.com/packages/16/f7/57713ba479fd405eb76de31404b2c744c289e336b2d999511ebf51e496f7/typer-0.27.2.tar.gz", hash = "sha256:269b7eb9d3c202ca84b4bc9618cb04ebb43d3d4d1e567e4c768607232c05f945", size = 204045, upload-time = "2026-08-28T10:26:55.046Z" }
+sdist = { url = "https://pypi-proxy.cloud.databricks.com/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
 wheels = [
-    { url = "https://pypi-proxy.cloud.databricks.com/packages/dc/bf/205d0004930ede8f542fb58f601526fccf4ae7626075ca1e6c4de5d3d652/typer-0.27.2-py3-none-any.whl", hash = "sha256:b3a5fc4342d5fc8fda8fc3010b1cf117e9249aab7fae800c2eff62fd3842d97d", size = 123130, upload-time = "2026-08-28T10:26:53.752Z" },
+    { url = "https://pypi-proxy.cloud.databricks.com/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
 ]
 
 [[package]]
@@ -3387,7 +3387,7 @@ requires-dist = [
     { name = "mlflow", extras = ["databricks"], marker = "extra == 'tracing'", specifier = ">=3.4" },
     { name = "questionary", specifier = ">=2.0.0" },
     { name = "tomlkit", specifier = ">=0.13.0" },
-    { name = "typer", specifier = ">=0.12.0" },
+    { name = "typer", specifier = ">=0.12.0,<0.26" },
     { name = "websockets", specifier = ">=13" },
 ]
 provides-extras = ["tracing"]


### PR DESCRIPTION
problem: typer added the _click module in 0.26.0. if <0.25 is cached, then _click will fail. 

the fix is: 
- remove the use of the _click module (wasn't needed...)
- pin typer to >=0.26 so that this doesnt recur in the future 

repro to confirm that 0.26 is the right version: 
```
$ uv run --with "typer==0.25.1" python -c \
  'import typer; print(typer.__version__); from typer._click import Context as ClickContext; print(ClickContext)'
warning: `VIRTUAL_ENV=.venv` does not match the project environment path `/home/lilly.luo/ucode/.venv` and will be ignored; use `--active` to target the active environment instead
Installed 8 packages in 8ms
0.25.1
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'typer._click'
``` 

``` 
$ uv run --with "typer==0.26.0" python -c \
  'import typer; print(typer.__version__); from typer._click import Context as ClickContext; print(ClickContext)'
warning: `VIRTUAL_ENV=.venv` does not match the project environment path `/home/lilly.luo/ucode/.venv` and will be ignored; use `--active` to target the active environment instead
Installed 7 packages in 9ms
0.26.0
<class 'typer._click.core.Context'>
``` 