### PR TITLE
skill/mcp remove: normalize --agents aliases like the add paths

### DIFF
--- a/src/ucode/agents/__init__.py
+++ b/src/ucode/agents/__init__.py
@@ -110,6 +110,24 @@ def normalize_tool(tool: str) -> str:
     return normalized
 
 
+def normalize_agent(agent: str) -> str:
+    """Canonical name for an ``--agents`` entry. Same alias resolution as
+    ``normalize_tool`` (``claude-code`` -> ``claude``, ``gemini-cli`` -> ``gemini``),
+    plus the MCP-only ``cursor`` agent, which has no model routing and so is not a
+    ``normalize_tool`` value."""
+    if agent.strip().lower() == "cursor":
+        return "cursor"
+    return normalize_tool(agent)
+
+
+def normalize_agents(spec: str | None) -> set[str] | None:
+    """Parse a comma-separated ``--agents`` value into canonical agent names, or
+    ``None`` when unset or empty."""
+    if spec is None:
+        return None
+    return {normalize_agent(a) for a in spec.split(",") if a.strip()} or None
+
+
 def _update_installed_tool_binary(tool: str, version: str | None = None) -> bool:
     spec = TOOL_SPECS[tool]
     binary = spec["binary"]

--- a/src/ucode/cli.py
+++ b/src/ucode/cli.py
@@ -28,6 +28,8 @@ from ucode.agents import (
     explicit_model_arg_value,
     install_databricks_ai_tools_for_agents,
     install_tool_binary,
+    normalize_agent,
+    normalize_agents,
     normalize_tool,
     provider_permission_error,
     resolve_gemini_provider_model,
@@ -1133,7 +1135,7 @@ def _configure_agents_for_mcp(
     Cursor is MCP-only, so it just needs workspace state established and rides
     along via MCP_ONLY_CLIENTS. Interactive — prompts for the workspace URL on
     first run."""
-    scope = {a if a == "cursor" else normalize_tool(a) for a in requested}
+    scope = {normalize_agent(a) for a in requested}
     ready = set(configured_mcp_clients(load_state(), available_mcp_clients()))
     to_bootstrap = scope - ready
     model_agents = sorted(a for a in to_bootstrap if a != "cursor")
@@ -1201,11 +1203,7 @@ def mcp_add(
     (and, if needed, set up) specific agents.
     """
     selected = None if services is None else {s.strip() for s in services.split(",") if s.strip()}
-    requested_agents = (
-        None
-        if agents is None
-        else ({a.strip().lower() for a in agents.split(",") if a.strip()} or None)
-    )
+    requested_agents = normalize_agents(agents)
     try:
         scope = _configure_agents_for_mcp(sorted(requested_agents)) if requested_agents else None
         add_mcp_command(location=location, services=selected, agents=scope)
@@ -1235,11 +1233,7 @@ def mcp_remove(
     Interactive: shows the servers you currently have configured and unregisters the
     ones you select. Needs no Databricks login.
     """
-    requested_agents = (
-        None
-        if agents is None
-        else ({a.strip().lower() for a in agents.split(",") if a.strip()} or None)
-    )
+    requested_agents = normalize_agents(agents)
     try:
         remove_mcp_command(agents=requested_agents)
     except RuntimeError as exc:
@@ -1315,11 +1309,7 @@ def skills_add(
         requested_skills = (
             None if skills is None else {s.strip() for s in skills.split(",") if s.strip()}
         )
-        requested_agents = (
-            None
-            if agents is None
-            else ({agent.strip().lower() for agent in agents.split(",") if agent.strip()} or None)
-        )
+        requested_agents = normalize_agents(agents)
         if mcp and path is not None:
             raise RuntimeError("--path is not supported when using --mcp")
         if mcp and requested_skills is not None:
@@ -1421,11 +1411,7 @@ def skills_remove(
                 "Removing downloaded skills is not supported yet. Pass --mcp to remove "
                 "schemas from the skills MCP connection."
             )
-        requested_agents = (
-            None
-            if agents is None
-            else ({agent.strip().lower() for agent in agents.split(",") if agent.strip()} or None)
-        )
+        requested_agents = normalize_agents(agents)
         remove_skills_command(agents=requested_agents)
     except RuntimeError as exc:
         print_err(str(exc))

--- a/tests/test_agents_init.py
+++ b/tests/test_agents_init.py
@@ -19,6 +19,8 @@ from ucode.agents import (
     explicit_model_arg_value,
     install_databricks_ai_tools_for_agents,
     install_tool_binary,
+    normalize_agent,
+    normalize_agents,
     normalize_tool,
     provider_permission_error,
     resolve_launch_model,
@@ -202,6 +204,32 @@ class TestNormalizeTool:
     def test_unknown_raises(self):
         with pytest.raises(RuntimeError, match="Unsupported"):
             normalize_tool("unknown-agent")
+
+
+class TestNormalizeAgent:
+    def test_resolves_aliases_like_normalize_tool(self):
+        assert normalize_agent("claude-code") == "claude"
+        assert normalize_agent("  Gemini-CLI ") == "gemini"
+
+    def test_accepts_cursor(self):
+        assert normalize_agent("cursor") == "cursor"
+        assert normalize_agent(" CURSOR ") == "cursor"
+
+    def test_unknown_raises(self):
+        with pytest.raises(RuntimeError, match="Unsupported"):
+            normalize_agent("unknown-agent")
+
+
+class TestNormalizeAgents:
+    def test_none_passthrough(self):
+        assert normalize_agents(None) is None
+
+    def test_empty_becomes_none(self):
+        assert normalize_agents(" , ") is None
+
+    def test_parses_dedupes_and_normalizes(self):
+        assert normalize_agents("claude-code, codex , claude") == {"claude", "codex"}
+        assert normalize_agents("cursor,claude-code") == {"cursor", "claude"}
 
 
 class TestCheckGatewayEndpoint:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1063,6 +1063,20 @@ class TestMcpSubcommands:
         assert result.exit_code == 0
         assert "web-search" in result.output
 
+    def test_mcp_remove_forwards_agent_scope(self):
+        with patch("ucode.cli.remove_mcp_command") as remove:
+            result = runner.invoke(app, ["mcp", "remove", "--agents", "claude, codex"])
+
+        assert result.exit_code == 0, result.output
+        remove.assert_called_once_with(agents={"claude", "codex"})
+
+    def test_mcp_remove_normalizes_agent_aliases(self):
+        with patch("ucode.cli.remove_mcp_command") as remove:
+            result = runner.invoke(app, ["mcp", "remove", "--agents", "claude-code, gemini-cli"])
+
+        assert result.exit_code == 0, result.output
+        remove.assert_called_once_with(agents={"claude", "gemini"})
+
 
 class TestAuthTokenCommand:
     """`ucode auth-token` is the cross-platform apiKeyHelper (#116)."""
@@ -1620,6 +1634,17 @@ class TestSkillsRemoveCommand:
 
         assert result.exit_code == 0, result.output
         remove.assert_called_once_with(agents={"claude", "codex"})
+
+    def test_mcp_remove_normalizes_agent_aliases(self):
+        # `skill add` resolves aliases like `claude-code`; removal must too, or a
+        # user who added with an alias can't remove with the same name.
+        with patch("ucode.cli.remove_skills_command") as remove:
+            result = runner.invoke(
+                app, ["skill", "remove", "--mcp", "--agents", "claude-code, gemini-cli"]
+            )
+
+        assert result.exit_code == 0, result.output
+        remove.assert_called_once_with(agents={"claude", "gemini"})
 
 
 class TestManagedSkillsOnLaunch:


### PR DESCRIPTION
## What

`skill remove --agents` and `mcp remove --agents` only lowercased the agent names before `setup_mcp_clients`' configured-client membership check. An alias like `claude-code` therefore failed with "not configured", even though `skill add` and `mcp add` accept it (they resolve aliases through `normalize_tool`). A user who added a scope with an alias could not remove it with the same name. `mcp remove` had the identical pre-existing gap.

## How

- Add `normalize_agent` / `normalize_agents` helpers in `agents/__init__.py`. `normalize_agent` is `normalize_tool` plus the MCP-only `cursor` agent (which has no model routing, so it is not a `normalize_tool` value); `normalize_agents` parses a comma-separated `--agents` value into canonical names.
- Route all four `skill`/`mcp` `--agents` boundaries (`add` and `remove`) through `normalize_agents`, so add and remove resolve names identically. The add-path helper `_configure_agents_for_mcp` now uses `normalize_agent` in place of its inline `a if a == "cursor" else normalize_tool(a)`.
- Leave `normalize_tool` unchanged, so the launch/configure paths that must reject `cursor` as a model agent keep that behavior.
- Behavior is identical for valid input; an invalid name now raises the clearer `Unsupported tool '...'` at parse time instead of a later "not configured".

## Tests

- `test_agents_init.py`: unit tests for `normalize_agent` (aliases, `cursor`, invalid raise) and `normalize_agents` (None, empty, dedupe, normalize).
- `test_cli.py`: `skill remove` and `mcp remove` resolve `claude-code` / `gemini-cli` to `{claude, gemini}`; adds a first forwarding test for `mcp remove --agents`.
- `uv run pytest tests/test_agents_init.py tests/test_cli.py tests/test_mcp.py tests/test_lint.py` passes (562); `ruff check` clean.

## Stacking

Follow-up on top of #525 (`xshen/skill-per-agent-remove`), addressing Sunish's P2 review comment there about normalizing `--agents` aliases on the remove paths. Also fixes the identical pre-existing gap in `mcp remove`.

This pull request and its description were written by Isaac.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
