### PR TITLE
Bugfix: Discover model services outside the system.ai schema

### DIFF
--- a/src/ucode/databricks.py
+++ b/src/ucode/databricks.py
@@ -1460,6 +1460,29 @@ _MODEL_SERVICE_REQUIRED_PREFIX = "system.ai."
 # is the only server-side narrowing that works.
 _MODEL_SERVICE_PARENT_SCHEMA = "schemas/system.ai"
 
+# Some workspaces host their coding-agent model services in a custom UC catalog
+# rather than `system.ai` (e.g. `model_service_catalog.default`). Those are invisible
+# to the `system.ai`-scoped walk above, so discovery reports no models even when
+# several exist. This env var opts a workspace into searching additional
+# `catalog.schema` locations: a comma-separated list, each walked with its own
+# `parent=schemas/{catalog}.{schema}` scope (one fast page, like system.ai). It's
+# empty by default so the common case never scoops up unrelated user schemas.
+_MODEL_SERVICE_EXTRA_SCHEMAS_ENV = "UCODE_MODEL_SERVICE_SCHEMAS"
+
+
+def _extra_model_service_schemas() -> list[str]:
+    """Additional `catalog.schema` locations to search, from the env var.
+
+    De-duplicated, order-preserving; empty when the var is unset or blank."""
+    raw = os.environ.get(_MODEL_SERVICE_EXTRA_SCHEMAS_ENV, "")
+    schemas: list[str] = []
+    for part in raw.split(","):
+        part = part.strip()
+        if part and part not in schemas:
+            schemas.append(part)
+    return schemas
+
+
 # Supported OSS chat families, matched by name substring. Add an entry to
 # support a new family.
 _OSS_MODEL_FAMILIES = ("kimi-", "glm-", "deepseek-")
@@ -1517,18 +1540,24 @@ def model_token_limits(model_id: str) -> dict[str, int] | None:
     return None
 
 
-def _model_service_id(service: dict) -> str | None:
-    """Extract the `system.ai.<model-name>` id from one model-service entry.
+def _model_service_id(
+    service: dict, *, required_prefix: str = _MODEL_SERVICE_REQUIRED_PREFIX
+) -> str | None:
+    """Extract the `<catalog>.<schema>.<model-name>` id from one model-service entry.
 
-    Returns None for services in any other schema, so user/internal model
-    services don't leak into the family buckets."""
+    ``required_prefix`` defaults to ``system.ai.`` so services in any other
+    schema are dropped and user/internal model services don't leak into the
+    family buckets. Pass ``required_prefix=""`` to accept every id after the
+    ``model-services/`` prefix — used for the schema-scoped extra walks
+    (see :func:`_extra_model_service_schemas`), where the ``parent`` query has
+    already narrowed the listing to a single trusted schema."""
     name = service.get("name")
     if not isinstance(name, str):
         return None
     name = name.strip()
     if name.startswith(_MODEL_SERVICE_NAME_PREFIX):
         name = name[len(_MODEL_SERVICE_NAME_PREFIX) :]
-    if not name.startswith(_MODEL_SERVICE_REQUIRED_PREFIX):
+    if required_prefix and not name.startswith(required_prefix):
         return None
     return name or None
 
@@ -1595,6 +1624,50 @@ def has_cached_model_provider_services(workspace: str, parent: str | None = None
     return (workspace, parent or "") in _MODEL_PROVIDER_SERVICES_CACHE
 
 
+def _walk_model_services(
+    hostname: str,
+    token: str,
+    parent: str,
+    *,
+    required_prefix: str,
+    page_size: int,
+    max_pages: int,
+) -> tuple[list[str], str | None]:
+    """Page one ``parent``-scoped model-services listing to its end.
+
+    Returns (ids, reason) where ``reason`` is the last page's failure reason
+    (None on a clean walk, even when the schema is legitimately empty). ``ids``
+    holds every entry that survives ``required_prefix`` filtering; a
+    mid-pagination blip still returns whatever was collected so far."""
+    ids: list[str] = []
+    page_token: str | None = None
+    seen_tokens: set[str] = set()
+    last_reason: str | None = None
+    for _ in range(max_pages):
+        params: dict[str, str] = {"parent": parent, "page_size": str(page_size)}
+        if page_token:
+            params["page_token"] = page_token
+        url = f"https://{hostname}/api/2.1/unity-catalog/model-services?{urlencode(params)}"
+        payload, reason = _get_model_services_page(url, token)
+        if payload is None:
+            last_reason = reason
+            break
+        data = cast(dict, payload) if isinstance(payload, dict) else {}
+        for service in data.get("model_services", []):
+            if isinstance(service, dict):
+                model_id = _model_service_id(service, required_prefix=required_prefix)
+                if model_id:
+                    ids.append(model_id)
+        page_token = data.get("next_page_token") or None
+        if not page_token:
+            last_reason = None
+            break
+        if page_token in seen_tokens:
+            break
+        seen_tokens.add(page_token)
+    return ids, last_reason
+
+
 def list_model_services(
     workspace: str,
     token: str,
@@ -1603,16 +1676,21 @@ def list_model_services(
     max_pages: int = 100,
     use_cache: bool = True,
 ) -> tuple[list[str], str | None]:
-    """List all `system.ai.*` model ids via the UC model-services API.
+    """List `system.ai.*` (plus any opt-in extra-schema) model ids via the UC API.
 
     Pages through ``/api/2.1/unity-catalog/model-services`` scoped to the
     ``system.ai`` schema (``parent=schemas/system.ai``) with a bounded
     ``page_size`` (the endpoint 499s without one) and returns the de-duplicated,
-    sorted list of ``system.ai.<model-name>`` ids. Returns (ids, reason); reason
-    is None on success, otherwise it describes why the list is empty (HTTP/network
-    error or no services). Scoping matters: the unscoped metastore listing walks
-    every schema across dozens of ~2s pages (~50s on a busy workspace) only to
-    keep the same ``system.ai.*`` subset — see ``_MODEL_SERVICE_PARENT_SCHEMA``.
+    sorted list of ``<catalog>.<schema>.<model-name>`` ids. Returns (ids, reason);
+    reason is None on success, otherwise it describes why the list is empty
+    (HTTP/network error or no services). Scoping matters: the unscoped metastore
+    listing walks every schema across dozens of ~2s pages (~50s on a busy
+    workspace) only to keep the same ``system.ai.*`` subset — see
+    ``_MODEL_SERVICE_PARENT_SCHEMA``.
+
+    Workspaces whose model services live outside ``system.ai`` can name those
+    schemas in ``UCODE_MODEL_SERVICE_SCHEMAS``; each is walked with its own scope
+    and merged in (see ``_extra_model_service_schemas``).
 
     A successful result is memoized per workspace for the life of the process; pass
     ``use_cache=False`` to force a fresh walk.
@@ -1623,37 +1701,32 @@ def list_model_services(
             return list(cached), None
 
     hostname = workspace_hostname(workspace)
-    ids: list[str] = []
-    page_token: str | None = None
-    seen_tokens: set[str] = set()
-    last_reason: str | None = None
-    for _ in range(max_pages):
-        params: dict[str, str] = {
-            "parent": _MODEL_SERVICE_PARENT_SCHEMA,
-            "page_size": str(page_size),
-        }
-        if page_token:
-            params["page_token"] = page_token
-        url = f"https://{hostname}/api/2.1/unity-catalog/model-services?{urlencode(params)}"
-        payload, reason = _get_model_services_page(url, token)
-        if payload is None:
-            # Surface the failure only if we have nothing yet; a mid-pagination
-            # blip still returns whatever we collected.
-            last_reason = reason
-            break
-        data = cast(dict, payload) if isinstance(payload, dict) else {}
-        for service in data.get("model_services", []):
-            if isinstance(service, dict):
-                model_id = _model_service_id(service)
-                if model_id:
-                    ids.append(model_id)
-        page_token = data.get("next_page_token") or None
-        if not page_token:
+    # Primary: the `system.ai` schema (one fast scoped page on most workspaces).
+    ids, last_reason = _walk_model_services(
+        hostname,
+        token,
+        _MODEL_SERVICE_PARENT_SCHEMA,
+        required_prefix=_MODEL_SERVICE_REQUIRED_PREFIX,
+        page_size=page_size,
+        max_pages=max_pages,
+    )
+    # Opt-in: additional catalog.schema locations for workspaces whose model
+    # services live outside system.ai. Each is scoped to its own schema, so the
+    # `parent` query already trusts every returned id (required_prefix="").
+    for schema in _extra_model_service_schemas():
+        extra_ids, extra_reason = _walk_model_services(
+            hostname,
+            token,
+            f"schemas/{schema}",
+            required_prefix="",
+            page_size=page_size,
+            max_pages=max_pages,
+        )
+        ids.extend(extra_ids)
+        # A clean extra walk clears an earlier `system.ai` failure only when it
+        # actually contributed models; otherwise keep the original reason.
+        if extra_ids and extra_reason is None:
             last_reason = None
-            break
-        if page_token in seen_tokens:
-            break
-        seen_tokens.add(page_token)
 
     deduped = sorted(set(ids))
     if deduped:
@@ -1732,7 +1805,7 @@ def model_service_exists(
 
 
 def discover_claude_models_unbucketed(workspace: str, token: str) -> tuple[list[str], str | None]:
-    """Every `system.ai.claude-*` id on the workspace, unbucketed.
+    """Every Claude model-service id on the workspace, unbucketed.
 
     `discover_model_services` keeps only the newest id per family because the launch path pins one
     model per Claude family alias. An admin authoring a managed config needs the alternatives too

--- a/tests/test_databricks.py
+++ b/tests/test_databricks.py
@@ -452,6 +452,132 @@ class TestDiscoverModelServices:
         assert calls["n"] == 3  # two failures, third succeeds
 
 
+class TestExtraModelServiceSchemas:
+    """UCODE_MODEL_SERVICE_SCHEMAS opts a workspace into searching model-service
+    schemas outside system.ai (e.g. a workspace whose Claude models live in
+    `model_service_catalog.default`)."""
+
+    def test_env_parsing_dedupes_and_trims(self, monkeypatch):
+        monkeypatch.setenv(
+            "UCODE_MODEL_SERVICE_SCHEMAS",
+            " model_service_catalog.default , main.foo ,, model_service_catalog.default ",
+        )
+        assert db_mod._extra_model_service_schemas() == [
+            "model_service_catalog.default",
+            "main.foo",
+        ]
+
+    def test_env_unset_is_empty(self, monkeypatch):
+        monkeypatch.delenv("UCODE_MODEL_SERVICE_SCHEMAS", raising=False)
+        assert db_mod._extra_model_service_schemas() == []
+
+    @staticmethod
+    def _payload_by_parent(services_by_parent: dict[str, list[str]]):
+        """Fake `_http_get_json` that serves a schema's services keyed by its
+        `parent=schemas/...` scope, so each scoped walk gets its own listing."""
+
+        def fake_get(url, token, timeout=10):
+            # urlencode leaves dots/underscores unencoded, so the parent scope
+            # appears verbatim after `schemas%2F`.
+            for parent, model_ids in services_by_parent.items():
+                if f"parent=schemas%2F{parent}" in url:
+                    return {"model_services": [_model_service(m) for m in model_ids]}, None
+            return {"model_services": []}, None
+
+        return fake_get
+
+    def test_discovers_claude_models_in_extra_schema(self, monkeypatch):
+        # system.ai is empty; the three Claude models live in a custom catalog.
+        monkeypatch.setenv("UCODE_MODEL_SERVICE_SCHEMAS", "model_service_catalog.default")
+        monkeypatch.setattr(
+            db_mod,
+            "_http_get_json",
+            self._payload_by_parent(
+                {
+                    "system.ai": [],
+                    "model_service_catalog.default": [
+                        "model_service_catalog.default.claude-opus-5",
+                        "model_service_catalog.default.claude-sonnet-5",
+                        "model_service_catalog.default.claude-haiku-4-5",
+                    ],
+                }
+            ),
+        )
+
+        claude, codex, gemini, oss, reason = db_mod.discover_model_services(WS, "token")
+
+        assert reason is None
+        assert claude == {
+            "opus": "model_service_catalog.default.claude-opus-5",
+            "sonnet": "model_service_catalog.default.claude-sonnet-5",
+            "haiku": "model_service_catalog.default.claude-haiku-4-5",
+        }
+        assert (codex, gemini, oss) == ([], [], [])
+
+    def test_extra_walk_is_scoped_to_its_own_schema(self, monkeypatch):
+        monkeypatch.setenv("UCODE_MODEL_SERVICE_SCHEMAS", "model_service_catalog.default")
+        urls: list[str] = []
+
+        def fake_get(url, token, timeout=10):
+            urls.append(url)
+            if "parent=schemas%2Fmodel_service_catalog.default" in url:
+                return {
+                    "model_services": [
+                        _model_service("model_service_catalog.default.claude-opus-5")
+                    ]
+                }, None
+            return {"model_services": []}, None
+
+        monkeypatch.setattr(db_mod, "_http_get_json", fake_get)
+
+        ids, reason = db_mod.list_model_services(WS, "token")
+
+        assert reason is None
+        assert ids == ["model_service_catalog.default.claude-opus-5"]
+        # Both the system.ai scope and the extra schema's own scope were queried.
+        assert any("parent=schemas%2Fsystem.ai" in u for u in urls)
+        assert any("parent=schemas%2Fmodel_service_catalog.default" in u for u in urls)
+
+    def test_extra_schema_ids_join_system_ai_ids(self, monkeypatch):
+        monkeypatch.setenv("UCODE_MODEL_SERVICE_SCHEMAS", "model_service_catalog.default")
+        monkeypatch.setattr(
+            db_mod,
+            "_http_get_json",
+            self._payload_by_parent(
+                {
+                    "system.ai": ["system.ai.gpt-5"],
+                    "model_service_catalog.default": [
+                        "model_service_catalog.default.claude-opus-5"
+                    ],
+                }
+            ),
+        )
+
+        claude, codex, gemini, oss, reason = db_mod.discover_model_services(WS, "token")
+
+        assert reason is None
+        assert codex == ["system.ai.gpt-5"]
+        assert claude == {"opus": "model_service_catalog.default.claude-opus-5"}
+
+    def test_env_unset_ignores_custom_catalog(self, monkeypatch):
+        # Without the opt-in, a custom-catalog service is never picked up even if
+        # the endpoint were to return it (the system.ai prefix filter drops it).
+        monkeypatch.delenv("UCODE_MODEL_SERVICE_SCHEMAS", raising=False)
+        payload = {
+            "model_services": [
+                _model_service("model_service_catalog.default.claude-opus-5"),
+            ]
+        }
+        monkeypatch.setattr(
+            db_mod, "_http_get_json", lambda url, token, timeout=10: (payload, None)
+        )
+
+        claude, codex, gemini, oss, reason = db_mod.discover_model_services(WS, "token")
+
+        assert claude == {}
+        assert reason is not None
+
+
 class TestModelServiceExists:
     def test_true_when_listed_in_its_schema(self, monkeypatch):
         urls: list[str] = []


### PR DESCRIPTION
## Problem

`ug claude` (and the other agents) report "No coding agents are available on this workspace" even when the workspace has Claude model services available. Repro: a workspace with three Claude model services (`il-claude-haiku-4-5`, `il-claude-opus-5`, `il-claude-sonnet-5`) whose Location is a custom UC catalog (`il_model_service.default` in the report), and no foundation-model endpoints. `ug` finds nothing:

```
ERROR No coding agents are available on this workspace.
 Claude models (needed for: claude, opencode, copilot, pi): AI Gateway returned no Claude model ids
 ...
 OSS models (needed for: opencode): model-services listing returned no models
```

See #569 for the full trace.

## Root cause

Model-service discovery is hardcoded to the `system.ai` schema in two places:

- `_MODEL_SERVICE_PARENT_SCHEMA = "schemas/system.ai"` scopes the server-side query, so the API only returns services in `system.ai`.
- `_model_service_id()` drops any name that doesn't start with `system.ai.`.

Model services in a custom UC catalog are invisible to both. This is family-agnostic: `discover_model_services()` buckets claude/codex/gemini/oss out of the same single `system.ai`-scoped walk, so a custom-catalog GPT/Gemini/OSS service would be missed the same way. The per-family fallbacks don't help either, because they look at foundation-model endpoints, not UC model services in other catalogs.

## Fix

Add an opt-in `UCODE_MODEL_SERVICE_SCHEMAS` env var: a comma-separated list of `catalog.schema` locations to search in addition to `system.ai`. Each is walked with its own `parent=schemas/{catalog}.{schema}` scope (one fast page, same as `system.ai`) and merged into the result.

This deliberately stays opt-in. `system.ai` remains the default, and when the var is unset the behavior is unchanged, so the common case never scoops up unrelated user schemas (the existing `test_ignores_non_system_ai_schemas` still holds). The paging loop is refactored into `_walk_model_services` so the `system.ai` walk and the extra-schema walks share it.

Usage — point discovery at the `catalog.schema` where your model services live:

```
export UCODE_MODEL_SERVICE_SCHEMAS=model_service_catalog.default   # your catalog.schema
ug claude
```

## Testing

- New `TestExtraModelServiceSchemas` covers env parsing (trim/dedupe/blank), discovery of Claude models in an extra schema, per-schema scoping of the extra walk, merging with `system.ai` ids, and the env-unset case still ignoring custom catalogs.
- Full `tests/test_databricks.py` passes (266), `ruff check` and `ruff format --check` clean.
- The 3 `test_claude_smart_routing_v2` PTY failures and the `test_e2e_user_agent` failure reproduce on a clean checkout in this sandbox (local socket / live-gateway env issues), unrelated to this change.

## Notes / open questions

- Scope is discovery only, which is the reported symptom. A custom-catalog id like `model_service_catalog.default.claude-opus-5` flows through launch fine; the only cosmetic gap is `_maybe_add_1m_suffix` not recognizing it for the auto `[1m]` suffix (its regex expects `system.ai.`/`databricks-` prefixes). Happy to widen that too if you'd like.
- Open to an alternative shape if you'd prefer auto-discovery of catalogs over an env var, but I leaned opt-in to preserve the intentional "don't pick up scratch schemas" behavior.

Fixes #569

This pull request and its description were written by Isaac.
