### PR TITLE
use codex custom catalog for smart routing if exists 

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -1330,7 +1330,7 @@ def launch(
     if state.get("claude_relayed"):
         _launch_relayed(state, binary, tool_args)
         return
-    # Smart routing v2 needs Unix PTY support, which Windows does not provide.
+    # Smart routing needs Unix PTY support, which Windows does not provide.
     if options.launch_smart_routing and os.name == "nt":
         raise RuntimeError(
             "Smart routing in Claude Code is currently not supported on Windows. "

--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -12,11 +12,10 @@ import tomlkit
 from tomlkit.exceptions import ParseError
 
 from ucode.codex_config import (
-    CODEX_PROFILE_NAME,
-    DEFAULT_CODEX_CONFIG_PATH,
     codex_config_args,
     codex_config_precedence_paths,
     codex_managed_config_path,
+    custom_catalog_models,
 )
 from ucode.config_io import (
     APP_DIR,
@@ -57,8 +56,9 @@ from ucode.ui import print_warning_err
 
 from .args import LaunchOptions
 
-CODEX_CONFIG_PATH = DEFAULT_CODEX_CONFIG_PATH
-CODEX_CONFIG_DIR = CODEX_CONFIG_PATH.parent
+CODEX_CONFIG_DIR = Path.home() / ".codex"
+CODEX_PROFILE_NAME = "ucode"
+CODEX_CONFIG_PATH = CODEX_CONFIG_DIR / f"{CODEX_PROFILE_NAME}.config.toml"
 CODEX_BACKUP_PATH = APP_DIR / "codex-ucode-config.backup.toml"
 LEGACY_CODEX_CONFIG_PATH = CODEX_CONFIG_DIR / "config.toml"
 LEGACY_CODEX_BACKUP_PATH = APP_DIR / "codex-config.backup.toml"
@@ -582,7 +582,7 @@ def _launch_smart_routing(state: dict, tool_args: list[str]) -> None:
         )
 
     configured_model = _smart_routing_config_model(state)
-    models = smart_routing_v2.custom_catalog_models() or routing_models(state)
+    models = custom_catalog_models() or routing_models(state)
     start_model = (
         configured_model
         or (codex_model_id(models[0]) if models else None)

--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -500,19 +500,27 @@ def _smart_routing_config_model(state: dict) -> str | None:
     model = state.get("codex_default_model")
     if isinstance(model, str) and model.strip():
         return model
+
+    for path in config_precedence_paths():
+        model = read_toml_safe(path).get("model")
+        if isinstance(model, str) and model.strip():
+            return model
+    return None
+
+
+def config_precedence_paths() -> tuple[Path, ...]:
+    """Return Codex config paths in managed, profile, then user precedence."""
     config_home = os.environ.get("CODEX_HOME")
     profile_path = (
         Path(config_home).expanduser() / f"{CODEX_PROFILE_NAME}.config.toml"
         if config_home
         else CODEX_CONFIG_PATH
     )
-    for path in (_managed_config_path(), profile_path, profile_path.parent / "config.toml"):
-        if path is None:
-            continue
-        model = read_toml_safe(path).get("model")
-        if isinstance(model, str) and model.strip():
-            return model
-    return None
+    return tuple(
+        path
+        for path in (_managed_config_path(), profile_path, profile_path.parent / "config.toml")
+        if path is not None
+    )
 
 
 def clear_model_preferences(state: dict) -> bool:

--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -579,13 +579,8 @@ def _launch_smart_routing(state: dict, tool_args: list[str]) -> None:
             f"{MINIMUM_ROUTING_CODEX_VERSION_TEXT} or newer; found {version_text}."
         )
 
-<<<<<<< Updated upstream
     configured_model = _smart_routing_config_model(state)
-    models = routing_models(state)
-=======
-    managed_model = default_model(state)
     models = smart_routing_v2.custom_catalog_models() or routing_models(state)
->>>>>>> Stashed changes
     start_model = (
         configured_model
         or (codex_model_id(models[0]) if models else None)

--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -577,6 +577,7 @@ def _launch_smart_routing(state: dict, tool_args: list[str]) -> None:
         )
 
     configured_model = _smart_routing_config_model(state)
+    # Prefer the custom catalog if it exists.
     models = custom_catalog_models() or routing_models(state)
     start_model = (
         configured_model

--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -395,11 +395,6 @@ def _is_gpt_family(model: str) -> bool:
     return tail.startswith("gpt-")
 
 
-def _managed_config_path() -> Path | None:
-    """Return Codex's managed config path on platforms supported by ucode's sudo writer."""
-    return codex_managed_config_path()
-
-
 def _parse_managed_config(text: str) -> dict:
     try:
         return tomlkit.parse(text)
@@ -408,7 +403,7 @@ def _parse_managed_config(text: str) -> dict:
 
 
 def managed_config_is_current(state: dict) -> bool:
-    path = _managed_config_path()
+    path = codex_managed_config_path()
     if path is None:
         return True
     required_scope = "managed" if managed_writes_allowed() else None
@@ -416,7 +411,7 @@ def managed_config_is_current(state: dict) -> bool:
 
 
 def managed_config_status(state: dict) -> tuple[Path | None, str, str]:
-    path = _managed_config_path()
+    path = codex_managed_config_path()
     status, backup = managed_file_status(state, "codex", path, parser=_parse_managed_config)
     return path, status, backup
 
@@ -432,7 +427,7 @@ def revert_managed_config() -> str:
 
 def _reconcile_managed_config(state: dict, compose: Callable[[dict], dict]) -> None:
     """Reconcile Codex's highest-precedence config while preserving unrelated policy."""
-    path = _managed_config_path()
+    path = codex_managed_config_path()
     if path is None:
         print_warning_err(
             "Machine-wide Codex settings aren't supported on this platform; skipped the managed "
@@ -512,7 +507,7 @@ def _smart_routing_config_model(state: dict) -> str | None:
 def config_precedence_paths() -> tuple[Path, ...]:
     """Return Codex config paths in managed, profile, then user precedence."""
     return codex_config_precedence_paths(
-        _managed_config_path(),
+        codex_managed_config_path(),
         CODEX_CONFIG_PATH,
     )
 

--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -579,8 +579,13 @@ def _launch_smart_routing(state: dict, tool_args: list[str]) -> None:
             f"{MINIMUM_ROUTING_CODEX_VERSION_TEXT} or newer; found {version_text}."
         )
 
+<<<<<<< Updated upstream
     configured_model = _smart_routing_config_model(state)
     models = routing_models(state)
+=======
+    managed_model = default_model(state)
+    models = smart_routing_v2.custom_catalog_models() or routing_models(state)
+>>>>>>> Stashed changes
     start_model = (
         configured_model
         or (codex_model_id(models[0]) if models else None)

--- a/src/ucode/agents/codex.py
+++ b/src/ucode/agents/codex.py
@@ -11,7 +11,13 @@ from pathlib import Path
 import tomlkit
 from tomlkit.exceptions import ParseError
 
-from ucode.codex_config import codex_config_args
+from ucode.codex_config import (
+    CODEX_PROFILE_NAME,
+    DEFAULT_CODEX_CONFIG_PATH,
+    codex_config_args,
+    codex_config_precedence_paths,
+    codex_managed_config_path,
+)
 from ucode.config_io import (
     APP_DIR,
     ToolSpec,
@@ -28,9 +34,7 @@ from ucode.databricks import (
 )
 from ucode.launcher import exec_or_spawn
 from ucode.managed_files import (
-    OS,
     ManagedFileWriteUnavailable,
-    current_os,
     managed_file_conflicts,
     managed_file_is_verified,
     managed_file_status,
@@ -53,9 +57,8 @@ from ucode.ui import print_warning_err
 
 from .args import LaunchOptions
 
-CODEX_CONFIG_DIR = Path.home() / ".codex"
-CODEX_PROFILE_NAME = "ucode"
-CODEX_CONFIG_PATH = CODEX_CONFIG_DIR / f"{CODEX_PROFILE_NAME}.config.toml"
+CODEX_CONFIG_PATH = DEFAULT_CODEX_CONFIG_PATH
+CODEX_CONFIG_DIR = CODEX_CONFIG_PATH.parent
 CODEX_BACKUP_PATH = APP_DIR / "codex-ucode-config.backup.toml"
 LEGACY_CODEX_CONFIG_PATH = CODEX_CONFIG_DIR / "config.toml"
 LEGACY_CODEX_BACKUP_PATH = APP_DIR / "codex-config.backup.toml"
@@ -394,9 +397,7 @@ def _is_gpt_family(model: str) -> bool:
 
 def _managed_config_path() -> Path | None:
     """Return Codex's managed config path on platforms supported by ucode's sudo writer."""
-    if current_os() in (OS.LINUX, OS.MACOS):
-        return Path("/etc/codex/managed_config.toml")
-    return None
+    return codex_managed_config_path()
 
 
 def _parse_managed_config(text: str) -> dict:
@@ -510,16 +511,9 @@ def _smart_routing_config_model(state: dict) -> str | None:
 
 def config_precedence_paths() -> tuple[Path, ...]:
     """Return Codex config paths in managed, profile, then user precedence."""
-    config_home = os.environ.get("CODEX_HOME")
-    profile_path = (
-        Path(config_home).expanduser() / f"{CODEX_PROFILE_NAME}.config.toml"
-        if config_home
-        else CODEX_CONFIG_PATH
-    )
-    return tuple(
-        path
-        for path in (_managed_config_path(), profile_path, profile_path.parent / "config.toml")
-        if path is not None
+    return codex_config_precedence_paths(
+        _managed_config_path(),
+        CODEX_CONFIG_PATH,
     )
 
 

--- a/src/ucode/codex_config.py
+++ b/src/ucode/codex_config.py
@@ -23,15 +23,22 @@ def codex_managed_config_path() -> Path | None:
 
 def codex_config_precedence_paths(
     managed_path: Path | None,
-    profile_path: Path = DEFAULT_CODEX_CONFIG_PATH,
+    profile_path: Path,
 ) -> tuple[Path, ...]:
     """Return Codex config paths in managed, profile, then user precedence."""
     config_home = os.environ.get("CODEX_HOME")
     if config_home:
         profile_path = Path(config_home).expanduser() / f"{CODEX_PROFILE_NAME}.config.toml"
+
+    # Highest precedence: machine-managed settings, normally /etc/codex/managed_config.toml.
+    managed_config = managed_path
+    # Middle precedence: Unity Gateway's ucode.config.toml layer passed to Codex via the CLI.
+    cli_config = profile_path
+    # Lowest precedence: $CODEX_HOME/config.toml, or ~/.codex/config.toml by default.
+    default_config = profile_path.parent / "config.toml"
     return tuple(
         path
-        for path in (managed_path, profile_path, profile_path.parent / "config.toml")
+        for path in (managed_config, cli_config, default_config)
         if path is not None
     )
 

--- a/src/ucode/codex_config.py
+++ b/src/ucode/codex_config.py
@@ -2,10 +2,38 @@
 
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping
+from pathlib import Path
 
 import tomlkit
 from tomlkit.items import Item
+
+from ucode.managed_files import OS, current_os
+
+CODEX_PROFILE_NAME = "ucode"
+DEFAULT_CODEX_CONFIG_PATH = Path.home() / ".codex" / f"{CODEX_PROFILE_NAME}.config.toml"
+
+
+def codex_managed_config_path() -> Path | None:
+    if current_os() in (OS.LINUX, OS.MACOS):
+        return Path("/etc/codex/managed_config.toml")
+    return None
+
+
+def codex_config_precedence_paths(
+    managed_path: Path | None,
+    profile_path: Path = DEFAULT_CODEX_CONFIG_PATH,
+) -> tuple[Path, ...]:
+    """Return Codex config paths in managed, profile, then user precedence."""
+    config_home = os.environ.get("CODEX_HOME")
+    if config_home:
+        profile_path = Path(config_home).expanduser() / f"{CODEX_PROFILE_NAME}.config.toml"
+    return tuple(
+        path
+        for path in (managed_path, profile_path, profile_path.parent / "config.toml")
+        if path is not None
+    )
 
 
 def _toml_item(value: object) -> Item:

--- a/src/ucode/codex_config.py
+++ b/src/ucode/codex_config.py
@@ -1,4 +1,4 @@
-"""Shared helpers for passing Codex configuration on the command line."""
+"""Shared Codex configuration helpers."""
 
 from __future__ import annotations
 
@@ -9,7 +9,9 @@ from pathlib import Path
 import tomlkit
 from tomlkit.items import Item
 
+from ucode.config_io import read_json_safe, read_toml_safe
 from ucode.managed_files import OS, current_os
+from ucode.ui import print_warning
 
 CODEX_PROFILE_NAME = "ucode"
 DEFAULT_CODEX_CONFIG_PATH = Path.home() / ".codex" / f"{CODEX_PROFILE_NAME}.config.toml"
@@ -41,6 +43,52 @@ def codex_config_precedence_paths(
         for path in (managed_config, cli_config, default_config)
         if path is not None
     )
+
+
+def custom_catalog_models() -> list[str] | None:
+    """Read model slugs from the configured model_catalog_json, if present."""
+    try:
+        paths = codex_config_precedence_paths(
+            codex_managed_config_path(),
+            DEFAULT_CODEX_CONFIG_PATH,
+        )
+    except OSError:
+        return None
+    for path in paths:
+        if not path.is_file():
+            continue
+        settings = read_toml_safe(path)
+        catalog_ref = settings.get("model_catalog_json")
+        if not isinstance(catalog_ref, str) or not catalog_ref.strip():
+            continue
+        slugs = _catalog_slugs(Path(catalog_ref).expanduser())
+        if slugs:
+            return slugs
+        print_warning(
+            f"Codex smart routing could not read models from the custom catalog {catalog_ref} "
+            f"referenced by {path}; falling back to the cached model services."
+        )
+        return None
+    return None
+
+
+def _catalog_slugs(path: Path) -> list[str]:
+    """Extract deduplicated model slugs from a Codex custom catalog JSON file."""
+    catalog = read_json_safe(path)
+    models = catalog.get("models")
+    if not isinstance(models, list):
+        return []
+    slugs: list[str] = []
+    seen: set[str] = set()
+    for row in models:
+        if not isinstance(row, dict) or not isinstance(row.get("slug"), str):
+            continue
+        slug = row["slug"].strip()
+        if not slug or slug in seen:
+            continue
+        seen.add(slug)
+        slugs.append(slug)
+    return slugs
 
 
 def _toml_item(value: object) -> Item:

--- a/src/ucode/codex_config.py
+++ b/src/ucode/codex_config.py
@@ -38,11 +38,7 @@ def codex_config_precedence_paths(
     cli_config = profile_path
     # Lowest precedence: $CODEX_HOME/config.toml, or ~/.codex/config.toml by default.
     default_config = profile_path.parent / "config.toml"
-    return tuple(
-        path
-        for path in (managed_config, cli_config, default_config)
-        if path is not None
-    )
+    return tuple(path for path in (managed_config, cli_config, default_config) if path is not None)
 
 
 def custom_catalog_models() -> list[str] | None:

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -392,7 +392,7 @@ def launch_claude(
     workspace = state.get("workspace")
     if not workspace:
         raise RuntimeError(
-            "Smart routing v2 needs a configured workspace; run `ucode configure claude` first."
+            "Smart routing needs a configured workspace; run `ucode configure claude` first."
         )
     token = get_databricks_token(workspace, state.get("profile"))
     os.environ[OAUTH_TOKEN_ENV_VAR] = token
@@ -449,7 +449,7 @@ def launch_claude(
         )
 
     print_note(
-        "Smart routing v2: the first submitted prompt will select Claude Code's "
+        "Smart routing: the first submitted prompt will select Claude Code's "
         f"model; log: {CLAUDE_PTY_LOG}."
     )
     try:
@@ -504,11 +504,11 @@ def launch_codex(
     workspace = state.get("workspace")
     if not workspace:
         raise RuntimeError(
-            "Smart routing v2 needs a configured workspace; run `ucode configure codex` first."
+            "Smart routing needs a configured workspace; run `ucode configure codex` first."
         )
     if not start_model:
         raise RuntimeError(
-            "Smart routing v2 could not determine a starting Codex model for this workspace."
+            "Smart routing could not determine a starting Codex model for this workspace."
         )
 
     profile = state.get("profile")
@@ -517,7 +517,7 @@ def launch_codex(
     available_models = catalog_models or _cached_routing_models(state)
     if catalog_models:
         print_note(
-            f"Smart routing v2: routing across {len(catalog_models)} models from the configured "
+            f"Smart routing: routing across {len(catalog_models)} models from the configured "
             "Codex custom catalog (model_catalog_json); cached model services are not used."
         )
     if not available_models:
@@ -551,7 +551,7 @@ def launch_codex(
     try:
         if not _wait_for_app_server(app_port, timeout=APP_SERVER_READY_TIMEOUT_SECONDS):
             raise RuntimeError(
-                "Codex app-server did not become ready for smart routing v2; check workspace auth."
+                "Codex app-server did not become ready for smart routing; check workspace auth."
             )
         tui_port, stop_interposer = codex_interposer.start_interposer_thread(
             LOOPBACK_HOST,

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -15,7 +15,12 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import NoReturn, TextIO
 
-from ucode.codex_config import codex_config_args
+from ucode.codex_config import (
+    DEFAULT_CODEX_CONFIG_PATH,
+    codex_config_args,
+    codex_config_precedence_paths,
+    codex_managed_config_path,
+)
 from ucode.config_io import APP_DIR, read_json_safe, read_toml_safe, write_json_file
 from ucode.constants import LOOPBACK_HOST
 from ucode.databricks import (
@@ -107,10 +112,11 @@ def custom_catalog_models() -> list[str] | None:
     administrator exposed, so there is no need to read the cached model services.
     """
     try:
-        from ucode.agents.codex import config_precedence_paths
-
-        paths = config_precedence_paths()
-    except (ImportError, OSError):
+        paths = codex_config_precedence_paths(
+            codex_managed_config_path(),
+            DEFAULT_CODEX_CONFIG_PATH,
+        )
+    except OSError:
         return None
     for path in paths:
         if path is None or not path.is_file():
@@ -522,9 +528,10 @@ def _cached_routing_models(state: dict) -> list[str]:
 
 
 def _codex_home_config_path() -> Path:
-    from ucode.agents.codex import config_precedence_paths
-
-    return config_precedence_paths()[-1]
+    codex_home = os.environ.get("CODEX_HOME")
+    if codex_home:
+        return Path(codex_home).expanduser() / "config.toml"
+    return Path.home() / ".codex" / "config.toml"
 
 
 def _v2_pre_tool_use_hooks(state: dict, available_models: list[str]) -> list[dict]:

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -107,11 +107,9 @@ def custom_catalog_models() -> list[str] | None:
     administrator exposed, so there is no need to read the cached model services.
     """
     try:
-        from ucode.agents.codex import CODEX_CONFIG_PATH, _managed_config_path
+        from ucode.agents.codex import config_precedence_paths
 
-        # Hierarchy: managed settings, CLI-supplied settings (the ucode profile config passed as
-        # `--config` overrides), then the local `$CODEX_HOME/config.toml`.
-        paths = [_managed_config_path(), CODEX_CONFIG_PATH, _codex_home_config_path()]
+        paths = config_precedence_paths()
     except (ImportError, OSError):
         return None
     for path in paths:
@@ -524,10 +522,9 @@ def _cached_routing_models(state: dict) -> list[str]:
 
 
 def _codex_home_config_path() -> Path:
-    codex_home = os.environ.get("CODEX_HOME")
-    if codex_home:
-        return Path(codex_home).expanduser() / "config.toml"
-    return Path.home() / ".codex" / "config.toml"
+    from ucode.agents.codex import config_precedence_paths
+
+    return config_precedence_paths()[-1]
 
 
 def _v2_pre_tool_use_hooks(state: dict, available_models: list[str]) -> list[dict]:

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -16,10 +16,8 @@ from pathlib import Path
 from typing import NoReturn, TextIO
 
 from ucode.codex_config import (
-    DEFAULT_CODEX_CONFIG_PATH,
     codex_config_args,
-    codex_config_precedence_paths,
-    codex_managed_config_path,
+    custom_catalog_models,
 )
 from ucode.config_io import APP_DIR, read_json_safe, read_toml_safe, write_json_file
 from ucode.constants import LOOPBACK_HOST
@@ -37,7 +35,7 @@ from ucode.smart_routing.claude_hooks import (
     sync_smart_routing_hooks,
 )
 from ucode.smart_routing.codex_hooks import merge_pre_tool_use_hooks, routing_models
-from ucode.ui import print_note, print_warning
+from ucode.ui import print_note
 
 ENV_VAR = "ENABLE_SMART_ROUTING_V2"
 LEGACY_STATE_KEY = "smart_routing_enabled"
@@ -103,56 +101,6 @@ def _model_picker_catalog() -> AnthropicModelCatalog | None:
         if model_ids:
             return AnthropicModelCatalog(model_ids, {})
     return None
-
-
-def custom_catalog_models() -> list[str] | None:
-    """Read model slugs from a model_catalog_json custom catalog, when one is configured.
-
-    A custom catalog is authoritative for smart routing: its models are the ones the
-    administrator exposed, so there is no need to read the cached model services.
-    """
-    try:
-        paths = codex_config_precedence_paths(
-            codex_managed_config_path(),
-            DEFAULT_CODEX_CONFIG_PATH,
-        )
-    except OSError:
-        return None
-    for path in paths:
-        if path is None or not path.is_file():
-            continue
-        settings = read_toml_safe(path)
-        catalog_ref = settings.get("model_catalog_json")
-        if not isinstance(catalog_ref, str) or not catalog_ref.strip():
-            continue
-        slugs = _catalog_slugs(Path(catalog_ref).expanduser())
-        if slugs:
-            return slugs
-        print_warning(
-            f"Codex smart routing could not read models from the custom catalog {catalog_ref} "
-            f"referenced by {path}; falling back to the cached model services."
-        )
-        return None
-    return None
-
-
-def _catalog_slugs(path: Path) -> list[str]:
-    """Extract deduplicated model slugs from a Codex custom catalog JSON file."""
-    catalog = read_json_safe(path)
-    models = catalog.get("models")
-    if not isinstance(models, list):
-        return []
-    slugs: list[str] = []
-    seen: set[str] = set()
-    for row in models:
-        if not isinstance(row, dict) or not isinstance(row.get("slug"), str):
-            continue
-        slug = row["slug"].strip()
-        if not slug or slug in seen:
-            continue
-        seen.add(slug)
-        slugs.append(slug)
-    return slugs
 
 
 def enabled() -> bool:

--- a/src/ucode/smart_routing/v2.py
+++ b/src/ucode/smart_routing/v2.py
@@ -32,7 +32,7 @@ from ucode.smart_routing.claude_hooks import (
     sync_smart_routing_hooks,
 )
 from ucode.smart_routing.codex_hooks import merge_pre_tool_use_hooks, routing_models
-from ucode.ui import print_note
+from ucode.ui import print_note, print_warning
 
 ENV_VAR = "ENABLE_SMART_ROUTING_V2"
 LEGACY_STATE_KEY = "smart_routing_enabled"
@@ -98,6 +98,57 @@ def _model_picker_catalog() -> AnthropicModelCatalog | None:
         if model_ids:
             return AnthropicModelCatalog(model_ids, {})
     return None
+
+
+def custom_catalog_models() -> list[str] | None:
+    """Read model slugs from a model_catalog_json custom catalog, when one is configured.
+
+    A custom catalog is authoritative for smart routing: its models are the ones the
+    administrator exposed, so there is no need to read the cached model services.
+    """
+    try:
+        from ucode.agents.codex import CODEX_CONFIG_PATH, _managed_config_path
+
+        # Hierarchy: managed settings, CLI-supplied settings (the ucode profile config passed as
+        # `--config` overrides), then the local `$CODEX_HOME/config.toml`.
+        paths = [_managed_config_path(), CODEX_CONFIG_PATH, _codex_home_config_path()]
+    except (ImportError, OSError):
+        return None
+    for path in paths:
+        if path is None or not path.is_file():
+            continue
+        settings = read_toml_safe(path)
+        catalog_ref = settings.get("model_catalog_json")
+        if not isinstance(catalog_ref, str) or not catalog_ref.strip():
+            continue
+        slugs = _catalog_slugs(Path(catalog_ref).expanduser())
+        if slugs:
+            return slugs
+        print_warning(
+            f"Codex smart routing could not read models from the custom catalog {catalog_ref} "
+            f"referenced by {path}; falling back to the cached model services."
+        )
+        return None
+    return None
+
+
+def _catalog_slugs(path: Path) -> list[str]:
+    """Extract deduplicated model slugs from a Codex custom catalog JSON file."""
+    catalog = read_json_safe(path)
+    models = catalog.get("models")
+    if not isinstance(models, list):
+        return []
+    slugs: list[str] = []
+    seen: set[str] = set()
+    for row in models:
+        if not isinstance(row, dict) or not isinstance(row.get("slug"), str):
+            continue
+        slug = row["slug"].strip()
+        if not slug or slug in seen:
+            continue
+        seen.add(slug)
+        slugs.append(slug)
+    return slugs
 
 
 def enabled() -> bool:
@@ -510,7 +561,13 @@ def launch_codex(
 
     profile = state.get("profile")
     os.environ[OAUTH_TOKEN_ENV_VAR] = get_databricks_token(workspace, profile)
-    available_models = _cached_routing_models(state)
+    catalog_models = custom_catalog_models()
+    available_models = catalog_models or _cached_routing_models(state)
+    if catalog_models:
+        print_note(
+            f"Smart routing v2: routing across {len(catalog_models)} models from the configured "
+            "Codex custom catalog (model_catalog_json); cached model services are not used."
+        )
     if not available_models:
         print_note(
             f"Smart routing model metadata is unavailable; starting Codex on {start_model} "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def _isolate_ucode_state(tmp_path, monkeypatch):
     monkeypatch.setattr(
         managed_files_mod, "MANAGED_BACKUP_MANIFEST_PATH", backup_dir / "manifest.json"
     )
-    monkeypatch.setattr(codex_mod, "_managed_config_path", lambda: None)
+    monkeypatch.setattr(codex_mod, "codex_managed_config_path", lambda: None)
 
     def reject_privileged_write(path, _desired_text):
         pytest.fail(

--- a/tests/test_agent_codex.py
+++ b/tests/test_agent_codex.py
@@ -723,7 +723,7 @@ class TestCodexManagedConfig:
         monkeypatch.setattr(codex, "managed_writes_allowed", lambda: True)
         # Deterministic managed path + a mocked sudo writer that writes straight to disk, so the test
         # can read the TOML back and NO real sudo/`/etc` write ever happens.
-        monkeypatch.setattr(codex, "_managed_config_path", lambda: managed_path)
+        monkeypatch.setattr(codex, "codex_managed_config_path", lambda: managed_path)
 
         def fake_write_managed(path, text, **kwargs):
             Path(path).parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -387,42 +387,25 @@ class TestCustomCatalogModels:
         monkeypatch.setattr(codex, "_managed_config_path", lambda: managed_path)
         monkeypatch.setattr(codex, "CODEX_CONFIG_PATH", cli_path)
 
-    def test_managed_catalog_wins_over_cli_and_local(self, tmp_path, monkeypatch):
-        self._settings(
-            tmp_path,
-            monkeypatch,
-            managed=self._catalog(tmp_path / "managed.json", ["gpt-6-astra"]),
-            cli=self._catalog(tmp_path / "cli.json", ["gpt-6-b"]),
-            local=self._catalog(tmp_path / "local.json", ["gpt-6-c"]),
+    @pytest.mark.parametrize(
+        ("catalogs", "expected"),
+        [
+            (("gpt-managed", "gpt-profile", "gpt-user"), ["gpt-managed"]),
+            ((None, "gpt-profile", "gpt-user"), ["gpt-profile"]),
+            ((None, None, "gpt-user"), ["gpt-user"]),
+            ((None, None, None), None),
+        ],
+    )
+    def test_config_precedence(self, tmp_path, monkeypatch, catalogs, expected):
+        managed, cli, local = (
+            self._catalog(tmp_path / f"{name}.json", [slug]) if slug else None
+            for name, slug in zip(("managed", "cli", "local"), catalogs, strict=True)
         )
+        self._settings(tmp_path, monkeypatch, managed=managed, cli=cli, local=local)
 
-        assert v2.custom_catalog_models() == ["gpt-6-astra"]
+        assert v2.custom_catalog_models() == expected
 
-    def test_cli_catalog_wins_over_local(self, tmp_path, monkeypatch):
-        self._settings(
-            tmp_path,
-            monkeypatch,
-            cli=self._catalog(tmp_path / "cli.json", ["gpt-6-b"]),
-            local=self._catalog(tmp_path / "local.json", ["gpt-6-c"]),
-        )
-
-        assert v2.custom_catalog_models() == ["gpt-6-b"]
-
-    def test_local_catalog_used_when_managed_and_cli_define_none(self, tmp_path, monkeypatch):
-        self._settings(
-            tmp_path,
-            monkeypatch,
-            local=self._catalog(tmp_path / "local.json", ["gpt-6-c"]),
-        )
-
-        assert v2.custom_catalog_models() == ["gpt-6-c"]
-
-    def test_no_catalog_anywhere_returns_none(self, tmp_path, monkeypatch):
-        self._settings(tmp_path, monkeypatch)
-
-        assert v2.custom_catalog_models() is None
-
-    def test_unreadable_catalog_falls_back_with_warning(self, tmp_path, monkeypatch):
+    def test_unreadable_catalog_warns_and_falls_back(self, tmp_path, monkeypatch):
         self._settings(tmp_path, monkeypatch, cli=tmp_path / "missing.json")
         warnings = []
         monkeypatch.setattr(v2, "print_warning", warnings.append)
@@ -430,35 +413,6 @@ class TestCustomCatalogModels:
         assert v2.custom_catalog_models() is None
         assert len(warnings) == 1
         assert "falling back to the cached model services" in warnings[0]
-
-    def test_empty_catalog_falls_back_with_warning(self, tmp_path, monkeypatch):
-        self._settings(tmp_path, monkeypatch, cli=self._catalog(tmp_path / "empty.json", []))
-        warnings = []
-        monkeypatch.setattr(v2, "print_warning", warnings.append)
-
-        assert v2.custom_catalog_models() is None
-        assert len(warnings) == 1
-
-    def test_slugs_are_deduped_and_invalid_rows_skipped(self, tmp_path, monkeypatch):
-        catalog = tmp_path / "catalog.json"
-        catalog.write_text(
-            json.dumps(
-                {
-                    "models": [
-                        {"slug": "gpt-6-astra"},
-                        {"slug": " gpt-6-astra "},
-                        {"slug": ""},
-                        {"slug": 42},
-                        "not-a-row",
-                        {"slug": "gpt-6-b"},
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-        self._settings(tmp_path, monkeypatch, cli=catalog)
-
-        assert v2.custom_catalog_models() == ["gpt-6-astra", "gpt-6-b"]
 
     def test_launch_prefers_catalog_over_cached_models(self, tmp_path, monkeypatch):
         self._settings(

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -367,41 +367,53 @@ class TestCustomCatalogModels:
         )
         return path
 
-    def _settings(self, tmp_path, monkeypatch, *, managed=None, cli=None, local=None):
+    def _settings(self, tmp_path, monkeypatch, *, managed=None, cli=None, default=None):
         home = tmp_path / "codex-home"
         home.mkdir()
         monkeypatch.setenv("CODEX_HOME", str(home))
         managed_path = tmp_path / "managed_config.toml"
         cli_path = home / "ucode.config.toml"
-        local_path = home / "config.toml"
+        default_path = home / "config.toml"
         for path, catalog in (
             (managed_path, managed),
             (cli_path, cli),
-            (local_path, local),
+            (default_path, default),
         ):
             if catalog:
                 text = "model_catalog_json = " + json.dumps(str(catalog)) + "\n"
             else:
                 text = 'model = "gpt-5"\n'
             path.write_text(text, encoding="utf-8")
-        monkeypatch.setattr(codex, "_managed_config_path", lambda: managed_path)
-        monkeypatch.setattr(codex, "CODEX_CONFIG_PATH", cli_path)
+        monkeypatch.setattr(v2, "codex_managed_config_path", lambda: managed_path)
+        monkeypatch.setattr(v2, "DEFAULT_CODEX_CONFIG_PATH", cli_path)
 
     @pytest.mark.parametrize(
-        ("catalogs", "expected"),
+        ("managed_catalog", "cli_catalog", "default_catalog", "expected"),
         [
-            (("gpt-managed", "gpt-profile", "gpt-user"), ["gpt-managed"]),
-            ((None, "gpt-profile", "gpt-user"), ["gpt-profile"]),
-            ((None, None, "gpt-user"), ["gpt-user"]),
-            ((None, None, None), None),
+            ("gpt-managed", "gpt-cli", "gpt-default", ["gpt-managed"]),
+            (None, "gpt-cli", "gpt-default", ["gpt-cli"]),
+            (None, None, "gpt-default", ["gpt-default"]),
+            (None, None, None, None),
         ],
     )
-    def test_config_precedence(self, tmp_path, monkeypatch, catalogs, expected):
-        managed, cli, local = (
+    def test_config_precedence(
+        self,
+        tmp_path,
+        monkeypatch,
+        managed_catalog,
+        cli_catalog,
+        default_catalog,
+        expected,
+    ):
+        managed, cli, default = (
             self._catalog(tmp_path / f"{name}.json", [slug]) if slug else None
-            for name, slug in zip(("managed", "cli", "local"), catalogs, strict=True)
+            for name, slug in (
+                ("managed", managed_catalog),
+                ("cli", cli_catalog),
+                ("default", default_catalog),
+            )
         )
-        self._settings(tmp_path, monkeypatch, managed=managed, cli=cli, local=local)
+        self._settings(tmp_path, monkeypatch, managed=managed, cli=cli, default=default)
 
         assert v2.custom_catalog_models() == expected
 
@@ -423,6 +435,8 @@ class TestCustomCatalogModels:
         monkeypatch.setattr(v2, "get_databricks_token", lambda *_args: "token")
         monkeypatch.setattr(v2, "_free_port", lambda: 41001)
         monkeypatch.setattr(v2, "_wait_for_app_server", lambda port, timeout: True)
+        monkeypatch.setattr(codex, "agent_version", lambda _binary: "0.145.0")
+        monkeypatch.setattr(codex, "ucode_version", lambda: "test")
         launched = []
 
         class FakeProcess:

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 
+from ucode import codex_config
 from ucode.agents import LaunchOptions, codex
 from ucode.smart_routing import codex_interposer, codex_routing, v2
 
@@ -384,8 +385,8 @@ class TestCustomCatalogModels:
             else:
                 text = 'model = "gpt-5"\n'
             path.write_text(text, encoding="utf-8")
-        monkeypatch.setattr(v2, "codex_managed_config_path", lambda: managed_path)
-        monkeypatch.setattr(v2, "DEFAULT_CODEX_CONFIG_PATH", cli_path)
+        monkeypatch.setattr(codex_config, "codex_managed_config_path", lambda: managed_path)
+        monkeypatch.setattr(codex_config, "DEFAULT_CODEX_CONFIG_PATH", cli_path)
 
     @pytest.mark.parametrize(
         ("managed_catalog", "cli_catalog", "default_catalog", "expected"),
@@ -415,14 +416,14 @@ class TestCustomCatalogModels:
         )
         self._settings(tmp_path, monkeypatch, managed=managed, cli=cli, default=default)
 
-        assert v2.custom_catalog_models() == expected
+        assert codex_config.custom_catalog_models() == expected
 
     def test_unreadable_catalog_warns_and_falls_back(self, tmp_path, monkeypatch):
         self._settings(tmp_path, monkeypatch, cli=tmp_path / "missing.json")
         warnings = []
-        monkeypatch.setattr(v2, "print_warning", warnings.append)
+        monkeypatch.setattr(codex_config, "print_warning", warnings.append)
 
-        assert v2.custom_catalog_models() is None
+        assert codex_config.custom_catalog_models() is None
         assert len(warnings) == 1
         assert "falling back to the cached model services" in warnings[0]
 
@@ -481,7 +482,7 @@ class TestCustomCatalogModels:
         monkeypatch.setenv(v2.ENV_VAR, "1")
         monkeypatch.setattr(codex, "clear_model_preferences", lambda state: False)
         monkeypatch.setattr(codex, "_smart_routing_config_model", lambda state: None)
-        monkeypatch.setattr(v2, "custom_catalog_models", lambda: ["gpt-6-astra", "gpt-6-b"])
+        monkeypatch.setattr(codex, "custom_catalog_models", lambda: ["gpt-6-astra", "gpt-6-b"])
 
         def launch_v2(state, tool_args, **kwargs):
             calls.append(kwargs)

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -146,7 +146,7 @@ class TestLaunchCodex:
         monkeypatch.setenv(v2.ENV_VAR, "1")
         monkeypatch.delenv("CODEX_HOME", raising=False)
         monkeypatch.setattr(codex, "CODEX_CONFIG_PATH", profile_path)
-        monkeypatch.setattr(codex, "_managed_config_path", lambda: managed_path)
+        monkeypatch.setattr(codex, "codex_managed_config_path", lambda: managed_path)
         monkeypatch.setattr(codex, "agent_version", lambda _: "0.145.0")
         if custom_home:
             monkeypatch.setenv("CODEX_HOME", str(config_home))

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -359,6 +359,178 @@ class TestLaunchCodex:
         assert exc.value.code == 0
 
 
+class TestCustomCatalogModels:
+    def _catalog(self, path, slugs):
+        path.write_text(
+            json.dumps({"models": [{"slug": slug} for slug in slugs]}),
+            encoding="utf-8",
+        )
+        return path
+
+    def _settings(self, tmp_path, monkeypatch, *, managed=None, cli=None, local=None):
+        home = tmp_path / "codex-home"
+        home.mkdir()
+        monkeypatch.setenv("CODEX_HOME", str(home))
+        managed_path = tmp_path / "managed_config.toml"
+        cli_path = tmp_path / "ucode.config.toml"
+        local_path = home / "config.toml"
+        for path, catalog in (
+            (managed_path, managed),
+            (cli_path, cli),
+            (local_path, local),
+        ):
+            if catalog:
+                text = "model_catalog_json = " + json.dumps(str(catalog)) + "\n"
+            else:
+                text = 'model = "gpt-5"\n'
+            path.write_text(text, encoding="utf-8")
+        monkeypatch.setattr(codex, "_managed_config_path", lambda: managed_path)
+        monkeypatch.setattr(codex, "CODEX_CONFIG_PATH", cli_path)
+
+    def test_managed_catalog_wins_over_cli_and_local(self, tmp_path, monkeypatch):
+        self._settings(
+            tmp_path,
+            monkeypatch,
+            managed=self._catalog(tmp_path / "managed.json", ["gpt-6-astra"]),
+            cli=self._catalog(tmp_path / "cli.json", ["gpt-6-b"]),
+            local=self._catalog(tmp_path / "local.json", ["gpt-6-c"]),
+        )
+
+        assert v2.custom_catalog_models() == ["gpt-6-astra"]
+
+    def test_cli_catalog_wins_over_local(self, tmp_path, monkeypatch):
+        self._settings(
+            tmp_path,
+            monkeypatch,
+            cli=self._catalog(tmp_path / "cli.json", ["gpt-6-b"]),
+            local=self._catalog(tmp_path / "local.json", ["gpt-6-c"]),
+        )
+
+        assert v2.custom_catalog_models() == ["gpt-6-b"]
+
+    def test_local_catalog_used_when_managed_and_cli_define_none(self, tmp_path, monkeypatch):
+        self._settings(
+            tmp_path,
+            monkeypatch,
+            local=self._catalog(tmp_path / "local.json", ["gpt-6-c"]),
+        )
+
+        assert v2.custom_catalog_models() == ["gpt-6-c"]
+
+    def test_no_catalog_anywhere_returns_none(self, tmp_path, monkeypatch):
+        self._settings(tmp_path, monkeypatch)
+
+        assert v2.custom_catalog_models() is None
+
+    def test_unreadable_catalog_falls_back_with_warning(self, tmp_path, monkeypatch):
+        self._settings(tmp_path, monkeypatch, cli=tmp_path / "missing.json")
+        warnings = []
+        monkeypatch.setattr(v2, "print_warning", warnings.append)
+
+        assert v2.custom_catalog_models() is None
+        assert len(warnings) == 1
+        assert "falling back to the cached model services" in warnings[0]
+
+    def test_empty_catalog_falls_back_with_warning(self, tmp_path, monkeypatch):
+        self._settings(tmp_path, monkeypatch, cli=self._catalog(tmp_path / "empty.json", []))
+        warnings = []
+        monkeypatch.setattr(v2, "print_warning", warnings.append)
+
+        assert v2.custom_catalog_models() is None
+        assert len(warnings) == 1
+
+    def test_slugs_are_deduped_and_invalid_rows_skipped(self, tmp_path, monkeypatch):
+        catalog = tmp_path / "catalog.json"
+        catalog.write_text(
+            json.dumps(
+                {
+                    "models": [
+                        {"slug": "gpt-6-astra"},
+                        {"slug": " gpt-6-astra "},
+                        {"slug": ""},
+                        {"slug": 42},
+                        "not-a-row",
+                        {"slug": "gpt-6-b"},
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        self._settings(tmp_path, monkeypatch, cli=catalog)
+
+        assert v2.custom_catalog_models() == ["gpt-6-astra", "gpt-6-b"]
+
+    def test_launch_prefers_catalog_over_cached_models(self, tmp_path, monkeypatch):
+        self._settings(
+            tmp_path,
+            monkeypatch,
+            cli=self._catalog(tmp_path / "cli.json", ["gpt-6-astra", "gpt-6-b"]),
+        )
+        monkeypatch.setattr(v2, "get_databricks_token", lambda *_args: "token")
+        monkeypatch.setattr(v2, "_free_port", lambda: 41001)
+        monkeypatch.setattr(v2, "_wait_for_app_server", lambda port, timeout: True)
+        launched = []
+
+        class FakeProcess:
+            def __init__(self, argv, **kwargs):
+                launched.append(argv)
+
+            def wait(self, timeout=None):
+                return 0
+
+            def terminate(self):
+                pass
+
+            def kill(self):
+                pass
+
+        monkeypatch.setattr(v2.subprocess, "Popen", FakeProcess)
+        interposer_kwargs = {}
+
+        def start_interposer(*args, **kwargs):
+            interposer_kwargs.update(kwargs)
+            return 41002, lambda: None
+
+        monkeypatch.setattr(codex_interposer, "start_interposer_thread", start_interposer)
+
+        with pytest.raises(SystemExit):
+            v2.launch_codex(
+                {"workspace": WS, "codex_models": ["system.ai.gpt-5-6-sol"]},
+                [],
+                binary="codex",
+                start_model="gpt-6-astra",
+                render_overlay=codex.render_overlay,
+            )
+
+        assert interposer_kwargs["available_models"] == ["gpt-6-astra", "gpt-6-b"]
+        hook_override = next(arg for arg in launched[0] if arg.startswith("hooks.PreToolUse="))
+        assert "--model gpt-6-astra" in hook_override
+        assert "--model gpt-6-b" in hook_override
+        assert "gpt-5-6-sol" not in hook_override
+
+    def test_start_model_comes_from_custom_catalog(self, monkeypatch):
+        calls = []
+        monkeypatch.setenv(v2.ENV_VAR, "1")
+        monkeypatch.setattr(codex, "clear_model_preferences", lambda state: False)
+        monkeypatch.setattr(codex, "default_model", lambda state: None)
+        monkeypatch.setattr(v2, "custom_catalog_models", lambda: ["gpt-6-astra", "gpt-6-b"])
+
+        def launch_v2(state, tool_args, **kwargs):
+            calls.append(kwargs)
+            raise SystemExit(0)
+
+        monkeypatch.setattr(v2, "launch_codex", launch_v2)
+
+        with pytest.raises(SystemExit):
+            codex.launch(
+                {"workspace": WS, "codex_models": ["system.ai.gpt-5-6-luna"]},
+                [],
+                options=LaunchOptions(launch_smart_routing=True),
+            )
+
+        assert calls[0]["start_model"] == "gpt-6-astra"
+
+
 def test_interposer_startup_failure_is_propagated(monkeypatch):
     async def fail_to_serve(*args, **kwargs):
         raise OSError("bind failed")

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -372,7 +372,7 @@ class TestCustomCatalogModels:
         home.mkdir()
         monkeypatch.setenv("CODEX_HOME", str(home))
         managed_path = tmp_path / "managed_config.toml"
-        cli_path = tmp_path / "ucode.config.toml"
+        cli_path = home / "ucode.config.toml"
         local_path = home / "config.toml"
         for path, catalog in (
             (managed_path, managed),

--- a/tests/test_codex_smart_routing_v2.py
+++ b/tests/test_codex_smart_routing_v2.py
@@ -512,7 +512,7 @@ class TestCustomCatalogModels:
         calls = []
         monkeypatch.setenv(v2.ENV_VAR, "1")
         monkeypatch.setattr(codex, "clear_model_preferences", lambda state: False)
-        monkeypatch.setattr(codex, "default_model", lambda state: None)
+        monkeypatch.setattr(codex, "_smart_routing_config_model", lambda state: None)
         monkeypatch.setattr(v2, "custom_catalog_models", lambda: ["gpt-6-astra", "gpt-6-b"])
 
         def launch_v2(state, tool_args, **kwargs):


### PR DESCRIPTION
this PR does the following: 

1/ makes it so that for smart routing, IF a custom catalog for codex is defined, we use the slugs in the catalog and send those models to smart routing instead of automatic model discovery. 
2/ consolidates the hierarchy of config files (managed -> cli -> personal) into 1 place 

i also confirmed that if a custom catalog is defined, then codex doesn't poll codex/v1/models. - [refresh strategy](https://github.com/openai/codex/blob/53ff712a48379ce8df605e292afd6046ca88ae9b/codex-rs/models-manager/src/manager.rs#L630-L640) is not used for the raw catalog. 

to test: 
https://github.com/user-attachments/assets/9427e919-82f1-4d4f-aea1-2aecedb5b0dd

i intentionally dropped glm-5-3-flash from the catalog. then i peeked at the payload we sent to the smart router `routes:select` and confirmed glm-5-3-flash was not sent. 


