### PR TITLE
Move streaming picker primitives into ui.interactive_picker

### DIFF
--- a/src/ucode/mcp.py
+++ b/src/ucode/mcp.py
@@ -5,28 +5,14 @@ from __future__ import annotations
 import json
 import os
 import shutil
-import string
 import subprocess
 import threading
-import time
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from contextlib import suppress
 from typing import Any
 from urllib.parse import urlparse
 
 import questionary
-from prompt_toolkit.application import Application
-from prompt_toolkit.filters import Condition, IsDone
-from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.keys import Keys
-from prompt_toolkit.layout import ConditionalContainer, HSplit, Layout, Window
-from prompt_toolkit.layout.controls import FormattedTextControl
-from prompt_toolkit.layout.dimension import Dimension
-from prompt_toolkit.shortcuts import PromptSession
-from questionary.prompts.common import InquirerControl
-from questionary.question import Question
-from questionary.styles import merge_styles_default
 
 from ucode.agents import copilot, cursor, gemini, opencode
 from ucode.config_io import restore_file
@@ -45,27 +31,21 @@ from ucode.databricks import (
 )
 from ucode.state import load_full_state, load_state, save_state
 from ucode.ui import (
+    _BACK,
+    _Back,
     console,
+    picker_style,
     print_kv,
     print_note,
     print_section,
     print_success,
     print_warning,
+    scrolling_checkbox,
     spinner,
 )
 
 MCP_USER_SCOPE = "user"
 MCP_CLEANUP_SCOPES = ("local", "project", MCP_USER_SCOPE)
-MCP_PICKER_VISIBLE_ROWS = 10
-
-
-class _Back:
-    """Sentinel type: a wizard step returns the `_BACK` instance when the user
-    presses Left (←) to go back. Distinct from None (cancel) and [] (empty)."""
-
-
-# Singleton instance used everywhere; compare with `is _BACK`.
-_BACK = _Back()
 MCP_CLIENTS = {
     "claude": {
         "binary": "claude",
@@ -458,17 +438,6 @@ def _catalog_schema_server_name(prefix: str, catalog: str, schema: str, taken: s
     return f"{candidate}-{counter}"
 
 
-def _picker_style() -> questionary.Style:
-    return questionary.Style(
-        [
-            ("pointer", "fg:cyan bold"),
-            ("highlighted", "noinherit"),
-            ("selected", "noinherit"),
-            ("answer", "fg:cyan"),
-        ]
-    )
-
-
 def _server_name(server: dict) -> str | None:
     name = server.get("name")
     return name if isinstance(name, str) and name else None
@@ -567,313 +536,6 @@ def _mcp_service_choice(name: str, known_names: set[str], additive: bool) -> que
             )
         return _server_choice(registered_as, True, display_title)
     return _add_choice(f"{MCP_SERVICE_SELECTION_PREFIX}{name}", display_title)
-
-
-class _StreamingInquirerControl(InquirerControl):
-    """`InquirerControl` that tolerates an empty or all-disabled choice list.
-
-    Stock `InquirerControl.__init__` ends with ``if not self.is_selection_valid(): raise`` and
-    `is_selection_valid` dereferences `pointed_at`, which `_init_choices` leaves unset when no row
-    is selectable — so constructing it with an empty (or every-row-disabled) list raises, and
-    navigation later hits the same unset cursor. Our picker intentionally opens on an empty list
-    and fills it in via the background loader, and `ug mcp add` can legitimately show only
-    already-configured (disabled) rows. Default the cursor and treat "nothing selectable" as valid
-    so construction, rendering, and navigation don't crash."""
-
-    def is_selection_valid(self) -> bool:
-        if getattr(self, "pointed_at", None) is None:
-            self.pointed_at = 0
-        selectable = any(
-            not isinstance(c, questionary.Separator) and not c.disabled for c in self.choices
-        )
-        if not selectable:
-            # Empty, or every row a separator/disabled: nothing to validate, and nothing for the
-            # navigation skip-loop to land on — report valid so we neither raise nor spin.
-            return True
-        if self.pointed_at >= len(self.choices):
-            return False
-        return super().is_selection_valid()
-
-    def _get_choice_tokens(self):
-        # Stock rendering unconditionally reads `filtered_choices[pointed_at]`, which raises on an
-        # empty list. Render nothing when there are no rows (the picker is still streaming them in).
-        if not self.filtered_choices:
-            return []
-        return super()._get_choice_tokens()
-
-
-def _merge_new_choices(
-    existing: list[questionary.Choice | questionary.Separator],
-    new_choices: list[questionary.Choice],
-) -> list[questionary.Choice]:
-    """Return the choices from ``new_choices`` not already present in ``existing`` (compared by
-    Choice value). Used to dedupe background-streamed picker rows against what's already shown."""
-    shown = {c.value for c in existing if isinstance(c, questionary.Choice)}
-    return [c for c in new_choices if isinstance(c, questionary.Choice) and c.value not in shown]
-
-
-def _scrolling_checkbox(
-    message: str,
-    choices: list[questionary.Choice | questionary.Separator],
-    instruction: str,
-    style: questionary.Style,
-    allow_back: bool = False,
-    background_loader: Callable[[Callable[[list[questionary.Choice]], None]], None] | None = None,
-) -> Question:
-    """Multi-select checkbox picker.
-
-    ``background_loader``, if given, streams more choices in after the picker is already
-    on screen: it's run on a daemon thread and handed an ``append(choices)`` callback that
-    adds rows (deduped by value) and repaints, so the picker opens instantly on whatever
-    ``choices`` are ready and fills in the rest without blocking. A footer shows a live
-    "loading more…" count while it runs."""
-    merged_style = merge_styles_default(
-        [
-            questionary.Style([("bottom-toolbar", "noreverse")]),
-            style,
-        ]
-    )
-    # Empty-tolerant control: the picker can open with zero selectable rows (streaming in via the
-    # background loader, or an `mcp add` where everything is already configured) — see the subclass.
-    control = _StreamingInquirerControl(
-        choices,
-        pointer="›",
-        show_description=False,
-    )
-    # Live loading state for the background-loader footer (see below).
-    loading = {"active": background_loader is not None, "found": 0}
-
-    def get_prompt_tokens() -> list[tuple[str, str]]:
-        tokens = [("class:qmark", ""), ("class:question", f" {message} ")]
-        if control.is_answered:
-            selected_count = len(control.selected_options)
-            answer = "done" if selected_count == 0 else f"done ({selected_count} selections)"
-            tokens.append(("class:answer", answer))
-        else:
-            tokens.append(("class:instruction", instruction))
-        return tokens
-
-    def get_selected_values() -> list[Any]:
-        return [choice.value for choice in control.get_selected_values()]
-
-    def perform_validation() -> bool:
-        control.error_message = None
-        return True
-
-    @Condition
-    def has_more_choices() -> bool:
-        # Live so the scroll hint appears as background-loaded rows stream in.
-        return len(control.choices) > MCP_PICKER_VISIBLE_ROWS
-
-    @Condition
-    def is_loading() -> bool:
-        return bool(loading["active"])
-
-    def loading_tokens() -> list[tuple[str, str]]:
-        return [
-            ("class:instruction", f"  ⏳ loading more MCP services… ({loading['found']} found)")
-        ]
-
-    @Condition
-    def has_search_string() -> bool:
-        return control.get_search_string_tokens() is not None
-
-    validation_prompt: PromptSession = PromptSession(bottom_toolbar=lambda: control.error_message)
-    # Render the prompt as a fixed 1-row window rather than a PromptSession
-    # container: the latter expands to fill the terminal height, which in a tall
-    # window pushes the choices list to the very bottom (a large blank gap).
-    layout = Layout(
-        HSplit(
-            [
-                Window(
-                    height=Dimension.exact(1),
-                    content=FormattedTextControl(get_prompt_tokens),
-                ),
-                ConditionalContainer(
-                    # Height tracks the live choice count (capped at the visible max) so the
-                    # window grows as background-loaded rows stream in, with no blank gap when
-                    # only a few choices are present.
-                    Window(
-                        control,
-                        height=lambda: Dimension.exact(
-                            min(MCP_PICKER_VISIBLE_ROWS, max(1, len(control.choices)))
-                        ),
-                    ),
-                    filter=~IsDone(),
-                ),
-                ConditionalContainer(
-                    Window(
-                        height=Dimension.exact(1),
-                        content=FormattedTextControl(
-                            lambda: [("class:instruction", "  ↑/↓ scroll for more")]
-                        ),
-                    ),
-                    filter=has_more_choices & ~IsDone(),
-                ),
-                ConditionalContainer(
-                    Window(
-                        height=Dimension.exact(1),
-                        content=FormattedTextControl(loading_tokens),
-                    ),
-                    filter=is_loading & ~IsDone(),
-                ),
-                ConditionalContainer(
-                    Window(
-                        height=Dimension.exact(2),
-                        content=FormattedTextControl(control.get_search_string_tokens),
-                    ),
-                    filter=has_search_string & ~IsDone(),
-                ),
-                ConditionalContainer(
-                    validation_prompt.layout.container,
-                    filter=Condition(lambda: control.error_message is not None),
-                ),
-            ]
-        )
-    )
-
-    bindings = KeyBindings()
-
-    @bindings.add(Keys.ControlQ, eager=True)
-    @bindings.add(Keys.ControlC, eager=True)
-    def _(event: Any) -> None:
-        event.app.exit(exception=KeyboardInterrupt, style="class:aborting")
-
-    @bindings.add(" ", eager=True)
-    def _(_event: Any) -> None:
-        if control.choice_count == 0:
-            return  # nothing to toggle (e.g. picker still streaming, or all rows filtered out)
-        pointed = control.get_pointed_at()
-        if isinstance(pointed, questionary.Separator) or pointed.disabled:
-            return  # separators and already-configured (disabled) rows aren't toggleable
-        pointed_choice = pointed.value
-        if pointed_choice in control.selected_options:
-            control.selected_options.remove(pointed_choice)
-        else:
-            control.selected_options.append(pointed_choice)
-        perform_validation()
-
-    @bindings.add(Keys.ControlA, eager=True)
-    def _(_event: Any) -> None:
-        # Toggle-all: select every selectable choice, or clear the selection if
-        # everything is already selected. `a` alone is reserved for type-to-filter.
-        selectable = [
-            choice.value
-            for choice in control.choices
-            if not isinstance(choice, questionary.Separator) and not choice.disabled
-        ]
-        if all(value in control.selected_options for value in selectable):
-            control.selected_options = []
-        else:
-            control.selected_options = list(selectable)
-        perform_validation()
-
-    def move_cursor_down(event: Any) -> None:
-        if control.choice_count == 0:
-            return
-        control.select_next()
-        # Bound the skip-past-disabled scan so an all-disabled list can't spin forever.
-        tries = 0
-        while not control.is_selection_valid() and tries < control.choice_count:
-            control.select_next()
-            tries += 1
-
-    def move_cursor_up(event: Any) -> None:
-        if control.choice_count == 0:
-            return
-        control.select_previous()
-        tries = 0
-        while not control.is_selection_valid() and tries < control.choice_count:
-            control.select_previous()
-            tries += 1
-
-    def search_filter(event: Any) -> None:
-        control.add_search_character(event.key_sequence[0].key)
-
-    for character in string.printable:
-        if character in string.whitespace:
-            continue
-        bindings.add(character, eager=True)(search_filter)
-    bindings.add(Keys.Backspace, eager=True)(search_filter)
-
-    bindings.add(Keys.Down, eager=True)(move_cursor_down)
-    bindings.add(Keys.Up, eager=True)(move_cursor_up)
-    bindings.add(Keys.ControlN, eager=True)(move_cursor_down)
-    bindings.add(Keys.ControlP, eager=True)(move_cursor_up)
-
-    @bindings.add(Keys.ControlM, eager=True)
-    def _(event: Any) -> None:
-        control.submission_attempted = True
-        if perform_validation():
-            control.is_answered = True
-            event.app.exit(result=get_selected_values())
-
-    if allow_back:
-
-        @bindings.add(Keys.Left, eager=True)
-        def _(event: Any) -> None:
-            # Wizard back-navigation: exit this step with the _BACK sentinel so
-            # the caller re-shows the previous step. Left arrow is otherwise
-            # unused in this multi-select (cursor moves with up/down).
-            event.app.exit(result=_BACK)
-
-    @bindings.add(Keys.Any)
-    def _(_event: Any) -> None:
-        """Ignore other text input."""
-
-    app: Application = Application(
-        layout=layout,
-        key_bindings=bindings,
-        style=merged_style,
-    )
-
-    if background_loader is not None:
-        started = False
-
-        def run_on_loop(fn: Callable[[], None]) -> None:
-            # Background updates MUST run on the picker's event-loop thread: mutating the control
-            # off-thread drops rows (prompt_toolkit's invalidate() no-ops until the app is running)
-            # and disturbs live input (toggling/removal). Wait briefly for the app to start, then
-            # hand `fn` to the loop; bail once the picker has closed or if it never starts in time.
-            nonlocal started
-            deadline = time.monotonic() + 15.0
-            while not (app.is_running and app.loop is not None):
-                if started or time.monotonic() > deadline:
-                    return
-                time.sleep(0.02)
-            started = True
-            with suppress(Exception):
-                app.loop.call_soon_threadsafe(fn)
-
-        def append(new_choices: list[questionary.Choice]) -> None:
-            def apply() -> None:
-                # On the UI thread: rebind choices (atomic; render reads the list live) and repaint.
-                # Selections track by value, so appended rows never disturb checkboxes/scroll/filter.
-                additions = _merge_new_choices(control.choices, new_choices)
-                if additions:
-                    control.choices = [*control.choices, *additions]
-                    loading["found"] += len(additions)
-                    app.invalidate()
-
-            run_on_loop(apply)
-
-        def worker() -> None:
-            try:
-                background_loader(append)
-            except Exception:
-                # Discovery is best-effort; a failed background walk just stops streaming.
-                pass
-            finally:
-
-                def finish() -> None:
-                    loading["active"] = False
-                    app.invalidate()
-
-                run_on_loop(finish)
-
-        threading.Thread(target=worker, name="mcp-picker-loader", daemon=True).start()
-
-    return Question(app)
 
 
 def build_mcp_picker_choices(
@@ -1018,12 +680,12 @@ def prompt_for_mcp_server_choices(
     non-toggleable notes instead of pre-checked, removable boxes.
 
     ``background_loader`` streams more choices in after the picker opens (see
-    `_scrolling_checkbox`) — used to load the workspace-wide MCP-services walk without
+    `scrolling_checkbox`) — used to load the workspace-wide MCP-services walk without
     blocking on it up front."""
     instruction = "(space to toggle, ctrl-a all, enter to save, type to filter)"
     if allow_back:
         instruction = "(space to toggle, ctrl-a all, ← back, enter to save, type to filter)"
-    selection = _scrolling_checkbox(
+    selection = scrolling_checkbox(
         "MCP:",
         choices=build_mcp_picker_choices(
             available_external_names,
@@ -1035,7 +697,7 @@ def prompt_for_mcp_server_choices(
             available_uc_functions_servers,
             additive=additive,
         ),
-        style=_picker_style(),
+        style=picker_style(),
         instruction=instruction,
         allow_back=allow_back,
         background_loader=background_loader,
@@ -1970,10 +1632,10 @@ def _prompt_for_mcp_removal(servers: list[dict]) -> list[str] | None:
         choices.append(questionary.Choice(title=title, value=name, checked=False))
     if not choices:
         return []
-    selection = _scrolling_checkbox(
+    selection = scrolling_checkbox(
         "Remove MCP:",
         choices=choices,
-        style=_picker_style(),
+        style=picker_style(),
         instruction="(space to toggle, ctrl-a all, enter to remove, type to filter)",
     ).ask()
     if selection is None:
@@ -2354,10 +2016,10 @@ def _prompt_for_skill_removal(locations_by_client: dict[str, list[str]]) -> list
         )
     if not choices:
         return []
-    selection = _scrolling_checkbox(
+    selection = scrolling_checkbox(
         "Remove skill schemas:",
         choices=choices,
-        style=_picker_style(),
+        style=picker_style(),
         instruction="(space to toggle, ctrl-a all, enter to remove, type to filter)",
     ).ask()
     if selection is None:

--- a/src/ucode/ui/__init__.py
+++ b/src/ucode/ui/__init__.py
@@ -21,13 +21,21 @@ from rich.markup import escape
 from rich.panel import Panel
 from rich.progress import BarColumn, MofNCompleteColumn, Progress, TextColumn
 
+from ucode.ui.interactive_picker import _BACK as _BACK
+from ucode.ui.interactive_picker import PICKER_VISIBLE_ROWS as PICKER_VISIBLE_ROWS
+from ucode.ui.interactive_picker import StreamingInquirerControl as StreamingInquirerControl
+from ucode.ui.interactive_picker import _Back as _Back
+from ucode.ui.interactive_picker import merge_new_choices as merge_new_choices
+from ucode.ui.interactive_picker import picker_style as picker_style
+from ucode.ui.interactive_picker import scrolling_checkbox as scrolling_checkbox
+
 console = Console(highlight=False)
 err_console = Console(stderr=True, highlight=False)
 
 # Past this many options the choice list is pinned to a fixed-height scrolling viewport (see
 # `_cap_choice_viewport`) rather than growing to fill the terminal, and the pickers append a
 # "↑/↓ scroll" note to their instruction line. The value is both the boundary and the number of
-# rows shown at once; matches mcp.py's MCP_PICKER_VISIBLE_ROWS so both picker families agree.
+# rows shown at once; matches interactive_picker's PICKER_VISIBLE_ROWS so both picker families agree.
 _SCROLL_HINT_THRESHOLD = 10
 
 

--- a/src/ucode/ui/interactive_picker.py
+++ b/src/ucode/ui/interactive_picker.py
@@ -1,0 +1,358 @@
+"""Streaming multi-select picker built on questionary / prompt_toolkit.
+
+Presentation-only primitives shared by the product pickers (MCP services, skills). They operate on
+a generic `questionary.Choice` list and an optional `background_loader`, with no MCP- or
+Databricks-specific logic, so any caller can supply its own choices and discovery walk.
+"""
+
+from __future__ import annotations
+
+import string
+import threading
+import time
+from collections.abc import Callable
+from contextlib import suppress
+from typing import Any
+
+import questionary
+from prompt_toolkit.application import Application
+from prompt_toolkit.filters import Condition, IsDone
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.keys import Keys
+from prompt_toolkit.layout import ConditionalContainer, HSplit, Layout, Window
+from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.layout.dimension import Dimension
+from prompt_toolkit.shortcuts import PromptSession
+from questionary.prompts.common import InquirerControl
+from questionary.question import Question
+from questionary.styles import merge_styles_default
+
+PICKER_VISIBLE_ROWS = 10
+
+
+class _Back:
+    """Sentinel type: a wizard step returns the `_BACK` instance when the user
+    presses Left (←) to go back. Distinct from None (cancel) and [] (empty)."""
+
+
+# Singleton instance used everywhere; compare with `is _BACK`.
+_BACK = _Back()
+
+
+def picker_style() -> questionary.Style:
+    return questionary.Style(
+        [
+            ("pointer", "fg:cyan bold"),
+            ("highlighted", "noinherit"),
+            ("selected", "noinherit"),
+            ("answer", "fg:cyan"),
+        ]
+    )
+
+
+class StreamingInquirerControl(InquirerControl):
+    """`InquirerControl` that tolerates an empty or all-disabled choice list.
+
+    Stock `InquirerControl.__init__` ends with ``if not self.is_selection_valid(): raise`` and
+    `is_selection_valid` dereferences `pointed_at`, which `_init_choices` leaves unset when no row
+    is selectable — so constructing it with an empty (or every-row-disabled) list raises, and
+    navigation later hits the same unset cursor. Our picker intentionally opens on an empty list
+    and fills it in via the background loader, and `ug mcp add` can legitimately show only
+    already-configured (disabled) rows. Default the cursor and treat "nothing selectable" as valid
+    so construction, rendering, and navigation don't crash."""
+
+    def is_selection_valid(self) -> bool:
+        if getattr(self, "pointed_at", None) is None:
+            self.pointed_at = 0
+        selectable = any(
+            not isinstance(c, questionary.Separator) and not c.disabled for c in self.choices
+        )
+        if not selectable:
+            # Empty, or every row a separator/disabled: nothing to validate, and nothing for the
+            # navigation skip-loop to land on — report valid so we neither raise nor spin.
+            return True
+        if self.pointed_at >= len(self.choices):
+            return False
+        return super().is_selection_valid()
+
+    def _get_choice_tokens(self):
+        # Stock rendering unconditionally reads `filtered_choices[pointed_at]`, which raises on an
+        # empty list. Render nothing when there are no rows (the picker is still streaming them in).
+        if not self.filtered_choices:
+            return []
+        return super()._get_choice_tokens()
+
+
+def merge_new_choices(
+    existing: list[questionary.Choice | questionary.Separator],
+    new_choices: list[questionary.Choice],
+) -> list[questionary.Choice]:
+    """Return the choices from ``new_choices`` not already present in ``existing`` (compared by
+    Choice value). Used to dedupe background-streamed picker rows against what's already shown."""
+    shown = {c.value for c in existing if isinstance(c, questionary.Choice)}
+    return [c for c in new_choices if isinstance(c, questionary.Choice) and c.value not in shown]
+
+
+def scrolling_checkbox(
+    message: str,
+    choices: list[questionary.Choice | questionary.Separator],
+    instruction: str,
+    style: questionary.Style,
+    allow_back: bool = False,
+    background_loader: Callable[[Callable[[list[questionary.Choice]], None]], None] | None = None,
+    loading_noun: str = "MCP services",
+) -> Question:
+    """Multi-select checkbox picker.
+
+    ``background_loader``, if given, streams more choices in after the picker is already
+    on screen: it's run on a daemon thread and handed an ``append(choices)`` callback that
+    adds rows (deduped by value) and repaints, so the picker opens instantly on whatever
+    ``choices`` are ready and fills in the rest without blocking. A footer shows a live
+    "loading more {loading_noun}…" count while it runs."""
+    merged_style = merge_styles_default(
+        [
+            questionary.Style([("bottom-toolbar", "noreverse")]),
+            style,
+        ]
+    )
+    # Empty-tolerant control: the picker can open with zero selectable rows (streaming in via the
+    # background loader, or an `mcp add` where everything is already configured) — see the subclass.
+    control = StreamingInquirerControl(
+        choices,
+        pointer="›",
+        show_description=False,
+    )
+    # Live loading state for the background-loader footer (see below).
+    loading = {"active": background_loader is not None, "found": 0}
+
+    def get_prompt_tokens() -> list[tuple[str, str]]:
+        tokens = [("class:qmark", ""), ("class:question", f" {message} ")]
+        if control.is_answered:
+            selected_count = len(control.selected_options)
+            answer = "done" if selected_count == 0 else f"done ({selected_count} selections)"
+            tokens.append(("class:answer", answer))
+        else:
+            tokens.append(("class:instruction", instruction))
+        return tokens
+
+    def get_selected_values() -> list[Any]:
+        return [choice.value for choice in control.get_selected_values()]
+
+    def perform_validation() -> bool:
+        control.error_message = None
+        return True
+
+    @Condition
+    def has_more_choices() -> bool:
+        # Live so the scroll hint appears as background-loaded rows stream in.
+        return len(control.choices) > PICKER_VISIBLE_ROWS
+
+    @Condition
+    def is_loading() -> bool:
+        return bool(loading["active"])
+
+    def loading_tokens() -> list[tuple[str, str]]:
+        return [
+            ("class:instruction", f"  ⏳ loading more {loading_noun}… ({loading['found']} found)")
+        ]
+
+    @Condition
+    def has_search_string() -> bool:
+        return control.get_search_string_tokens() is not None
+
+    validation_prompt: PromptSession = PromptSession(bottom_toolbar=lambda: control.error_message)
+    # Render the prompt as a fixed 1-row window rather than a PromptSession
+    # container: the latter expands to fill the terminal height, which in a tall
+    # window pushes the choices list to the very bottom (a large blank gap).
+    layout = Layout(
+        HSplit(
+            [
+                Window(
+                    height=Dimension.exact(1),
+                    content=FormattedTextControl(get_prompt_tokens),
+                ),
+                ConditionalContainer(
+                    # Height tracks the live choice count (capped at the visible max) so the
+                    # window grows as background-loaded rows stream in, with no blank gap when
+                    # only a few choices are present.
+                    Window(
+                        control,
+                        height=lambda: Dimension.exact(
+                            min(PICKER_VISIBLE_ROWS, max(1, len(control.choices)))
+                        ),
+                    ),
+                    filter=~IsDone(),
+                ),
+                ConditionalContainer(
+                    Window(
+                        height=Dimension.exact(1),
+                        content=FormattedTextControl(
+                            lambda: [("class:instruction", "  ↑/↓ scroll for more")]
+                        ),
+                    ),
+                    filter=has_more_choices & ~IsDone(),
+                ),
+                ConditionalContainer(
+                    Window(
+                        height=Dimension.exact(1),
+                        content=FormattedTextControl(loading_tokens),
+                    ),
+                    filter=is_loading & ~IsDone(),
+                ),
+                ConditionalContainer(
+                    Window(
+                        height=Dimension.exact(2),
+                        content=FormattedTextControl(control.get_search_string_tokens),
+                    ),
+                    filter=has_search_string & ~IsDone(),
+                ),
+                ConditionalContainer(
+                    validation_prompt.layout.container,
+                    filter=Condition(lambda: control.error_message is not None),
+                ),
+            ]
+        )
+    )
+
+    bindings = KeyBindings()
+
+    @bindings.add(Keys.ControlQ, eager=True)
+    @bindings.add(Keys.ControlC, eager=True)
+    def _(event: Any) -> None:
+        event.app.exit(exception=KeyboardInterrupt, style="class:aborting")
+
+    @bindings.add(" ", eager=True)
+    def _(_event: Any) -> None:
+        if control.choice_count == 0:
+            return  # nothing to toggle (e.g. picker still streaming, or all rows filtered out)
+        pointed = control.get_pointed_at()
+        if isinstance(pointed, questionary.Separator) or pointed.disabled:
+            return  # separators and already-configured (disabled) rows aren't toggleable
+        pointed_choice = pointed.value
+        if pointed_choice in control.selected_options:
+            control.selected_options.remove(pointed_choice)
+        else:
+            control.selected_options.append(pointed_choice)
+        perform_validation()
+
+    @bindings.add(Keys.ControlA, eager=True)
+    def _(_event: Any) -> None:
+        # Toggle-all: select every selectable choice, or clear the selection if
+        # everything is already selected. `a` alone is reserved for type-to-filter.
+        selectable = [
+            choice.value
+            for choice in control.choices
+            if not isinstance(choice, questionary.Separator) and not choice.disabled
+        ]
+        if all(value in control.selected_options for value in selectable):
+            control.selected_options = []
+        else:
+            control.selected_options = list(selectable)
+        perform_validation()
+
+    def move_cursor_down(event: Any) -> None:
+        if control.choice_count == 0:
+            return
+        control.select_next()
+        # Bound the skip-past-disabled scan so an all-disabled list can't spin forever.
+        tries = 0
+        while not control.is_selection_valid() and tries < control.choice_count:
+            control.select_next()
+            tries += 1
+
+    def move_cursor_up(event: Any) -> None:
+        if control.choice_count == 0:
+            return
+        control.select_previous()
+        tries = 0
+        while not control.is_selection_valid() and tries < control.choice_count:
+            control.select_previous()
+            tries += 1
+
+    def search_filter(event: Any) -> None:
+        control.add_search_character(event.key_sequence[0].key)
+
+    for character in string.printable:
+        if character in string.whitespace:
+            continue
+        bindings.add(character, eager=True)(search_filter)
+    bindings.add(Keys.Backspace, eager=True)(search_filter)
+
+    bindings.add(Keys.Down, eager=True)(move_cursor_down)
+    bindings.add(Keys.Up, eager=True)(move_cursor_up)
+    bindings.add(Keys.ControlN, eager=True)(move_cursor_down)
+    bindings.add(Keys.ControlP, eager=True)(move_cursor_up)
+
+    @bindings.add(Keys.ControlM, eager=True)
+    def _(event: Any) -> None:
+        control.submission_attempted = True
+        if perform_validation():
+            control.is_answered = True
+            event.app.exit(result=get_selected_values())
+
+    if allow_back:
+
+        @bindings.add(Keys.Left, eager=True)
+        def _(event: Any) -> None:
+            # Wizard back-navigation: exit this step with the _BACK sentinel so
+            # the caller re-shows the previous step. Left arrow is otherwise
+            # unused in this multi-select (cursor moves with up/down).
+            event.app.exit(result=_BACK)
+
+    @bindings.add(Keys.Any)
+    def _(_event: Any) -> None:
+        """Ignore other text input."""
+
+    app: Application = Application(
+        layout=layout,
+        key_bindings=bindings,
+        style=merged_style,
+    )
+
+    if background_loader is not None:
+        started = False
+
+        def run_on_loop(fn: Callable[[], None]) -> None:
+            # Background updates MUST run on the picker's event-loop thread: mutating the control
+            # off-thread drops rows (prompt_toolkit's invalidate() no-ops until the app is running)
+            # and disturbs live input (toggling/removal). Wait briefly for the app to start, then
+            # hand `fn` to the loop; bail once the picker has closed or if it never starts in time.
+            nonlocal started
+            deadline = time.monotonic() + 15.0
+            while not (app.is_running and app.loop is not None):
+                if started or time.monotonic() > deadline:
+                    return
+                time.sleep(0.02)
+            started = True
+            with suppress(Exception):
+                app.loop.call_soon_threadsafe(fn)
+
+        def append(new_choices: list[questionary.Choice]) -> None:
+            def apply() -> None:
+                # On the UI thread: rebind choices (atomic; render reads the list live) and repaint.
+                # Selections track by value, so appended rows never disturb checkboxes/scroll/filter.
+                additions = merge_new_choices(control.choices, new_choices)
+                if additions:
+                    control.choices = [*control.choices, *additions]
+                    loading["found"] += len(additions)
+                    app.invalidate()
+
+            run_on_loop(apply)
+
+        def worker() -> None:
+            try:
+                background_loader(append)
+            except Exception:
+                # Discovery is best-effort; a failed background walk just stops streaming.
+                pass
+            finally:
+
+                def finish() -> None:
+                    loading["active"] = False
+                    app.invalidate()
+
+                run_on_loop(finish)
+
+        threading.Thread(target=worker, name="picker-loader", daemon=True).start()
+
+    return Question(app)

--- a/tests/test_interactive_picker.py
+++ b/tests/test_interactive_picker.py
@@ -1,0 +1,34 @@
+"""Tests for the streaming multi-select picker primitives."""
+
+from __future__ import annotations
+
+import questionary
+
+from ucode.ui.interactive_picker import StreamingInquirerControl, merge_new_choices
+
+
+def test_merge_new_choices_dedupes_by_value():
+    # Streamed rows are deduped against what's already shown, by Choice value, so a row already
+    # listed (e.g. from a fast up-front pass) isn't added twice.
+    a = questionary.Choice(title="A", value="cat.sch.a")
+    b = questionary.Choice(title="B", value="cat.sch.b")
+    merged = merge_new_choices([a], [a, b])
+    assert [c.value for c in merged] == ["cat.sch.b"]
+
+
+class TestStreamingInquirerControl:
+    """The picker must tolerate an empty or all-disabled choice list — it opens empty and streams
+    rows in via the background loader, and additive pickers can show only already-configured rows.
+    Stock InquirerControl raises in __init__/render for these; the subclass must not."""
+
+    def test_tolerates_empty_choice_list(self):
+        control = StreamingInquirerControl([], pointer="›", show_description=False)
+        assert control.is_selection_valid() is True
+        assert control._get_choice_tokens() == []
+
+    def test_tolerates_all_disabled_choices(self):
+        disabled = questionary.Choice(title="svc", value="svc", disabled="already configured")
+        assert disabled.disabled
+        control = StreamingInquirerControl([disabled], pointer="›", show_description=False)
+        assert control.is_selection_valid() is True
+        control._get_choice_tokens()  # must not raise

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -304,7 +304,7 @@ class TestMcpPicker:
             checkbox_calls.append({"args": args, "kwargs": kwargs})
             return FakePrompt()
 
-        monkeypatch.setattr(mcp, "_scrolling_checkbox", fake_checkbox)
+        monkeypatch.setattr(mcp, "scrolling_checkbox", fake_checkbox)
 
         assert mcp.prompt_for_mcp_server_choices(["github-mcp"], [], [], []) == [
             f"{mcp.MCP_ADD_PREFIX}external:github-mcp"
@@ -328,7 +328,7 @@ class TestMcpPicker:
             def ask(self):
                 return None
 
-        monkeypatch.setattr(mcp, "_scrolling_checkbox", lambda *args, **kwargs: FakePrompt())
+        monkeypatch.setattr(mcp, "scrolling_checkbox", lambda *args, **kwargs: FakePrompt())
 
         assert mcp.prompt_for_mcp_server_choices(["github-mcp"], [], [], []) is None
 
@@ -372,7 +372,7 @@ class TestMcpPicker:
             checkbox_calls.append(kwargs)
             return FakePrompt()
 
-        monkeypatch.setattr(mcp, "_scrolling_checkbox", fake_checkbox)
+        monkeypatch.setattr(mcp, "scrolling_checkbox", fake_checkbox)
 
         result = mcp._prompt_for_mcp_removal(
             [
@@ -818,14 +818,6 @@ class TestConfigureMcpCommand:
         assert toggle.value == "mycat-sch-weather" and toggle.checked
         note = mcp._mcp_service_choice("mycat.sch.weather", {"mycat-sch-weather"}, additive=True)
         assert note.value == "mycat-sch-weather" and note.disabled
-
-    def test_merge_new_choices_dedupes_by_value(self):
-        # Background-streamed rows are deduped against what's already shown, by Choice value,
-        # so a service already listed (e.g. from the fast system.ai pass) isn't added twice.
-        a = mcp._mcp_service_choice("cat.sch.a", set(), additive=False)
-        b = mcp._mcp_service_choice("cat.sch.b", set(), additive=False)
-        merged = mcp._merge_new_choices([a], [a, b])
-        assert [c.value for c in merged] == [b.value]
 
     def test_skips_slow_walks_unless_source_selected(self, monkeypatch):
         """Vector Search and UC functions walk the workspace and are OFF by
@@ -2908,21 +2900,3 @@ class TestDiscoverySkipsPermissionErrors:
         assert mcp._discover_mcp_source("Genie spaces", boom) == []
         out = capsys.readouterr().out
         assert "network down" in out
-
-
-class TestStreamingInquirerControl:
-    """The picker must tolerate an empty or all-disabled choice list — it opens empty and streams
-    rows in via the background loader, and `ug mcp add` can show only already-configured rows.
-    Stock InquirerControl raises in __init__/render for these; the subclass must not."""
-
-    def test_tolerates_empty_choice_list(self):
-        control = mcp._StreamingInquirerControl([], pointer="›", show_description=False)
-        assert control.is_selection_valid() is True
-        assert control._get_choice_tokens() == []
-
-    def test_tolerates_all_disabled_choices(self):
-        disabled = mcp._mcp_service_choice("cat.sch.svc", {"cat-sch-svc"}, additive=True)
-        assert disabled.disabled
-        control = mcp._StreamingInquirerControl([disabled], pointer="›", show_description=False)
-        assert control.is_selection_valid() is True
-        control._get_choice_tokens()  # must not raise


### PR DESCRIPTION
## What changed, and why?

**Change:** Turn `src/ucode/ui.py` into a `ui/` package and move the streaming multi-select picker primitives — `scrolling_checkbox`, `StreamingInquirerControl`, `merge_new_choices`, `picker_style`, and `PICKER_VISIBLE_ROWS` (renamed from `MCP_PICKER_VISIBLE_ROWS`) — out of `mcp.py` into a new `src/ucode/ui/interactive_picker.py`, re-exported from `ucode.ui`. Added a `loading_noun` parameter (default `"MCP services"`) so a non-MCP picker can label its loading footer.

**Why:** These primitives are source-agnostic UI. Extracting them lets the upcoming `ug skill add` (download path) picker reuse them without importing from `mcp.py`. This is the first PR (PR A) in the `ug skill add` interactive-picker stack; it is a pure refactor with no behavior change.

## How do you know it works?

**Testing:** `ruff check .` is clean and the full `uv run pytest` suite passes, except two pre-existing e2e failures (`test_e2e_user_agent`, `test_claude_smart_routing_v2`) that also fail on `main`. The picker unit tests moved to `tests/test_interactive_picker.py`; the MCP picker tests in `tests/test_mcp.py`, retargeted to the moved symbols, stay green.

This pull request and its description were written by Isaac.
