### PR TITLE
Document per-agent skill add/remove in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,21 +247,42 @@ you to run `ug <agent>` (existing agent sessions need a restart before the MCP t
 
 #### Add skill scopes without replacing existing ones
 
-`ucode skill add` registers skills additively, keeping anything already configured. With `--mcp` it
+`ug skill add` registers skills additively, keeping anything already configured. With `--mcp` it
 adds the schemas to the connection's scope, otherwise it downloads their skills to disk. `--skills`
 narrows a download to a subset of one schema's skills.
 
 ```bash
 # Add schemas to the skills MCP scope, keeping any already configured.
-ucode skill add --location main.default,ml.prod --mcp
+ug skill add --location main.default,ml.prod --mcp
+
+# Scope the schemas to specific agents. Any not set up yet are configured first.
+ug skill add --location main.default --mcp --agents claude,codex
 
 # Download a schema's skills to disk, keeping existing downloads.
-ucode skill add --location main.default
+ug skill add --location main.default
 
 # Download a named subset, by bare name (with --location) or fully-qualified name.
-ucode skill add --location main.default --skills my-skill,other-skill
-ucode skill add --skills main.default.my-skill,main.default.other-skill
+ug skill add --location main.default --skills my-skill,other-skill
+ug skill add --skills main.default.my-skill,main.default.other-skill
 ```
+
+With `--mcp`, `--agents` limits the change to the named agents; without it the schemas go to every
+configured agent. It applies only to `--mcp`, since downloaded skills are shared across agents.
+
+#### Remove skill scopes
+
+Remove schemas from the skills MCP connection with `ug skill remove --mcp`:
+
+```bash
+# Pick schemas to remove; each is removed from every agent it's on.
+ug skill remove --mcp
+
+# Remove from specific agents only. A schema scoped to several agents is
+# removed from the named ones and kept on the rest.
+ug skill remove --mcp --agents claude
+```
+
+`--mcp` is required; removing downloaded skills from disk isn't supported yet.
 
 ### Managed config for a workspace (admins)
 
@@ -370,7 +391,7 @@ The output looks like:
 
 | Command | Description |
 |---------|-------------|
-| `ug status` | Show current workspace, base URLs, managed config files, and selected models |
+| `ug status` | Show current workspace, base URLs, managed config files, selected models, and each agent's skill MCP scope |
 | `ug export` | Print the workspace's managed config as portable JSON (`--file <file>` / `-f` to write a file) |
 | `ug doctor` | Diagnose local issues (uv, npm, Databricks CLI, workspace, credentials, agent CLIs, tracing) and offer to fix any problems found |
 | `ug usage` | Show your AI Gateway dollars spent and total budget |
@@ -397,8 +418,11 @@ The output looks like:
 | `ug configure skills --location main.default --skill my-skill` | Download only the named skill(s) from a schema (comma-separated for several) |
 | `ug configure skills --location main.default --mcp` | Expose a schema's skills as MCP tools (override-only) instead of downloading |
 | `ug skill add --location main.default --mcp` | Add schemas to the skills MCP scope, keeping any already configured (additive; never replaces) |
+| `ug skill add --location main.default --mcp --agents claude,codex` | Add schemas to specific agents' skills MCP scope (sets up any not yet configured) |
 | `ug skill add --location main.default` | Download a schema's skills to disk without removing existing downloads |
 | `ug skill add --skills main.default.my-skill` | Download a named subset of skills (bare names need `--location`; fully-qualified names stand alone) |
+| `ug skill remove --mcp` | Remove skill schemas from the skills MCP connection (every agent) |
+| `ug skill remove --mcp --agents claude` | Remove skill schemas from specific agents only, keeping them on the rest |
 | `ug setup` | Author the managed config's agents and models (workspace admins only) |
 | `ug setup mcps` | Add or change the managed config's MCP servers |
 | `ug setup skills [--location a.b,c.d]` | Add or change the managed config's skills |


### PR DESCRIPTION
## What

Documents the per-agent skills behavior this stack introduced but the README did not yet cover:

- `--agents` scoping on `ug skill add --mcp` (add schemas to specific agents; any not set up yet are configured first).
- `ug skill remove --mcp`, with `--agents` to scope removal to named agents.
- Each agent's skill MCP scope now shown by `ug status`.

## How

- Added a "Remove skill scopes" subsection, plus an `--agents` example and note in "Add skill scopes".
- Added quick-reference rows for the per-agent `skill add` and both `skill remove` forms.
- Updated the `ug status` row to mention per-agent skill MCP scope.
- Aligned the existing `skill add` examples from `ucode` to `ug` for consistency with the rest of the README.

Docs only; no code changes.

## Stacking

Stacked on `xshen/skill-per-agent-remove` (#525), the top of the per-agent skills series. It documents the user-facing surface added across #520, #522, #523, #524, and #525.

This pull request and its description were written by Isaac.