### PR TITLE
Trim Claude launch smoke test to a minimal, tool-free probe

### DIFF
--- a/src/ucode/agents/claude.py
+++ b/src/ucode/agents/claude.py
@@ -1364,12 +1364,23 @@ def launch(
 
 
 def validate_cmd(binary: str) -> list[str]:
+    # A launch smoke test only proves auth + routing round-trip, so strip everything that
+    # bloats the request: built-in tool schemas (`--tools ""`), any MCP server tool defs
+    # (`--strict-mcp-config`), and Claude Code's large default system prompt (replaced with a
+    # one-liner). Together these dominate the token count — trimming them cuts a probe from
+    # ~25k input tokens to ~2k. The relayed path bills a real Anthropic subscription, so
+    # keeping each probe small matters most there.
     return [
         binary,
         "--settings",
         str(CLAUDE_SETTINGS_PATH),
+        "--tools",
+        "",
+        "--strict-mcp-config",
+        "--system-prompt",
+        "Reply in 5 words or less.",
         "-p",
-        "say hi in 5 words or less",
+        "hi",
         "--max-turns",
         "1",
     ]


### PR DESCRIPTION
## What
The e2e Claude launch validation (`validate_cmd`) only needs to prove auth + routing round-trips, but each probe sent Claude Code's full default system prompt and built-in tool schemas — ~25k input tokens per launch.

This disables built-in tools (`--tools ""`) and MCP servers (`--strict-mcp-config`) and replaces the default system prompt with a one-liner, cutting each probe to ~2k input tokens.

## Why
`validate_cmd` is shared by the agent-launch e2e tests and the real `ucode configure` post-write validation. The biggest saving is on the api-key-billed MPS launch tests (`TestModelProviderLaunch`), which run real inference through the pinned CI Model Provider Service.

## Testing
- `tests/test_agent_claude.py` (135 tests) pass; `ruff` clean.
- Ran the exact new command against a live model: exit 0, one turn, non-empty reply.
- Measured (clean, no MCP): 24,519 -> 2,246 context tokens per launch (~91% fewer), output already minimal.

This pull request and its description were written by Isaac.