### PR TITLE
Fix configure/launch loop for older Codex versions

### DIFF
--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -511,6 +511,14 @@ def launch(
     workspace = state.get("workspace")
     if workspace:
         os.environ["OAUTH_TOKEN"] = get_databricks_token(workspace, state.get("profile"))
+    if _use_legacy_layout():
+        print_warning_err(
+            f"Codex {agent_version(binary)} is outdated. Upgrade Codex to "
+            f"{MINIMUM_CODEX_VERSION_TEXT} or newer, then run `codex --version` to verify "
+            "the active installation."
+        )
+        exec_or_spawn([binary, "--profile", CODEX_PROFILE_NAME, *tool_args])
+        return
     # Layer ucode's named profile as ordinary config overrides. Unlike
     # `--profile`, `--config` is accepted by runtime, utility, and server
     # commands, so every invocation keeps the same Databricks settings without

--- a/tests/test_agent_codex.py
+++ b/tests/test_agent_codex.py
@@ -580,7 +580,7 @@ class TestCodexValidateCmd:
 
 
 class TestCodexLaunch:
-    """Normal launches layer the ucode profile as universal config overrides."""
+    """Launches use the configuration layout supported by the installed Codex."""
 
     @staticmethod
     def _patch(tmp_path, monkeypatch):
@@ -595,6 +595,7 @@ class TestCodexLaunch:
         )
         launches: list[list[str]] = []
         monkeypatch.setattr(codex, "CODEX_CONFIG_PATH", profile_path)
+        monkeypatch.setattr(codex, "agent_version", lambda binary: "0.134.0")
         monkeypatch.setattr(codex, "exec_or_spawn", lambda argv: launches.append(argv))
         monkeypatch.setattr(codex, "get_databricks_token", lambda workspace, profile=None: "tok")
         monkeypatch.setattr(codex, "clear_model_preferences", lambda state: False)
@@ -620,8 +621,12 @@ class TestCodexLaunch:
             ["app", "--new-window"],
         ],
     )
-    def test_layers_profile_as_config_overrides(self, tmp_path, monkeypatch, tool_args):
+    @pytest.mark.parametrize("version", ["0.134.0", "unknown"])
+    def test_layers_profile_as_config_overrides(
+        self, tmp_path, monkeypatch, capsys, tool_args, version
+    ):
         launches = self._patch(tmp_path, monkeypatch)
+        monkeypatch.setattr(codex, "agent_version", lambda binary: version)
 
         codex.launch({"workspace": WS}, tool_args, options=LaunchOptions())
 
@@ -633,9 +638,50 @@ class TestCodexLaunch:
             arg for arg in launches[0] if arg.startswith("model_providers.ucode-databricks=")
         )
         assert 'base_url = "https://example.databricks.com/ai-gateway/codex/v1"' in provider_arg
+        assert "Upgrade Codex" not in capsys.readouterr().err
+
+    @pytest.mark.parametrize("tool_args", [[], ["exec", "hi"]])
+    @pytest.mark.parametrize("stale_profile", [False, True])
+    @pytest.mark.parametrize("version", ["0.129.0", "0.133.0"])
+    def test_launches_legacy_config_after_configure(
+        self, tmp_path, monkeypatch, capsys, tool_args, stale_profile, version
+    ):
+        profile_path = tmp_path / "ucode.config.toml"
+        legacy_path = tmp_path / "config.toml"
+        monkeypatch.setattr(codex, "CODEX_CONFIG_PATH", profile_path)
+        monkeypatch.setattr(codex, "LEGACY_CODEX_CONFIG_PATH", legacy_path)
+        monkeypatch.setattr(codex, "CODEX_BACKUP_PATH", tmp_path / "profile-backup.toml")
+        monkeypatch.setattr(codex, "LEGACY_CODEX_BACKUP_PATH", tmp_path / "legacy-backup.toml")
+        monkeypatch.setattr(codex, "agent_version", lambda binary: version)
+        monkeypatch.setattr(codex, "save_state", lambda state: None)
+        monkeypatch.setattr(codex, "get_databricks_token", lambda *_args: "tok")
+        monkeypatch.delenv("OAUTH_TOKEN", raising=False)
+        launches: list[list[str]] = []
+        monkeypatch.setattr(codex, "exec_or_spawn", lambda argv: launches.append(argv))
+        if stale_profile:
+            profile_path.write_text('model_provider = "stale-provider"\n', encoding="utf-8")
+
+        state = codex.write_tool_config({"workspace": WS, "profile": "test-workspace"})
+
+        assert profile_path.exists() is stale_profile
+        config = read_toml_safe(legacy_path)
+        assert config["profiles"]["ucode"]["model_provider"] == "ucode-databricks"
+        assert config["model_providers"]["ucode-databricks"]["base_url"] == (
+            f"{WS}/ai-gateway/codex/v1"
+        )
+
+        codex.launch(state, tool_args, options=LaunchOptions())
+
+        assert launches == [["codex", "--profile", "ucode", *tool_args]]
+        assert launches[0][:3] == codex.validate_cmd("codex")[:3]
+        warning = " ".join(capsys.readouterr().err.split())
+        assert f"Codex {version} is outdated" in warning
+        assert "Upgrade Codex to 0.134.0 or newer" in warning
+        assert "codex --version" in warning
 
     def test_requires_populated_ucode_profile(self, tmp_path, monkeypatch):
         monkeypatch.setattr(codex, "CODEX_CONFIG_PATH", tmp_path / "missing.config.toml")
+        monkeypatch.setattr(codex, "agent_version", lambda binary: "0.134.0")
         launches = []
         monkeypatch.setattr(codex, "exec_or_spawn", lambda argv: launches.append(argv))
         monkeypatch.setattr(codex, "get_databricks_token", lambda *_args: "tok")
@@ -671,7 +717,7 @@ class TestCodexManagedConfig:
         return config_path, managed_path
 
     def test_writes_managed_config_by_default(self, tmp_path, monkeypatch):
-        _, managed_path = self._patch(tmp_path, monkeypatch)
+        config_path, managed_path = self._patch(tmp_path, monkeypatch)
         state = {"workspace": WS, "codex_models": ["gpt-5"]}
         codex.write_tool_config(state)
 
@@ -679,6 +725,7 @@ class TestCodexManagedConfig:
         assert doc["model_provider"] == "ucode-databricks"
         assert "model" not in doc
         assert "ucode-databricks" in doc["model_providers"]
+        assert read_toml_safe(config_path)["model_provider"] == "ucode-databricks"
 
     def test_managed_config_preserves_other_keys(self, tmp_path, monkeypatch):
         _, managed_path = self._patch(tmp_path, monkeypatch)


### PR DESCRIPTION
Codex versions below 0.134.0 enter a configure/launch loop: configure writes `[profiles.ucode]` into `~/.codex/config.toml` and validation succeeds, but launch requires the newer `ucode.config.toml` file. This restores compatibility lost in #502 by using the same version check as configure and launching older Codex with `--profile ucode`.

Older versions also receive a warning on stderr to upgrade to 0.134.0 or newer and verify the active installation with `codex --version`. Modern and unknown versions retain the existing `--config` behavior for runtime, utility, and server commands.

### Validation

- 105 focused tests pass across `test_agent_codex.py`, `test_codex_config.py`, and `test_codex_smart_routing_v2.py`, covering legacy versions, stale profile files, the version boundary, unknown versions, and upgrade warnings.
- Ruff lint, formatting, and `git diff --check` pass.
- Tested the official Linux ARM64 Codex 0.129.0 binary in isolated containers against a local Responses API test server. With UG e7553f4, validation succeeds and both launch attempts fail with the reported missing-file error. With this patch, validation and both real `codex exec` launches exit 0, use the `ucode-databricks` provider, and show the upgrade warning. Gateway authentication and responses use local test equivalents.
