### PR TITLE
bump default to taskv3

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ ug claude --enable-smart-routing
 ```
 
 The flag applies only to that launch; later launches use normal model selection unless the flag is
-passed again. Smart routing uses the `task_v2` router by default. Power users can select another
+passed again. Smart routing uses the `task_v3` router by default. Power users can select another
 router for a launch by setting `SMART_ROUTER_NAME`, for example
 `SMART_ROUTER_NAME=task_v1 ug codex --enable-smart-routing`.
 

--- a/src/ucode/smart_routing/routing.py
+++ b/src/ucode/smart_routing/routing.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-ROUTER_NAME = "task_v2"
+ROUTER_NAME = "task_v3"
 ROUTER_NAME_ENV_VAR = "SMART_ROUTER_NAME"
 ROUTING_PATH = "/ai-gateway/routing/v1/routes:select"
 REQUEST_TIMEOUT_S = 30.0
@@ -100,7 +100,7 @@ def normalize_model(model: str) -> str:
 
 
 def configured_router_name() -> str:
-    """Return the environment-selected router, falling back to ``task_v2``."""
+    """Return the environment-selected router, falling back to ``task_v3``."""
     return os.environ.get(ROUTER_NAME_ENV_VAR, "").strip() or ROUTER_NAME
 
 


### PR DESCRIPTION
if users set no env var, then task_v3 will be their default smart router (which is currently our best 1). this means if users opt in via `--enable-smart-routing`, they get our best router 