### PR TITLE
don't set model discovery env var when modelPicker is defined for smart routing

### DIFF
--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -393,10 +393,17 @@ def launch_claude(
         )
     token = get_databricks_token(workspace, state.get("profile"))
     os.environ[OAUTH_TOKEN_ENV_VAR] = token
-    os.environ[GATEWAY_MODEL_DISCOVERY_ENV_VAR] = "1"
-    os.environ["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
-    # modelPicker takes priority over model discovery.
-    catalog = _model_picker_catalog() or list_anthropic_model_catalog(workspace, token)
+    # modelPicker takes priority over model discovery. When an administrator has pinned
+    # models via modelPicker (in the OS-managed settings or anywhere in Claude's settings
+    # hierarchy), the router already has its models and there is nothing to discover, so
+    # gateway model discovery is left disabled rather than enabled alongside the picker.
+    picker_catalog = _model_picker_catalog()
+    if picker_catalog is None:
+        os.environ[GATEWAY_MODEL_DISCOVERY_ENV_VAR] = "1"
+        os.environ["CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY"] = "1"
+        catalog = list_anthropic_model_catalog(workspace, token)
+    else:
+        catalog = picker_catalog
     if not catalog.model_ids:
         raise RuntimeError(
             catalog.error_msg or "Anthropic models endpoint returned no Claude models"

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -393,10 +393,7 @@ def launch_claude(
         )
     token = get_databricks_token(workspace, state.get("profile"))
     os.environ[OAUTH_TOKEN_ENV_VAR] = token
-    # modelPicker takes priority over model discovery. When an administrator has pinned
-    # models via modelPicker (in the OS-managed settings or anywhere in Claude's settings
-    # hierarchy), the router already has its models and there is nothing to discover, so
-    # gateway model discovery is left disabled rather than enabled alongside the picker.
+    # if modelPicker is defined, then skip model discovery.
     picker_catalog = _model_picker_catalog()
     if picker_catalog is None:
         os.environ[GATEWAY_MODEL_DISCOVERY_ENV_VAR] = "1"

--- a/tests/test_claude_smart_routing_v2.py
+++ b/tests/test_claude_smart_routing_v2.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import threading
 import time
@@ -348,6 +349,69 @@ class TestV2Launch:
             "model": v2.CLAUDE_TARGET_MODEL,
             "theme": "dark",
         }
+
+
+class TestV2ModelPickerDiscovery:
+    """modelPicker takes priority over gateway model discovery for smart routing."""
+
+    @staticmethod
+    def _launch(monkeypatch, tmp_path, *, picker_catalog):
+        user_settings = tmp_path / "settings.json"
+        user_settings.write_text(json.dumps({"model": "opus"}))
+        monkeypatch.setattr(v2, "APP_DIR", tmp_path)
+        monkeypatch.setattr(v2, "CLAUDE_PTY_LOG", tmp_path / "v2.log")
+        monkeypatch.setattr(v2, "get_databricks_token", lambda *_args, **_kwargs: "token")
+        monkeypatch.setattr(v2, "build_auth_token_argv", lambda *_args, **_kwargs: ["ucode"])
+        monkeypatch.setattr(v2, "_model_picker_catalog", lambda: picker_catalog)
+
+        discovery_calls = 0
+
+        def fake_discovery(*_args):
+            nonlocal discovery_calls
+            discovery_calls += 1
+            return AnthropicModelCatalog(
+                model_ids=["system.ai.claude-opus-4-8"], model_id_to_display_name={}
+            )
+
+        monkeypatch.setattr(v2, "list_anthropic_model_catalog", fake_discovery)
+        monkeypatch.setattr(claude_pty, "run_claude_pty", lambda _argv, **_kwargs: 0)
+
+        with pytest.raises(SystemExit) as exc:
+            v2.launch_claude(
+                {"workspace": "https://example.com"},
+                [],
+                binary="claude",
+                user_settings_path=user_settings,
+                launch_model="opus",
+                compose_settings=lambda _args: ({}, []),
+                launch_model_args=claude._launch_model_args,
+                model_name=claude._maybe_add_1m_suffix,
+            )
+        assert exc.value.code == 0
+        return discovery_calls
+
+    def test_model_picker_disables_model_discovery(self, tmp_path, monkeypatch):
+        discovery_calls = self._launch(
+            monkeypatch,
+            tmp_path,
+            picker_catalog=AnthropicModelCatalog(
+                model_ids=["system.ai.claude-opus-4-8", "system.ai.claude-sonnet-5"],
+                model_id_to_display_name={},
+            ),
+        )
+        # The picker supplied the models, so discovery never ran and the launch left
+        # gateway model discovery disabled instead of enabling it alongside the picker.
+        assert discovery_calls == 0
+        assert "CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY" not in os.environ
+        assert "ENABLE_CLAUDE_CODE_GATEWAY_MODEL_DISCOVERY" not in os.environ
+
+    def test_no_model_picker_enables_model_discovery(self, tmp_path, monkeypatch):
+        discovery_calls = self._launch(monkeypatch, tmp_path, picker_catalog=None)
+        # Without a picker the router falls back to gateway discovery and enables Claude
+        # Code's model-discovery feature for the launch.
+        assert discovery_calls == 1
+        assert os.environ.get("CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY") == "1"
+        assert os.environ.get("ENABLE_CLAUDE_CODE_GATEWAY_MODEL_DISCOVERY") == "1"
 
 
 class TestSubagentRouting:


### PR DESCRIPTION
## Problem

if modelPicker is defined in cc settings, then skip the anthropic/v1/models call by setting model_discovery env var to 0. this way we don't overload the list api. 


## Validation

- Added `TestV2ModelPickerDiscovery` with two cases: a `modelPicker` catalog leaves both discovery env vars unset and never calls `list_anthropic_model_catalog`; no picker enables discovery and queries the catalog (1 call). Both pass.
- `ruff check` clean on both files.

manual:

add models in modelPicker in managed config then `uv run ug claude --enable-smart-routing`

smart routing worked + i see the models in my picker. i also confirmed no anthropic/v1/models calls were made. i also tested without models in modelPicker to confirm no regression to auto discovery + smart routing  

<img width="1128" height="170" alt="Screenshot 2026-09-10 at 10 58 39 PM" src="https://github.com/user-attachments/assets/fd11553f-7e06-4ce1-ac85-14b02a177e32" />


<img width="699" height="262" alt="Screenshot 2026-09-10 at 10 58 23 PM" src="https://github.com/user-attachments/assets/ecb75896-0641-4765-bf4c-f5af144fbc92" />

